### PR TITLE
box86 - profile / alias fixes to enable gallium-nine

### DIFF
--- a/packages/compat/box86/profile.d/098-box86.conf
+++ b/packages/compat/box86/profile.d/098-box86.conf
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-export BOX86_PREFER_EMULATED=1
+export BOX86_PREFER_EMULATED=0
+export BOX86_PREFER_WRAPPED=1
 export BOX86_LD_LIBRARY_PATH="/usr/share/box86/lib"
 export BOX86_BASH="/usr/bin/bash-x86"
 export BOX86_LOG=0
-alias box86='LD_LIBRARY_PATH=/usr/lib32:/usr/lib32/gles /usr/bin/box86'
+alias box86='LD_LIBRARY_PATH=/usr/lib32:/usr/lib32/gles:/usr/lib32/d3d /usr/bin/box86'


### PR DESCRIPTION
With these changes, ninewinecfg can pick up libd3dadapter9.so ok. Not a lot of success with games with Panfrost on Gameforce ACE, but Half Life 2 was running nicely with Panthor.