### PR TITLE
Sway, display modes etc

### DIFF
--- a/packages/rocknix/sources/post-update
+++ b/packages/rocknix/sources/post-update
@@ -77,20 +77,3 @@ fi
 
 ### Add items below this line that are safe to remove after a period of time.
 ################################################################################
-
-## 20240312 clean config files on specific rk3326 devices
-model=$(cat /sys/firmware/devicetree/base/model)
-clean_list="ODROID-GO Advance Black Edition Powkiddy RGB10"
-if echo "${clean_list}" | grep "$model"; then
-  rm -rf /storage/.config/mupen64plus
-  rm -rf /storage/.config/drastic
-  rm -f /storage/.config/ppsspp/PSP/SYSTEM/controls.ini
-  rm -f /storage/.config/mednafen/mednafen.cfg
-fi
-if [ "${model}" = "Powkiddy RGB10" ]; then
-  rm -f /storage/joypads/odroidgo2_v11_joypad.cfg
-fi
-
-### 20240207 - Update Vita launchers and data.
-rsync -ah --update /usr/config/vita3k/* /storage/.config/vita3k 2>/dev/null
-rm -f "/storage/.config/vita3k/launcher/Start Vita3K.sh"

--- a/packages/rocknix/sources/scripts/runemu.sh
+++ b/packages/rocknix/sources/scripts/runemu.sh
@@ -363,6 +363,16 @@ then
   fi
 fi
 
+### Display mode for emulation
+DISPLAY_MODE=$(get_setting "display_mode" "${PLATFORM}" "${ROMNAME##*/}")
+if [ ! -z "${DISPLAY_MODE}" ]
+then
+DISPLAY_OUTPUT=$(/usr/bin/wlr-randr | awk 'NR==1{print $1;}')
+RESOLUTION=$(/usr/bin/wlr-randr --output ${DISPLAY_OUTPUT} | awk 'f{print $1;f=0}/Modes/{f=1}')
+/usr/bin/wlr-randr --output ${DISPLAY_OUTPUT} --mode ${RESOLUTION}@$(echo ${DISPLAY_MODE} | tr -cd '[[:digit:]].')
+fi
+
+
 ### Offline all but the number of threads we need for this game if configured.
 NUMTHREADS=$(get_setting "threads" "${PLATFORM}" "${ROMNAME##*/}")
 if [ -n "${NUMTHREADS}" ] &&
@@ -392,6 +402,14 @@ fi
 performance
 
 clear_screen
+
+### Display mode preferred
+DISPLAY_MODE=$(get_setting "display_mode" "${PLATFORM}" "${ROMNAME##*/}")
+if [ ! -z "${DISPLAY_MODE}" ]
+then
+DISPLAY_OUTPUT=$(/usr/bin/wlr-randr | awk 'NR==1{print $1;}')
+/usr/bin/wlr-randr --output ${DISPLAY_OUTPUT} --preferred
+fi
 
 ### Restore cooling profile.
 if [ "${DEVICE_HAS_FAN}" = "true" ]

--- a/packages/rocknix/sources/scripts/runemu.sh
+++ b/packages/rocknix/sources/scripts/runemu.sh
@@ -372,10 +372,10 @@ then
   onlinethreads ${NUMTHREADS} 0
 fi
 
-### Set the performance mode for emulation
-PERFORMANCE_MODE=$(get_setting "cpugovernor" "${PLATFORM}" "${ROMNAME##*/}")
-${VERBOSE} && log $0 "Set emulation performance mode to (${PERFORMANCE_MODE})"
-${PERFORMANCE_MODE}
+### Set the governor mode for emulation
+CPU_GOVERNOR=$(get_setting "cpugovernor" "${PLATFORM}" "${ROMNAME##*/}")
+${VERBOSE} && log $0 "Set emulation performance mode to (${CPU_GOVERNOR})"
+${CPU_GOVERNOR}
 
 # If the rom is a shell script just execute it, useful for DOSBOX and ScummVM scan scripts
 if [[ "${ROMNAME}" == *".sh" ]]; then

--- a/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -50,6 +50,7 @@ output="output ${con}"
     else
         angle="0"
     fi
+    echo "${output} bg #000000 solid_color" >> $SWAY_HOME/config
     echo "${output} transform ${angle}" >> $SWAY_HOME/config
     echo "${output} max_render_time off" >> $SWAY_HOME/config
 fi

--- a/packages/wayland/compositor/sway/config/config.kiosk
+++ b/packages/wayland/compositor/sway/config/config.kiosk
@@ -1,2 +1,1 @@
-seat * hide_cursor 1000
 default_border none

--- a/packages/wayland/compositor/sway/package.mk
+++ b/packages/wayland/compositor/sway/package.mk
@@ -35,7 +35,8 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
     cp ${PKG_DIR}/scripts/sway.sh     ${INSTALL}/usr/bin
     cp ${PKG_DIR}/scripts/sway-config ${INSTALL}/usr/lib/sway
-    cp ${PKG_DIR}/scripts/sway_init.sh     ${INSTALL}/usr/bin
+  mkdir -p ${INSTALL}/usr/lib/autostart/common
+    cp ${PKG_DIR}/autostart/111-sway-init     ${INSTALL}/usr/lib/autostart/common
     cp ${PKG_DIR}/scripts/sway-touch.sh     ${INSTALL}/usr/bin
 
   chmod +x ${INSTALL}/usr/bin/sway*

