### PR TITLE
Arc better panel timings

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/RK3326/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/RK3326/SUPPORTED_EMULATORS_AND_CORES.md
@@ -96,7 +96,7 @@ This document describes all available systems emulators and cores available for 
 |Sega|Mega Drive (megadrive)|1990|`megadrive`|.bin .gen .md .sg .smd .zip .7z|**retroarch:** genesis_plus_gx (default)<br>**retroarch:** genesis_plus_gx_wide<br>**retroarch:** picodrive<br>**mednafen:** md<br>|
 |Sega|Mega Drive (megadrive-japan)|1988|`megadrive-japan`|.bin .gen .md .sg .smd .zip .7z|**retroarch:** genesis_plus_gx (default)<br>**retroarch:** genesis_plus_gx_wide<br>**retroarch:** picodrive<br>**mednafen:** md<br>|
 |Sega|Naomi (naomi)|1998|`naomi`|.lst .bin .dat .zip .7z|**retroarch:** flycast2021<br>**flycast:** flycast-sa<br>**retroarch:** flycast (default)<br>|
-|Sega|Saturn (saturn)|1994|`saturn`|.cue .chd .iso|**yabasanshiro:** yabasanshiro-sa (default)<br>**retroarch:** yabasanshiro<br>|
+|Sega|Saturn (saturn)|1994|`saturn`|.cue .chd .iso .zip|**yabasanshiro:** yabasanshiro-sa (default)<br>**retroarch:** yabasanshiro<br>|
 |Sega|Sega 32X (sega32x)|1994|`sega32x`|.32x .smd .bin .md .zip .7z|**retroarch:** picodrive (default)<br>|
 |Sega|Sega CD (segacd)|1991|`segacd`|.chd .cue .iso .m3u|**retroarch:** genesis_plus_gx (default)<br>**retroarch:** picodrive<br>|
 |Sega|SG-1000 (sg-1000)|1983|`sg-1000`|.bin .sg .zip .7z|**retroarch:** gearsystem (default)<br>**retroarch:** genesis_plus_gx<br>**retroarch:** picodrive<br>|

--- a/projects/Rockchip/patches/linux/RK3566/034-arc-panel.patch
+++ b/projects/Rockchip/patches/linux/RK3566/034-arc-panel.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/gpu/drm/panel/panel-sitronix-st7701.c b/drivers/gpu/drm/panel/panel-sitronix-st7701.c
+index 421eb4592b61..334135b73873 100644
+--- a/drivers/gpu/drm/panel/panel-sitronix-st7701.c
++++ b/drivers/gpu/drm/panel/panel-sitronix-st7701.c
+@@ -876,7 +876,7 @@ static const struct st7701_panel_desc kd50t048a_desc = {
+ };
+ 
+ static const struct drm_display_mode rg_arc_mode = {
+-	.clock          = 25600,
++	.clock          = 26000,
+ 
+ 	.hdisplay	= 480,
+ 	.hsync_start	= 480 + 60,
+@@ -884,9 +884,9 @@ static const struct drm_display_mode rg_arc_mode = {
+ 	.htotal         = 480 + 60 + 42 + 60,
+ 
+ 	.vdisplay	= 640,
+-	.vsync_start	= 640 + 10,
+-	.vsync_end	= 640 + 10 + 4,
+-	.vtotal         = 640 + 10 + 4 + 16,
++	.vsync_start	= 640 + 8,
++	.vsync_end	= 640 + 8 + 4,
++	.vtotal         = 640 + 8 + 4 + 13,
+ 
+ 	.width_mm	= 63,
+ 	.height_mm	= 84,


### PR DESCRIPTION
* Request 26000kHz, but actually recieve 25600kHz as before. this to get around choppiness issue. Again weird "clock" behavior, albeit different than rgb30.
* More visible rows, thogh 1 is still missing but noticeble better than before.
* 59.96Hz refresh rate.