### PR TITLE
Only save environment variables to Docker `.env`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ docker-%: INTERACTIVE=$(shell [ -t 0 ] && echo "-it")
 docker-%: COMMAND=make $*
 
 # Get .env file ready
-docker-%: $(shell for var in $(compgen -e); do echo "$var=${!var}"; done > .env)
+docker-%: $(shell ./scripts/get_env > .env)
 
 # If the user issues a `make docker-shell` just start up bash as the shell to run commands
 docker-shell: COMMAND=bash

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ docker-%: INTERACTIVE=$(shell [ -t 0 ] && echo "-it")
 docker-%: COMMAND=make $*
 
 # Get .env file ready
-docker-%: $(shell env | grep "=" > .env)
+docker-%: $(shell for var in $(compgen -e); do echo "$var=${!var}"; done > .env)
 
 # If the user issues a `make docker-shell` just start up bash as the shell to run commands
 docker-shell: COMMAND=bash

--- a/scripts/get_env
+++ b/scripts/get_env
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+for var in $(compgen -ve); do echo "$var=${!var}"; done

--- a/scripts/get_env
+++ b/scripts/get_env
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-for var in $(compgen -ve); do echo "$var=${!var}"; done
+for var in $(compgen -e); do echo "$var=${!var}"; done


### PR DESCRIPTION
Right now, `.env` files are generated like so in `Makefile`:
```make
# Get .env file ready
docker-%: $(shell env | grep "=" > .env)
```

However, `env | grep "="` does not only capture environment variables, it also captures Bash function definitions:

```bash
$ env | grep "="
SHELL=/bin/bash
PYENV_SHELL=bash
...
BASH_FUNC_play_youtube%%=() {  
URL="$1";
if [[ $FILENAME == "Example" ]]
BASH_FUNC_example%%=() {                                 
```

Each of those lines contains a `=`, however only some of them are actually environment variables, the rest are mangled Bash function definitions.

When those mangled function definitions are written to `.env`, and then are passed to Docker, Docker evaluates the `.env` file. That fills the environment with mangled variables, and Docker also tries to evaluate lines like `if [[ $FILENAME == "Example" ]]` from above, which will fail.

If the `.env` file contains lines that fail to evaluate, then a `make docker-*` build will also fail to run. This happened on my end, failing with this error:

```bash
$ make docker-S922X
BUILD_DIR=~/distribution docker run  -it --init --env-file .env --rm --user 1000:1000   -v ~/distribution:~/distribution -w ~/distribution  "rocknix/rocknix-build:latest" make S922X
docker: poorly formatted environment: variable 'if [[ $FILENAME ' contains whitespaces.
```

By instead using the shell built-in `compgen`, we can exclude mangled defintions by getting a list of exported environment variables from `compgen -e` and then printing their name-value pairs to `.env`:

```bash
$ for var in $(compgen -e); do echo "$var=${!var}"; done                                                                                                                                         
BAT_PAGER=less -RF --mouse                                                     
BYOBU_ACCENT=#75507B 
BYOBU_BACKEND=tmux
SHELL=/bin/bash
...
```

So a `.env` file with only environment variables gets generated like so:
```make
docker-%: $(shell ./scripts/get_env > .env)
```
