### PR TITLE
allow a specific arch-type docker image to be built and loaded locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,11 @@ docker-%: $(shell env | grep "=" > .env)
 # If the user issues a `make docker-shell` just start up bash as the shell to run commands
 docker-shell: COMMAND=bash
 
-# Command: builds and pushes a hybrid docker image to dockerhub
-# You must login with: docker login --username <username> and provide either a password or token (from user settings -> security in dockerhub) before this will work.  The build user must also be a member of the "docker" group.
+# Command: builds and saves a docker builder image locally.
+# The build user must also be a member of the "docker" group.
 docker-image-build:
 	$(DOCKER_CMD) buildx create --use
-	$(DOCKER_CMD) buildx build --tag $(DOCKER_IMAGE) --platform linux/amd64,linux/arm64 --push .
+	$(DOCKER_CMD) buildx build --tag $(DOCKER_IMAGE) --platform $(shell if [ "$(uname -m)" = "aarch64" ]; then echo "linux/arm64"; else echo "linux/amd64"; fi) --load .
 
 # Command: pulls latest docker image from dockerhub.  This will *replace* locally built version.
 docker-image-pull:


### PR DESCRIPTION
Instead of pulling an image from dockerhub, a user should run `make docker-image-build` before running any other docker commands. This will build the docker image locally and store it locally. After building, any docker command can be run normally.