--- a/packages/wayland/compositor/sway/scripts/sway-config
+++ b/packages/wayland/compositor/sway/scripts/sway-config
@@ -2,11 +2,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
-# Initialize config file, and add output line.
-# at least on the RG552 (rk3399 270 degree rotated display)
-# sway segafaults without it.
-/usr/bin/bash /usr/bin/sway_init.sh
-
 export XDG_RUNTIME_DIR=/var/run/0-runtime-dir
 export WAYLAND_DISPLAY=wayland-1
 SWAY_DAEMON_ARGS=""

--- a/projects/Rockchip/patches/linux/RK3326/020-elida-refresh-rates.patch
+++ b/projects/Rockchip/patches/linux/RK3326/020-elida-refresh-rates.patch
@@ -1,0 +1,79 @@
+diff --git a/drivers/gpu/drm/panel/panel-elida-kd35t133.c b/drivers/gpu/drm/panel/panel-elida-kd35t133.c
+index ad7628053e1b..0be014aa7292 100644
+--- a/drivers/gpu/drm/panel/panel-elida-kd35t133.c
++++ b/drivers/gpu/drm/panel/panel-elida-kd35t133.c
+@@ -177,8 +177,9 @@ static int kd35t133_prepare(struct drm_panel *panel)
+ 	return ret;
+ }
+ 
+-static const struct drm_display_mode default_mode = {
+-	.hdisplay	= 320,
++/* drm_display_mode template without clock as it is variable */
++static const struct drm_display_mode mode_template = {
++    .hdisplay	= 320,
+ 	.hsync_start	= 320 + 130,
+ 	.hsync_end	= 320 + 130 + 4,
+ 	.htotal		= 320 + 130 + 4 + 130,
+@@ -186,31 +187,49 @@ static const struct drm_display_mode default_mode = {
+ 	.vsync_start	= 480 + 2,
+ 	.vsync_end	= 480 + 2 + 1,
+ 	.vtotal		= 480 + 2 + 1 + 2,
+-	.clock		= 17000,
+ 	.width_mm	= 42,
+ 	.height_mm	= 82,
+ };
+ 
++static const int pixel_clocks[] = {
++	14118, /* 49.84 Hz PAL everything */
++	15545, /* 54.88 Hz Arcade: Midway, Toaplan, R-Type */
++	16286, /* 57.50 Hz Arcade: Toaplan, more? */
++	16917, /* 59.73 Hz GB/GBC/GBA */
++	16976, /* 59.935 Hz NTSC MS/MD/GG/PS */
++	17022, /* 60.01 Hz NTSC NES/SNES */
++	21375, /* 75.47 Hz Wonderswan(Color) */
++};
++
+ static int kd35t133_get_modes(struct drm_panel *panel,
+ 				struct drm_connector *connector)
+ {
+ 	struct kd35t133 *ctx = panel_to_kd35t133(panel);
++	struct drm_display_mode mode_tmp;
+ 	struct drm_display_mode *mode;
+-
+-	mode = drm_mode_duplicate(connector->dev, &default_mode);
+-	if (!mode) {
+-		dev_err(ctx->dev, "Failed to add mode %ux%u@%u\n",
+-			default_mode.hdisplay, default_mode.vdisplay,
+-			drm_mode_vrefresh(&default_mode));
+-		return -ENOMEM;
++	unsigned int i;
++
++	for (i = 0; i < ARRAY_SIZE(pixel_clocks); i++) {
++		mode_tmp = mode_template;
++        mode_tmp.clock = pixel_clocks[i];
++		mode = drm_mode_duplicate(connector->dev, &mode_tmp);
++		if (!mode) {
++			dev_err(ctx->dev, "Failed to add mode %u\n",
++				drm_mode_vrefresh(mode));
++			return -ENOMEM;
++		}
++		drm_mode_set_name(mode);
++
++		mode->type = DRM_MODE_TYPE_DRIVER;
++		if (pixel_clocks[i] == pixel_clocks[4])
++			mode->type |= DRM_MODE_TYPE_PREFERRED;
++
++		drm_mode_probed_add(connector, mode);
++		connector->display_info.width_mm = mode->width_mm;
++		connector->display_info.height_mm = mode->height_mm;
+ 	}
+ 
+-	drm_mode_set_name(mode);
+ 
+-	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+-	connector->display_info.width_mm = mode->width_mm;
+-	connector->display_info.height_mm = mode->height_mm;
+-	drm_mode_probed_add(connector, mode);
+ 	/*
+ 	 * TODO: Remove once all drm drivers call
+ 	 * drm_connector_set_orientation_from_panel()


### PR DESCRIPTION
move sway init to autostart, to allow modifying the config after boot. remove cursor, set bg black.
add more display modes to elida.

Note this doesn't enable sway nor changing display mode to the user, that part is implemented in ES which I am holding off on merging until we know if we move to sway.

cosmetics:
renamed performance mode to cpu governor in runemu to make it easier to understand
removed old post update stuff