### PR TITLE
moonlight: set 60FPS as a default

### DIFF
--- a/packages/apps/moonlight/sources/moonlight.conf
+++ b/packages/apps/moonlight/sources/moonlight.conf
@@ -5,7 +5,7 @@
 ## Video streaming configuration
 width = @MWIDTH@
 height = @MHEIGHT@
-fps = 30
+fps = 60
 
 ## Output rotation (independent of xrandr or framebuffer settings!)
 ## Allowed values: 0, 90, 180, 270


### PR DESCRIPTION
* Apps like sunshine allow setting outputs back to 30 for those who need it
* Tested 60FPS on RK3566-X55 @ 720p [10MBPS and 15MBPS bitrates] are great.