### PR TITLE
RK3399: RG552 patch clean up

### DIFF
--- a/projects/Rockchip/patches/linux/RK3399/000-rk3399-dts.patch
+++ b/projects/Rockchip/patches/linux/RK3399/000-rk3399-dts.patch
@@ -1,6 +1,6 @@
 diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/Makefile linux/arch/arm64/boot/dts/rockchip/Makefile
 --- linux.orig/arch/arm64/boot/dts/rockchip/Makefile	2024-04-12 20:11:08.853321539 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/Makefile	2024-04-23 16:40:41.368372474 +0000
++++ linux/arch/arm64/boot/dts/rockchip/Makefile	2024-05-01 23:32:31.908510282 +0000
 @@ -30,6 +30,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-li
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-orion-r68-meta.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-px5-evb.dtb
@@ -11,8 +11,8 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/Makefile linux/arch/arm64/boo
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-ficus.dtb
 diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts
 --- linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts	1970-01-01 00:00:00.000000000 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts	2024-04-24 14:55:25.961040764 +0000
-@@ -0,0 +1,1304 @@
++++ linux/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts	2024-05-01 23:33:30.689814365 +0000
+@@ -0,0 +1,1300 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -27,7 +27,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts lin
 +#include <dt-bindings/pwm/pwm.h>
 +#include <dt-bindings/usb/pd.h>
 +#include "rk3399.dtsi"
-+#include "rk3399-op1-opp.dtsi"
++#include "rk3399-opp.dtsi"
 +
 +/ {
 +	model = "Anbernic RG552";
@@ -106,7 +106,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts lin
 +		};
 +	};
 +
