### PR TITLE
rk356x.dtsi: set CPU/GPU target temperature to 85/82 C

### DIFF
--- a/projects/Rockchip/patches/linux/RK3566/000-rk3566-dtsi.patch
+++ b/projects/Rockchip/patches/linux/RK3566/000-rk3566-dtsi.patch
@@ -14,3 +14,14 @@ index 6c4b17d27bdc..f4050ae1cbf4 100644
 +		turbo-mode;
 +	};
 +};
+--- linux-6.9-rc3/arch/arm64/boot/dts/rockchip/rk356x.dtsi.orig	2024-04-19 15:00:45.070637916 +0300
++++ linux-6.9-rc3/arch/arm64/boot/dts/rockchip/rk356x.dtsi	2024-04-19 15:03:01.108366560 +0300
+@@ -1507,7 +1507,7 @@
+ 
+ 			cooling-maps {
+ 				map0 {
+-					trip = <&cpu_alert0>;
++					trip = <&cpu_alert1>;
+ 					cooling-device =
+ 						<&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+ 						<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,


### PR DESCRIPTION
increase the target temperatures on RK3566.
CPU is throttled at 85C
GPU is throttled at 82C

This seems stable. In 3d-intensive games/emus performance is limited by CPU temp, GPU is usually about 77C.