### PR TITLE
RK3399: use GPT partition tables

### DIFF
--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -29,7 +29,7 @@
     DEVICE_NAME="RK3399"
     KERNEL_TARGET="Image"
     BOOTLOADER="u-boot"
-    PARTITION_TABLE="msdos"
+    PARTITION_TABLE="gpt"
     DEVICE_DTB=("rk3399-anbernic-rg552")
     UBOOT_DTB="${DEVICE_DTB[0]}"
     UBOOT_FIT_IMAGE="rk3399-uboot.bin"


### PR DESCRIPTION
This only affects new installs