### PR TITLE
Workaround: PowKiddy X55: increase himax panel clk freq by 400KHz to fix

### DIFF
--- a/projects/Rockchip/patches/linux/RK3566/032-powkiddy-x55-fix-wraparound.patch
+++ b/projects/Rockchip/patches/linux/RK3566/032-powkiddy-x55-fix-wraparound.patch
@@ -1,0 +1,27 @@
+From b08c7f57172d3df1483f08ebe367db25b2837839 Mon Sep 17 00:00:00 2001
+From: Paul Reioux <reioux@gmail.com>
+Date: Thu, 18 Apr 2024 22:42:54 -0700
+Subject: [PATCH] PowKiddy: increase clock by 400KHz to address single pixel
+ wraparound issue
+
+Signed-off-by: Paul Reioux <reioux@gmail.com>
+---
+ drivers/gpu/drm/panel/panel-himax-hx8394.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-himax-hx8394.c b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+index ff0dc08b9829..44dfe99f87cf 100644
+--- a/drivers/gpu/drm/panel/panel-himax-hx8394.c
++++ b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+@@ -324,7 +324,7 @@ static const struct drm_display_mode powkiddy_x55_mode = {
+ 	.vsync_start	= 1280 + 12,
+ 	.vsync_end	= 1280 + 12 + 10,
+ 	.vtotal		= 1280 + 12 + 10 + 10,
+-	.clock		= 63290,
++	.clock		= 63690,
+ 	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
+ 	.width_mm	= 67,
+ 	.height_mm	= 121,
+-- 
+2.34.1
+


### PR DESCRIPTION
boot logo wraparound issue

suggested by sydarn