### PR TITLE
Bump SDL2 to 2.30.2

### DIFF
--- a/packages/graphics/SDL2/package.mk
+++ b/packages/graphics/SDL2/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.28.5"
+PKG_VERSION="2.30.2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/SDL2-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Emulation Station issue appears to have been resolved. 