-+	joypad: singleadc-joypad {
++	joypad: rg552_joypad {
 +		compatible = "rg552_joypad";
 +
 +		pwms = <&pwm3 0 200000000 0>;
@@ -304,10 +304,6 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-anbernic-rg552.dts lin
 +		enable-gpios = <&gpio1 RK_PC5 GPIO_ACTIVE_HIGH>;
 +		sound-name-prefix = "Speaker Amplifier";
 +		VCC-supply = <&vcc5v0_sys>;
-+	};
-+
-+	hdmi-sound {
-+		status = "okay";
 +	};
 +
 +	fan: pwm-fan {

--- a/projects/Rockchip/patches/linux/RK3399/001-rk3399-opp.patch
+++ b/projects/Rockchip/patches/linux/RK3399/001-rk3399-opp.patch
@@ -1,160 +1,146 @@
-diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi linux/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi
---- linux.orig/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi	2024-01-31 00:19:09.560493706 +0000
-+++ linux/arch/arm64/boot/dts/rockchip/rk3399-op1-opp.dtsi	2024-01-31 00:23:30.222617860 +0000
-@@ -9,34 +9,35 @@
+diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi linux/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+--- linux.orig/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi	2024-04-12 20:11:08.857321667 +0000
++++ linux/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi	2024-05-01 18:44:49.576985506 +0000
+@@ -9,30 +9,35 @@
  		opp-shared;
  
  		opp00 {
 -			opp-hz = /bits/ 64 <408000000>;
--			opp-microvolt = <800000>;
--			clock-latency-ns = <40000>;
--		};
--		opp01 {
- 			opp-hz = /bits/ 64 <600000000>;
- 			opp-microvolt = <825000>;
-+			clock-latency-ns = <40000>;
++			opp-hz = /bits/ 64 <600000000>;
+ 			opp-microvolt = <825000 825000 1250000>;
+ 			clock-latency-ns = <40000>;
  		};
--		opp02 {
--			opp-hz = /bits/ 64 <816000000>;
--			opp-microvolt = <850000>;
+ 		opp01 {
+-			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <825000 825000 1250000>;
 -		};
+-		opp02 {
+ 			opp-hz = /bits/ 64 <816000000>;
+ 			opp-microvolt = <850000 850000 1250000>;
+ 		};
 -		opp03 {
-+		opp01 {
++		opp02 {
  			opp-hz = /bits/ 64 <1008000000>;
- 			opp-microvolt = <900000>;
+ 			opp-microvolt = <925000 925000 1250000>;
  		};
 -		opp04 {
-+		opp02 {
++		opp03 {
  			opp-hz = /bits/ 64 <1200000000>;
- 			opp-microvolt = <975000>;
+ 			opp-microvolt = <1000000 1000000 1250000>;
  		};
 -		opp05 {
-+		opp03 {
- 			opp-hz = /bits/ 64 <1416000000>;
- 			opp-microvolt = <1100000>;
- 		};
--		opp06 {
 +		opp04 {
- 			opp-hz = /bits/ 64 <1512000000>;
- 			opp-microvolt = <1150000>;
+ 			opp-hz = /bits/ 64 <1416000000>;
+ 			opp-microvolt = <1125000 1125000 1250000>;
  		};
-+		opp05 {
-+			opp-hz = /bits/ 64 <1608000000>;
-+			opp-microvolt = <1200000>;
-+		};
++                opp05 {
++                        opp-hz = /bits/ 64 <1608000000>;
++                        opp-microvolt = <1250000 1275000 1300000>;
++                };
 +                opp06 {
 +                        opp-hz = /bits/ 64 <1704000000>;
-+                        opp-microvolt = <1225000>;
++                        opp-microvolt = <1300000 1300000 1300000>;
 +                        turbo-mode;
 +                };
  	};
  
  	cluster1_opp: opp-table-1 {
-@@ -44,42 +45,39 @@
+@@ -40,38 +45,43 @@
  		opp-shared;
  
  		opp00 {
 -			opp-hz = /bits/ 64 <408000000>;
--			opp-microvolt = <800000>;
+-			opp-microvolt = <825000 825000 1250000>;
 -			clock-latency-ns = <40000>;
 -		};
 -		opp01 {
  			opp-hz = /bits/ 64 <600000000>;
--			opp-microvolt = <800000>;
--		};
+ 			opp-microvolt = <825000 825000 1250000>;
++                        clock-latency-ns = <40000>;
+ 		};
 -		opp02 {
--			opp-hz = /bits/ 64 <816000000>;
- 			opp-microvolt = <825000>;
-+			clock-latency-ns = <40000>;
++		opp01 {
+ 			opp-hz = /bits/ 64 <816000000>;
+ 			opp-microvolt = <825000 825000 1250000>;
  		};
 -		opp03 {
-+		opp01 {
++		opp02 {
  			opp-hz = /bits/ 64 <1008000000>;
- 			opp-microvolt = <850000>;
+ 			opp-microvolt = <875000 875000 1250000>;
  		};
 -		opp04 {
-+		opp02 {
++		opp03 {
  			opp-hz = /bits/ 64 <1200000000>;
- 			opp-microvolt = <900000>;
+ 			opp-microvolt = <950000 950000 1250000>;
  		};
 -		opp05 {
-+		opp03 {
++		opp04 {
  			opp-hz = /bits/ 64 <1416000000>;
- 			opp-microvolt = <975000>;
+ 			opp-microvolt = <1025000 1025000 1250000>;
  		};
 -		opp06 {
-+		opp04 {
++		opp05 {
  			opp-hz = /bits/ 64 <1608000000>;
- 			opp-microvolt = <1050000>;
+ 			opp-microvolt = <1100000 1100000 1250000>;
  		};
 -		opp07 {
-+		opp05 {
- 			opp-hz = /bits/ 64 <1800000000>;
- 			opp-microvolt = <1150000>;
- 		};
--		opp08 {
--			opp-hz = /bits/ 64 <2016000000>;
 +		opp06 {
-+			opp-hz = /bits/ 64 <2088000000>;
- 			opp-microvolt = <1250000>;
+ 			opp-hz = /bits/ 64 <1800000000>;
+ 			opp-microvolt = <1200000 1200000 1250000>;
  		};
 +                opp07 {
++                        opp-hz = /bits/ 64 <2088000000>;
++                        opp-microvolt = <1275000 1300000 1300000>;
++                };
++                opp08 {
 +                        opp-hz = /bits/ 64 <2208000000>;
-+                        opp-microvolt = <1350000>;
++                        opp-microvolt = <1300000 1325000 1350000>;
 +                        turbo-mode;
 +                };
  	};
  
  	gpu_opp_table: opp-table-2 {
-@@ -90,44 +88,25 @@
- 			opp-microvolt = <800000>;
+@@ -82,25 +92,30 @@
+ 			opp-microvolt = <825000 825000 1150000>;
  		};
  		opp01 {
 -			opp-hz = /bits/ 64 <297000000>;
--			opp-microvolt = <800000>;
+-			opp-microvolt = <825000 825000 1150000>;
 -		};
 -		opp02 {
 -			opp-hz = /bits/ 64 <400000000>;
--			opp-microvolt = <825000>;
+-			opp-microvolt = <825000 825000 1150000>;
 -		};
 -		opp03 {
 -			opp-hz = /bits/ 64 <500000000>;
--			opp-microvolt = <850000>;
+-			opp-microvolt = <875000 875000 1150000>;
 -		};
 -		opp04 {
  			opp-hz = /bits/ 64 <600000000>;
- 			opp-microvolt = <925000>;
+ 			opp-microvolt = <925000 925000 1150000>;
  		};
 -		opp05 {
 +		opp02 {
  			opp-hz = /bits/ 64 <800000000>;
- 			opp-microvolt = <1075000>;
+ 			opp-microvolt = <1100000 1100000 1150000>;
  		};
-+		opp03 {
-+			opp-hz = /bits/ 64 <900000000>;
-+			opp-microvolt = <1150000>;
-+		};
++                opp03 {
++                        opp-hz = /bits/ 64 <900000000>;
++                        opp-microvolt = <1150000 1150000 1150000>;
++                };
++	};
 +
++	dmc_opp_table: opp-table-3 {
++		compatible = "operating-points-v2";
++
++		opp00 {
++			opp-hz = /bits/ 64 <666000000>;
++			opp-microvolt = <900000>;
++		};
++		opp01 {
++			opp-hz = /bits/ 64 <856000000>;
++			opp-microvolt = <900000>;
++		};
  	};
+ };
  
- 	dmc_opp_table: opp-table-3 {
- 		compatible = "operating-points-v2";
- 
- 		opp00 {
--			opp-hz = /bits/ 64 <400000000>;
--			opp-microvolt = <900000>;
--		};
--		opp01 {
--			opp-hz = /bits/ 64 <666000000>;
--			opp-microvolt = <900000>;
--		};
--		opp02 {
--			opp-hz = /bits/ 64 <800000000>;
--			opp-microvolt = <900000>;
--		};
--		opp03 {
--			opp-hz = /bits/ 64 <928000000>;
-+			opp-hz = /bits/ 64 <933000000>;
- 			opp-microvolt = <925000>;
- 		};
- 	};

--- a/projects/Rockchip/patches/linux/RK3399/003-rg552-joypad.patch
+++ b/projects/Rockchip/patches/linux/RK3399/003-rg552-joypad.patch
@@ -1,6 +1,6 @@
 diff -rupN linux.orig/drivers/gpio/gpiolib-of.c linux/drivers/gpio/gpiolib-of.c
---- linux.orig/drivers/gpio/gpiolib-of.c	2024-01-08 18:42:48.903867377 +0000
-+++ linux/drivers/gpio/gpiolib-of.c	2024-01-08 18:46:49.713063075 +0000
+--- linux.orig/drivers/gpio/gpiolib-of.c	2024-04-12 20:11:09.129330342 +0000
++++ linux/drivers/gpio/gpiolib-of.c	2024-05-02 00:52:08.985482784 +0000
 @@ -25,21 +25,6 @@
  #include "gpiolib.h"
  #include "gpiolib-of.h"
@@ -23,7 +23,7 @@ diff -rupN linux.orig/drivers/gpio/gpiolib-of.c linux/drivers/gpio/gpiolib-of.c
  /**
   * of_gpio_named_count() - Count GPIOs for a device
   * @np:		device node to count GPIOs for
-@@ -398,6 +383,20 @@ out:
+@@ -408,6 +393,20 @@ out:
  	return desc;
  }
  
@@ -45,8 +45,8 @@ diff -rupN linux.orig/drivers/gpio/gpiolib-of.c linux/drivers/gpio/gpiolib-of.c
   * of_get_named_gpio() - Get a GPIO number to use with GPIO API
   * @np:		device node to get GPIO from
 diff -rupN linux.orig/drivers/input/Kconfig linux/drivers/input/Kconfig
---- linux.orig/drivers/input/Kconfig	2024-01-08 18:42:49.679884040 +0000
-+++ linux/drivers/input/Kconfig	2024-01-08 18:43:42.593020626 +0000
+--- linux.orig/drivers/input/Kconfig	2024-04-12 20:11:09.469341185 +0000
++++ linux/drivers/input/Kconfig	2024-05-02 00:52:08.985482784 +0000
 @@ -51,6 +51,19 @@ config INPUT_FF_MEMLESS
  	  To compile this driver as a module, choose M here: the
  	  module will be called ff-memless.
@@ -68,8 +68,8 @@ diff -rupN linux.orig/drivers/input/Kconfig linux/drivers/input/Kconfig
  	tristate "Sparse keymap support library"
  	help
 diff -rupN linux.orig/drivers/input/Makefile linux/drivers/input/Makefile
---- linux.orig/drivers/input/Makefile	2024-01-08 18:42:49.679884040 +0000
-+++ linux/drivers/input/Makefile	2024-01-08 18:43:42.593020626 +0000
+--- linux.orig/drivers/input/Makefile	2024-04-12 20:11:09.469341185 +0000
++++ linux/drivers/input/Makefile	2024-05-02 00:52:08.985482784 +0000
 @@ -10,6 +10,7 @@ input-core-y := input.o input-compat.o i
  input-core-y += touchscreen.o
  
@@ -80,7 +80,7 @@ diff -rupN linux.orig/drivers/input/Makefile linux/drivers/input/Makefile
  obj-$(CONFIG_INPUT_VIVALDIFMAP)	+= vivaldi-fmap.o
 diff -rupN linux.orig/drivers/input/input-polldev.c linux/drivers/input/input-polldev.c
 --- linux.orig/drivers/input/input-polldev.c	1970-01-01 00:00:00.000000000 +0000
-+++ linux/drivers/input/input-polldev.c	2024-01-08 18:43:42.593020626 +0000
++++ linux/drivers/input/input-polldev.c	2024-05-02 00:52:08.985482784 +0000
 @@ -0,0 +1,362 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
@@ -445,8 +445,8 @@ diff -rupN linux.orig/drivers/input/input-polldev.c linux/drivers/input/input-po
 +}
 +EXPORT_SYMBOL(input_unregister_polled_device);
 diff -rupN linux.orig/drivers/input/joystick/Kconfig linux/drivers/input/joystick/Kconfig
---- linux.orig/drivers/input/joystick/Kconfig	2024-01-08 18:42:49.679884040 +0000
-+++ linux/drivers/input/joystick/Kconfig	2024-01-08 18:43:42.593020626 +0000
+--- linux.orig/drivers/input/joystick/Kconfig	2024-04-12 20:11:09.469341185 +0000
++++ linux/drivers/input/joystick/Kconfig	2024-05-02 00:52:08.985482784 +0000
 @@ -393,6 +393,12 @@ config JOYSTICK_FSIA6B
  	  To compile this driver as a module, choose M here: the
  	  module will be called fsia6b.
@@ -461,20 +461,20 @@ diff -rupN linux.orig/drivers/input/joystick/Kconfig linux/drivers/input/joystic
  	bool "N64 controller"
  	depends on MACH_NINTENDO64
 diff -rupN linux.orig/drivers/input/joystick/Makefile linux/drivers/input/joystick/Makefile
---- linux.orig/drivers/input/joystick/Makefile	2024-01-08 18:42:49.679884040 +0000
-+++ linux/drivers/input/joystick/Makefile	2024-01-08 18:43:42.593020626 +0000
-@@ -30,6 +30,7 @@ obj-$(CONFIG_JOYSTICK_PXRC)		+= pxrc.o
+--- linux.orig/drivers/input/joystick/Makefile	2024-04-12 20:11:09.469341185 +0000
++++ linux/drivers/input/joystick/Makefile	2024-05-02 00:59:41.167445165 +0000
+@@ -28,6 +28,7 @@ obj-$(CONFIG_JOYSTICK_N64)		+= n64joy.o
+ obj-$(CONFIG_JOYSTICK_PSXPAD_SPI)	+= psxpad-spi.o
+ obj-$(CONFIG_JOYSTICK_PXRC)		+= pxrc.o
  obj-$(CONFIG_JOYSTICK_QWIIC)		+= qwiic-joystick.o
++obj-$(CONFIG_JOYSTICK_RG552)		+= rg552_joypad.o
+ obj-$(CONFIG_JOYSTICK_SEESAW)		+= adafruit-seesaw.o
  obj-$(CONFIG_JOYSTICK_SENSEHAT)	+= sensehat-joystick.o
  obj-$(CONFIG_JOYSTICK_SIDEWINDER)	+= sidewinder.o
-+obj-$(CONFIG_JOYSTICK_RG552)		+= rg552_joypad.o
- obj-$(CONFIG_JOYSTICK_SPACEBALL)	+= spaceball.o
- obj-$(CONFIG_JOYSTICK_SPACEORB)		+= spaceorb.o
- obj-$(CONFIG_JOYSTICK_STINGER)		+= stinger.o
 diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/joystick/rg552_joypad.c
 --- linux.orig/drivers/input/joystick/rg552_joypad.c	1970-01-01 00:00:00.000000000 +0000
-+++ linux/drivers/input/joystick/rg552_joypad.c	2024-01-08 18:43:54.081267482 +0000
-@@ -0,0 +1,1448 @@
++++ linux/drivers/input/joystick/rg552_joypad.c	2024-05-02 04:17:12.276052203 +0000
+@@ -0,0 +1,1408 @@
 +/*----------------------------------------------------------------------------*/
 +
 +/*
@@ -638,11 +638,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +		pwm_vibrator_stop(joypad);
 +}
 +
-+/*----------------------------------------------------------------------------*/
-+//
-+// set to the value in the boot.ini file. (if exist)
-+//
-+/*----------------------------------------------------------------------------*/
 +static unsigned int g_button_adc_fuzz = 0;
 +static unsigned int g_button_adc_flat = 0;
 +static unsigned int g_button_adc_scale = 0;
@@ -1015,7 +1010,7 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +	struct platform_device *pdev  = to_platform_device(dev);
 +	struct joypad *joypad = platform_get_drvdata(pdev);
 +
-+	return sprintf(buf, "%d\n", pwm_get_period(joypad->pwm));
++	return sprintf(buf, "%llu\n", pwm_get_period(joypad->pwm));
 +}
 +
 +/*----------------------------------------------------------------------------*/
@@ -1124,9 +1119,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +				     struct device_attribute *attr,
 +				     char *buf)
 +{
-+	struct platform_device *pdev  = to_platform_device(dev);
-+	struct joypad *joypad = platform_get_drvdata(pdev);
-+	//int stcon;
 +	ssize_t pos=0;
 +	if(gpio_get_value(54)==1)
 +	{
@@ -1219,7 +1211,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +		/* Read first joystick axis */
 +		adcx->value = joypad_adc_read(joypad->amux, adcx);
 +		if (!adcx->value) {
-+			//dev_err(joypad->dev, "%s : saradc channels[%d]! adc->value : %d\n",__func__, nbtn, adc->value);
 +			continue;
 +		}
 +		adcx->value = adcx->value - adcx->cal;
@@ -1227,7 +1218,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +		/* Read second joystick axis */
 +		adcy->value = joypad_adc_read(joypad->amux, adcy);
 +		if (!adcy->value) {
-+			//dev_err(joypad->dev, "%s : saradc channels[%d]! adc->value : %d\n",__func__, nbtn, adc->value);
 +			continue;
 +		}
 +		adcy->value = adcy->value - adcy->cal;
@@ -1309,8 +1299,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +			continue;
 +		}
 +		adc->cal = adc->value;
-+		//dev_info(joypad->dev, "%s : adc[%d] adc->cal = %d\n",
-+		//	__func__, nbtn, adc->cal);
 +	}
 +	/* buttons status sync */
 +	joypad_adc_check(poll_dev);
@@ -1320,8 +1308,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +	mutex_lock(&joypad->lock);
 +	joypad->enable = true;
 +	mutex_unlock(&joypad->lock);
-+
-+	//dev_info(joypad->dev, "%s : opened\n", __func__);
 +}
 +
 +/*----------------------------------------------------------------------------*/
@@ -1336,8 +1322,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +
 +	cancel_work_sync(&joypad->play_work);
 +	pwm_vibrator_stop(joypad);
-+
-+	//dev_info(joypad->dev, "%s : closed\n", __func__);
 +}
 +
 +/*----------------------------------------------------------------------------*/
@@ -1570,30 +1554,6 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +}
 +
 +/*----------------------------------------------------------------------------*/
-+struct input_dev * joypad_input_g;
-+
-+
-+void rk_send_key_f_key_up(void)
-+{
-+	if (!joypad_input_g)
-+		return;
-+
-+	input_report_key(joypad_input_g, BTN_MODE, 1);
-+	input_sync(joypad_input_g);
-+}
-+EXPORT_SYMBOL(rk_send_key_f_key_up);
-+
-+
-+void rk_send_key_f_key_down(void)
-+{
-+	if (!joypad_input_g)
-+		return;
-+
-+	input_report_key(joypad_input_g, BTN_MODE, 0);
-+	input_sync(joypad_input_g);
-+}
-+EXPORT_SYMBOL(rk_send_key_f_key_down);
-+
 +static int rumble_play_effect(struct input_dev *dev, void *data, struct ff_effect *effect)
 +{
 +	struct joypad *joypad = data;
@@ -1925,7 +1885,7 @@ diff -rupN linux.orig/drivers/input/joystick/rg552_joypad.c linux/drivers/input/
 +module_exit(joypad_exit);
 diff -rupN linux.orig/include/linux/input-polldev.h linux/include/linux/input-polldev.h
 --- linux.orig/include/linux/input-polldev.h	1970-01-01 00:00:00.000000000 +0000
-+++ linux/include/linux/input-polldev.h	2024-01-08 18:43:42.593020626 +0000
++++ linux/include/linux/input-polldev.h	2024-05-02 00:52:08.985482784 +0000
 @@ -0,0 +1,58 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +#ifndef _INPUT_POLLDEV_H
@@ -1986,8 +1946,8 @@ diff -rupN linux.orig/include/linux/input-polldev.h linux/include/linux/input-po
 +
 +#endif
 diff -rupN linux.orig/include/linux/of_gpio.h linux/include/linux/of_gpio.h
---- linux.orig/include/linux/of_gpio.h	2024-01-08 18:42:51.555924323 +0000
-+++ linux/include/linux/of_gpio.h	2024-01-08 19:08:52.942972824 +0000
+--- linux.orig/include/linux/of_gpio.h	2024-04-12 20:11:09.977357387 +0000
++++ linux/include/linux/of_gpio.h	2024-05-02 00:52:08.985482784 +0000
 @@ -17,8 +17,26 @@
  
  struct device_node;
@@ -2048,8 +2008,8 @@ diff -rupN linux.orig/include/linux/of_gpio.h linux/include/linux/of_gpio.h
 +
  #endif /* __LINUX_OF_GPIO_H */
 diff -rupN linux.orig/include/linux/pwm.h linux/include/linux/pwm.h
---- linux.orig/include/linux/pwm.h	2024-01-22 21:57:30.564587413 +0000
-+++ linux/include/linux/pwm.h	2024-01-22 22:17:09.475459054 +0000
+--- linux.orig/include/linux/pwm.h	2024-04-12 20:11:09.985357642 +0000
++++ linux/include/linux/pwm.h	2024-05-02 00:52:08.985482784 +0000
 @@ -110,6 +110,12 @@ static inline bool pwm_is_enabled(const
  	return state.enabled;
  }

--- a/projects/Rockchip/patches/linux/RK3399/999-clear-log-spam.patch
+++ b/projects/Rockchip/patches/linux/RK3399/999-clear-log-spam.patch
@@ -1,6 +1,6 @@
 diff -rupN linux.orig/drivers/gpio/gpio-rockchip.c linux/drivers/gpio/gpio-rockchip.c
---- linux.orig/drivers/gpio/gpio-rockchip.c	2023-12-22 04:23:33.879905917 +0000
-+++ linux/drivers/gpio/gpio-rockchip.c	2023-12-22 05:08:03.636801366 +0000
+--- linux.orig/drivers/gpio/gpio-rockchip.c	2024-04-12 20:11:09.129330342 +0000
++++ linux/drivers/gpio/gpio-rockchip.c	2024-05-01 23:09:29.557274731 +0000
 @@ -335,13 +335,13 @@ static void rockchip_irq_demux(struct ir
  	unsigned long pending;
  	unsigned int irq;
@@ -18,9 +18,9 @@ diff -rupN linux.orig/drivers/gpio/gpio-rockchip.c linux/drivers/gpio/gpio-rockc
  		/*
  		 * Triggering IRQ on both rising and falling edge
 diff -rupN linux.orig/drivers/input/touchscreen/goodix.c linux/drivers/input/touchscreen/goodix.c
---- linux.orig/drivers/input/touchscreen/goodix.c	2023-12-22 04:23:34.199912947 +0000
-+++ linux/drivers/input/touchscreen/goodix.c	2023-12-22 05:08:59.121963345 +0000
-@@ -1019,7 +1019,7 @@ retry_get_irq_gpio:
+--- linux.orig/drivers/input/touchscreen/goodix.c	2024-04-12 20:11:09.473341313 +0000
++++ linux/drivers/input/touchscreen/goodix.c	2024-05-01 23:09:29.557274731 +0000
+@@ -1020,7 +1020,7 @@ retry_get_irq_gpio:
  	default:
  		if (ts->gpiod_int && ts->gpiod_rst) {
  			ts->reset_controller_at_probe = true;
@@ -29,3 +29,33 @@ diff -rupN linux.orig/drivers/input/touchscreen/goodix.c linux/drivers/input/tou
  			ts->irq_pin_access_method = IRQ_PIN_ACCESS_GPIO;
  		}
  	}
+diff -rupN linux.orig/sound/soc/codecs/hdmi-codec.c linux/sound/soc/codecs/hdmi-codec.c
+--- linux.orig/sound/soc/codecs/hdmi-codec.c	2024-04-12 20:11:10.145362745 +0000
++++ linux/sound/soc/codecs/hdmi-codec.c	2024-05-01 23:10:25.914597595 +0000
+@@ -438,7 +438,7 @@ static int hdmi_codec_startup(struct snd
+ 
+ 	mutex_lock(&hcp->lock);
+ 	if (hcp->busy) {
+-		dev_err(dai->dev, "Only one simultaneous stream supported!\n");
++		//dev_err(dai->dev, "Only one simultaneous stream supported!\n");
+ 		mutex_unlock(&hcp->lock);
+ 		return -EINVAL;
+ 	}
+diff -rupN linux.orig/sound/soc/soc-dai.c linux/sound/soc/soc-dai.c
+--- linux.orig/sound/soc/soc-dai.c	2024-04-12 20:11:10.169363511 +0000
++++ linux/sound/soc/soc-dai.c	2024-05-01 23:18:20.597488414 +0000
+@@ -23,10 +23,10 @@ static inline int _soc_dai_ret(struct sn
+ 	case -EPROBE_DEFER:
+ 	case -ENOTSUPP:
+ 		break;
+-	default:
+-		dev_err(dai->dev,
+-			"ASoC: error at %s on %s: %d\n",
+-			func, dai->name, ret);
++	//default:
++	//	dev_err(dai->dev,
++	//		"ASoC: error at %s on %s: %d\n",
++	//		func, dai->name, ret);
+ 	}
+ 
+ 	return ret;


### PR DESCRIPTION
Removes some dead code from the dts and input driver. Also removes some dmesg log "errors" that provide no value and are just noise. 

Switched up opp profiles as well, which seems to be more stable overall. 