### PR TITLE
rk3566: enable mupen64plus simple plugins

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-audio-sdl/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-audio-sdl/package.mk
@@ -14,13 +14,13 @@ PKG_LONGDESC="Mupen64Plus Standalone Audio SDL"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
 
 case ${DEVICE} in
-  AMD64|RK33*|RK3588)
+  AMD64|RK33*|RK3588|RK3566)
     PKG_DEPENDS_TARGET+=" ${OPENGL} glu libglvnd"
     export USE_GLES=0
   ;;
@@ -53,7 +53,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X|RK3399)
+    AMD64|RK3588|S922X|RK3399|RK3566)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-input-sdl/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-input-sdl/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Input SDL"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -53,7 +53,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X|RK3399)
+    AMD64|RK3588|S922X|RK3399|RK3566)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-cxd4/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-cxd4/package.mk
@@ -15,7 +15,7 @@ PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="-fpic"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -60,7 +60,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-rsp-cxd4${SUFFIX}.so ${PKG_BUILD}/projects/unix/mupen64plus-rsp-cxd4-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X|RK3399)
+    AMD64|RK3588|S922X|RK3399|RK3566)
       PKG_MAKE_OPTS_TARGET+=" cxd4VIDEO=1"
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-hle/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-hle/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone RSP HLE"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -52,7 +52,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle.so ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X|RK3399)
+    AMD64|RK3588|S922X|RK3399|RK3566)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle.so ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-ui-console/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-ui-console/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Console"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -48,7 +48,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus ${PKG_BUILD}/projects/unix/mupen64plus-base
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X|RK3399)
+    AMD64|RK3588|S922X|RK3399|RK3566)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       export CFLAGS="${CFLAGS} -DSIMPLECORE"
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-glide64mk2/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-glide64mk2/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Glide64 Video Driver"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -52,7 +52,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2.so ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X|RK3399)
+    AMD64|RK3588|S922X|RK3399|RK3566)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2.so ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-gliden64/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-gliden64/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone GLide64 Video Driver"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-rice/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-rice/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Rice Video Driver"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X|RK3399)
+  AMD64|RK3588|S922X|RK3399|RK3566)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -52,7 +52,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-video-rice.so ${PKG_BUILD}/projects/unix/mupen64plus-video-rice-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X|RK3399)
+    AMD64|RK3588|S922X|RK3399|RK3566)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-video-rice.so ${PKG_BUILD}/projects/unix/mupen64plus-video-rice-simple.so

--- a/scripts/build_distro
+++ b/scripts/build_distro
@@ -64,35 +64,6 @@ then
     fi
   fi
   PKG_CLEAN+=" ${CLEAN_DEVICE_ROOT}"
-elif [ -n "$BASE_DEVICE" ]
-then
-  build_dir="build.${DISTRO}-${DEVICE}.${ARCH}"
-    build_dir_base="build.${DISTRO}-${BASE_DEVICE}.${ARCH}"
-    echo "$build_dir_base"
-    if [ -d "$build_dir_base" ]; then
-      echo "Setting up ${DEVICE} build dir with ${BASE_DEVICE} as base"
-      if [ ! -d "$build_dir" ]; then
-        mkdir -p ${build_dir}
-      else
-        find ${build_dir} -maxdepth 1 -type l -exec rm {} \;
-      fi
-      if [ ! -d "$build_dir/.stamps" ]; then
-        mkdir -p ${build_dir}/.stamps
-      else
-        find ${build_dir}/.stamps -maxdepth 1 -type l -exec rm {} \;
-      fi
-      # We allow ln to fail in case some linkpaths exists, because we should prioritize the end device
-      ln -sr -t ${build_dir} ${build_dir_base}/*/ || true
-      ln -sr -t ${build_dir}/.stamps ${build_dir_base}/.stamps/*/ || true
-      mkdir -p ${build_dir}/image
-      rsync -a ${build_dir_base}/image/ ${build_dir}/image/
-      rm -rf ${build_dir}/linux*
-      rm -rf ${build_dir}/.stamps/linux*
-      rm -rf ${build_dir}/image/.stamps/linux*
-    else
-      echo "Base directory: $build_dir_base doesn't exists. Exiting..."
-      exit 1
-    fi
 fi
 
 # Clean necessary packages.


### PR DESCRIPTION
Also remove base devices concept from build scripts, not used by anyone.