### PR TITLE
More 32bit fixes

### DIFF
--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -78,8 +78,10 @@ post_makeinstall_target() {
 
   cp ${PKG_DIR}/config/system.pa ${INSTALL}/etc/pulse/
 
-  mkdir -p ${INSTALL}/etc/ld.so.conf.d
-  echo "/usr/lib/pulseaudio" >${INSTALL}/etc/ld.so.conf.d/${ARCH}-lib-pulseaudio.conf
+  # Sometimes apps cannot load `libpulsecommon`. It is located in ${libdir}/pulseaudio and is not intended to be loaded directly.
+  # Application loads `libpulse.so.0`, `libpulse` has `libpulsecommon` as a dep and RPATH set to ${libdir}/pulseaudio
+  # So, if there is error loading `libpulsecommon`, check RPATH of `libpulse` and `libpulse-simple`
+  # Adding pulseaudio subdir to `/etc/ld.so.conf.d/*.conf` may be a working hack for that, but please check/fix RPATH first
 }
 
 # Deprecated by pipewire

--- a/packages/compat/box86/profile.d/098-box86.conf
+++ b/packages/compat/box86/profile.d/098-box86.conf
@@ -6,4 +6,3 @@ export BOX86_PREFER_WRAPPED=1
 export BOX86_LD_LIBRARY_PATH="/usr/share/box86/lib"
 export BOX86_BASH="/usr/bin/bash-x86"
 export BOX86_LOG=0
-alias box86='LD_LIBRARY_PATH=/usr/lib32:/usr/lib32/gles:/usr/lib32/d3d /usr/bin/box86'

