### PR TITLE
update cursor_hide logic for sway kiosk

### DIFF
--- a/packages/wayland/compositor/sway/config/config.kiosk
+++ b/packages/wayland/compositor/sway/config/config.kiosk
@@ -1,2 +1,8 @@
-seat * hide_cursor 1000
+# hide_cursor hides the cursor image after the specified timeout (in milliseconds) has elapsed with no activity on that cursor
+seat * hide_cursor 500
+
+# Set a default rule to remove decorations for all windows
 default_border none
+
+# Hide mouse for kiosk mode
+exec /usr/bin/sway-mouse.sh hide

--- a/packages/wayland/compositor/sway/package.mk
+++ b/packages/wayland/compositor/sway/package.mk
@@ -34,6 +34,7 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/sway
   mkdir -p ${INSTALL}/usr/bin
     cp ${PKG_DIR}/scripts/sway.sh     ${INSTALL}/usr/bin
+    cp ${PKG_DIR}/scripts/sway-mouse.sh     ${INSTALL}/usr/bin
     cp ${PKG_DIR}/scripts/sway-config ${INSTALL}/usr/lib/sway
   mkdir -p ${INSTALL}/usr/lib/autostart/common
     cp ${PKG_DIR}/autostart/111-sway-init     ${INSTALL}/usr/lib/autostart/common

--- a/packages/wayland/compositor/sway/scripts/sway-mouse.sh
+++ b/packages/wayland/compositor/sway/scripts/sway-mouse.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+case "${1}" in
+    "show")
+	swaymsg -t get_seats | jq -r '.[] | .name' |
+	    while read SEAT
+	    do
+		swaymsg seat "${SEAT}" hide_cursor when-typing disable || exit 1
+	    done
+    ;;
+    "hide")
+	swaymsg -t get_seats | jq -r '.[] | .name' |
+	    while read SEAT
+	    do
+		swaymsg seat "${SEAT}" hide_cursor when-typing enable || exit 1
+	    done
+    ;;
+    *)
+	echo "${0} <show|hide>" >&2
+	exit 1
+esac
+exit 0


### PR DESCRIPTION
This PR is to update the cursor hide logic for sway kiosk, using a similar batocera pattern.
[batocera-mouse](https://github.com/batocera-linux/batocera.linux/blob/bb785cbfe06f30eeb9ee2c0a7624cce9af4a8500/package/batocera/core/batocera-scripts/scripts/batocera-mouse.wayland-sway#L4)
[sway/config](https://github.com/batocera-linux/batocera.linux/blob/bce06d8ddaabf41ac529ac089dce4fe4f795a743/package/batocera/emulationstation/batocera-emulationstation/wayland/sway/config#L35)
 
- Decreases cursor hide timeout to 500 milliseconds.
- Adds a new script to hide/show the mouse while typing on sway for the detected seat.
- Add comments to `config.kiosk`.

Tested on RK3566/RGB30
