### PR TITLE
rocknix-joypad: bump driver

### DIFF
--- a/packages/kernel/drivers/rocknix-joypad/package.mk
+++ b/packages/kernel/drivers/rocknix-joypad/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="rocknix-joypad"
-PKG_VERSION="38ec995c8516ad39544b85026876b0215fb16544"
+PKG_VERSION="df031f47f2762643f52ac5d64cb4bd9f928cb049"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/rocknix-joypad"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update rocknix-joypad revision to existing (and latest) one.  
This fixes sleep issue on rg503 (thanks to `to_platform_device` in PM functions)