### PR TITLE
Remove antiquated cmd line options on RK3399

### DIFF
--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -69,7 +69,7 @@
     PIPEWIRE_SUPPORT="yes"
 
   # kernel serial console
-    EXTRA_CMDLINE="quiet rootwait console=tty0 video=DSI-1:1152x1920p60 fbcon=rotate:3 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20"
+    EXTRA_CMDLINE="quiet rootwait console=tty0 ssh consoleblank=0 systemd.show_status=0 loglevel=0 panic=20"
 
   # additional packages to install
     ADDITIONAL_PACKAGES=""


### PR DESCRIPTION
these are left over from BSP