--- a/packages/compat/lib32/package.mk
+++ b/packages/compat/lib32/package.mk
@@ -27,6 +27,7 @@ makeinstall_target() {
   LIBROOT="${ROOT}/build.${DISTRO}-${DEVICE}.${LIBARCH}/image/system/"
   mkdir -p ${INSTALL}/usr/lib32
   rsync -al ${LIBROOT}/usr/lib/* ${INSTALL}/usr/lib32 >/dev/null 2>&1
+  rsync -al ${LIBROOT}/usr/lib32/* ${INSTALL}/usr/lib32 >/dev/null 2>&1
   chmod -f 0755 ${INSTALL}/usr/lib32/* || :
   mkdir -p ${INSTALL}/usr/lib
   ln -s /usr/lib32/${LDSO} ${INSTALL}/usr/lib/${LDSO}
@@ -35,8 +36,6 @@ makeinstall_target() {
   echo "/usr/lib32" > "${INSTALL}/etc/ld.so.conf.d/${LIBARCH}-lib32.conf"
   echo "/usr/lib32/pulseaudio" >"${INSTALL}/etc/ld.so.conf.d/${LIBARCH}-lib32-pulseaudio.conf"
 
-  if [ -d "${LIBROOT}/usr/lib/dri" ]
-  then
-    echo "/usr/lib32/dri" >"${INSTALL}/etc/ld.so.conf.d/${LIBARCH}-lib32-dri.conf"
-  fi
+  mkdir -p ${INSTALL}/usr/bin
+  cp ${LIBROOT}/usr/bin/ldd ${INSTALL}/usr/bin/ldd32
 }

--- a/packages/compat/lib32/package.mk
+++ b/packages/compat/lib32/package.mk
@@ -34,7 +34,6 @@ makeinstall_target() {
 
   mkdir -p "${INSTALL}/etc/ld.so.conf.d"
   echo "/usr/lib32" > "${INSTALL}/etc/ld.so.conf.d/${LIBARCH}-lib32.conf"
-  echo "/usr/lib32/pulseaudio" >"${INSTALL}/etc/ld.so.conf.d/${LIBARCH}-lib32-pulseaudio.conf"
 
   mkdir -p ${INSTALL}/usr/bin
   cp ${LIBROOT}/usr/bin/ldd ${INSTALL}/usr/bin/ldd32

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -37,29 +37,6 @@ esac
 
 get_graphicdrivers
 
-# For lib32 build Mesa needs some tweaks
-#   * scripts/build sets --libdir=/usr/lib
-#   * lib32 package moves /usr/lib into /usr/lib32
-#   * in running system /usr/lib is 64-bit
-#   * mesa loader looks for drivers in ${libdir}/{dri,gbm} etc.
-#   * 32-bit mesa fails to load 64-bit drivers
-#
-# This may be worked around by setting LIBGL_DRIVERS_PATH=/usr/lib32/dri
-#   but that needs careful editing of run scripts
-#
-# Just setting --libdir=/usr/lib32 in scripts/build fails because libtool wants exactly /usr/lib
-#
-# So, for 32-bit build we set a bunch of options normally derived from libdir
-# This hopefully will be not needed if libtool accepts lib32 (libtool-multilib?)
-case ${ARCH} in
-  arm|i686)
-    MESA_LIBS_PATH_OPTS=" -Ddri-drivers-path=/usr/lib32/dri -Dgbm-backends-path=/usr/lib32/gbm -Dd3d-drivers-path=/usr/lib32/d3d "
-    ;;
-  *)
-    MESA_LIBS_PATH_OPTS=""
-    ;;
-esac
-
 PKG_MESON_OPTS_TARGET=" ${MESA_LIBS_PATH_OPTS} \
                        -Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
@@ -136,9 +113,6 @@ else
 fi
 
 post_makeinstall_target() {
-  if [ -d "${INSTALL}/usr/lib32/dri" ]; then
-    mv "${INSTALL}/usr/lib32"/* "${INSTALL}/usr/lib/"
-  fi
   if [ "${DEVICE}" = "S922X" -a "${USE_MALI}" != "no" ]; then
     rm -f ${INSTALL}/usr/lib/libvulkan_panfrost.so ${INSTALL}/usr/share/vulkan/icd.d/panfrost_icd.aarch64.json
   fi

--- a/packages/misc/modules/sources/Start 32bit Retroarch.sh
+++ b/packages/misc/modules/sources/Start 32bit Retroarch.sh
@@ -6,5 +6,4 @@
 source /etc/profile
 
 set_kill set "retroarch32"
-export LIBGL_DRIVERS_PATH="/usr/lib32/dri"
 /usr/bin/retroarch32 --appendconfig /usr/config/retroarch/retroarch32bit-append.cfg

--- a/packages/rocknix/sources/scripts/runemu.sh
+++ b/packages/rocknix/sources/scripts/runemu.sh
@@ -186,11 +186,6 @@ case ${EMULATOR} in
         then
           ### Configure for 32bit Retroarch
           ${VERBOSE} && log $0 "Configuring for 32bit cores."
-          export LIBRARY_PATH="/usr/lib32"
-          export LD_LIBRARY_PATH="${LIBRARY_PATH}"
-          export SPA_PLUGIN_DIR="${LIBRARY_PATH}/spa-0.2"
-          export PIPEWIRE_MODULE_DIR="${LIBRARY_PATH}/pipewire-0.3/"
-          export LIBGL_DRIVERS_PATH="${LIBRARY_PATH}/dri"
           export RABIN="retroarch32"
         fi
       ;;

--- a/scripts/build
+++ b/scripts/build
@@ -160,12 +160,20 @@ TARGET_CMAKE_OPTS="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_CONF} \
                    -DCMAKE_INSTALL_PREFIX=/usr \
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 
+case ${ARCH} in
+  arm|i686)
+    BUILD_OPTS_TARGET_LIBDIR=/usr/lib32
+    ;;
+  *)
+    BUILD_OPTS_TARGET_LIBDIR=/usr/lib
+    ;;
+esac
 TARGET_MESON_OPTS="--prefix=/usr \
                    --bindir=/usr/bin \
                    --sbindir=/usr/sbin \
                    --sysconfdir=/etc \
-                   --libdir=/usr/lib \
-                   --libexecdir=/usr/lib \
+                   --libdir=${BUILD_OPTS_TARGET_LIBDIR} \
+                   --libexecdir=${BUILD_OPTS_TARGET_LIBDIR} \
                    --localstatedir=/var \
                    --buildtype=${MESON_BUILD_TYPE}"
 if [ ${BUILD_WITH_DEBUG} != yes ] && flag_enabled "strip" "yes"; then
@@ -412,6 +420,10 @@ rm -rf "${SYSROOT_PREFIX}"
 for d in /usr/lib /usr/include /usr/bin /usr/lib/pkgconfig; do
   mkdir -p "${SYSROOT_PREFIX}${d}"
 done
+# symlink lib32 -> lib to make 32-bit apps agnostic of dependencies' libdir
+if [ ! -d "${SYSROOT_PREFIX}${BUILD_OPTS_TARGET_LIBDIR}" ]; then
+  ln -s lib "${SYSROOT_PREFIX}${BUILD_OPTS_TARGET_LIBDIR}"
+fi
 
 # make install
 pkg_call_exists pre_makeinstall_${TARGET} && pkg_call pre_makeinstall_${TARGET}


### PR DESCRIPTION
Here I make meson packages build with `libdir=/usr/lib32`, just as it is in a running system.  
This eliminates the need for setting `LD_LIBRARY_PATH`, `LIBGL_DRIVERS_PATH` env vars and so on.  
Consequently, no `LD_LIBRARY_PATH` fixes pcsx-rearmed32 slideshow with libmali.