### PR TITLE
Re-enable BT for RK3566 devices

### DIFF
--- a/projects/Rockchip/devices/RK3566-X55/options
+++ b/projects/Rockchip/devices/RK3566-X55/options
@@ -81,7 +81,7 @@
   # additional Firmware to use ( )
   # Space separated list is supported,
   # e.g. FIRMWARE=""
-    FIRMWARE=""
+    FIRMWARE="RTL8821CS-firmware"
 
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -81,7 +81,7 @@
   # additional Firmware to use ( )
   # Space separated list is supported,
   # e.g. FIRMWARE=""
-    FIRMWARE=""
+    FIRMWARE="RTL8821CS-firmware"
 
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers


### PR DESCRIPTION
At some point between JELOS 20240206 and today, BT stopped working for some devices (keyboards, some gamepads).

This change theoretically fixes this.