### PR TITLE
Add OrangePi 5 Plus DTB to build

### DIFF
--- a/projects/Rockchip/bootloader/update.sh
+++ b/projects/Rockchip/bootloader/update.sh
@@ -41,6 +41,11 @@ if [ -f $BOOT_ROOT/extlinux/extlinux.conf ]; then
         echo "Setting boot FDT to GameForce Ace..."
         sed -i '/FDT/c\  FDT /rk3588s-gameforce-ace.dtb' $BOOT_ROOT/extlinux/extlinux.conf
         ;;
+      *orangepi-5-plus)
+        echo "Setting boot FDT to Orange Pi 5 Plus..."
+        sed -i '/FDT/c\  FDT /rk3588s-orangepi-5-plus.dtb' $BOOT_ROOT/extlinux/extlinux.conf
+        sed -i 's/ fbcon=rotate:1//' $BOOT_ROOT/extlinux/extlinux.conf
+        ;;
       *orangepi-5)
         echo "Setting boot FDT to Orange Pi 5..."
         sed -i '/FDT/c\  FDT /rk3588s-orangepi-5.dtb' $BOOT_ROOT/extlinux/extlinux.conf

--- a/projects/Rockchip/devices/RK3588/options
+++ b/projects/Rockchip/devices/RK3588/options
@@ -34,7 +34,7 @@
 
   # Single dtb settings
     TRUST_LABEL="trust"
-    DEVICE_DTB=("rk3588s-gameforce-ace" "rk3588s-orangepi-5" "rk3588-rock-5b")
+    DEVICE_DTB=("rk3588s-gameforce-ace" "rk3588s-orangepi-5" "rk3588-rock-5b" "rk3588-orangepi-5-plus")
     UBOOT_DTB="${DEVICE_DTB[0]}"
     
     UBOOT_CONFIG="orangepi_5_defconfig"


### PR DESCRIPTION
I have no way to test this.

Before first boot users need to make sure to set the correct device in extlinux.conf. It defaults to ace. 