### PR TITLE
samba: make shares browseable/writable without password

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -8,7 +8,7 @@
 # available from your machine
 
 [global]
-  server string = JELOS
+  server string = ROCKNIX
   unix extensions = no
   browseable = yes
   writeable = yes

--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -53,30 +53,35 @@
   path = /storage/.update
   available = yes
   browseable = yes
+  public = yes
   writeable = yes
 
 [games-roms]
   path = /storage/roms
   available = yes
   browseable = yes
+  public = yes
   writeable = yes
 
 [games-internal]
   path = /storage/games-internal
   available = yes
   browseable = yes
+  public = yes
   writeable = yes
 
 [games-external]
   path = /storage/games-external
   available = yes
   browseable = yes
+  public = yes
   writeable = yes
 
 [logs]
   path = /var/log
   available = yes
   browseable = yes
+  public = yes
   writeable = yes
   follow symlinks = yes
   wide links = yes
@@ -85,6 +90,7 @@
   path = /storage/.config/emulationstation/themes
   available = yes
   browseable = yes
+  public = yes
   writeable = yes
   follow symlinks = yes
   wide links = yes
@@ -93,6 +99,7 @@
   path = /storage/.config
   available = yes
   browseable = yes
+  public = yes
   writeable = yes
   follow symlinks = yes
   wide links = yes


### PR DESCRIPTION
This PR makes samba shares browsable/writable without needing user to enter a password.

Network and Samba is off by default.