### PR TITLE
Clean up S922X device checks

### DIFF
--- a/packages/emulators/libretro/flycast2021-lr/package.mk
+++ b/packages/emulators/libretro/flycast2021-lr/package.mk
@@ -48,7 +48,7 @@ pre_configure_target() {
 pre_make_target() {
   export BUILD_SYSROOT=${SYSROOT_PREFIX}
   case ${DEVICE} in
-    RK3*|S922X*)
+    RK3*|S922X)
       PKG_MAKE_OPTS_TARGET+=" platform=${DEVICE}"
     ;;
   esac

--- a/packages/emulators/libretro/mupen64plus-nx-lr/package.mk
+++ b/packages/emulators/libretro/mupen64plus-nx-lr/package.mk
@@ -29,7 +29,7 @@ pre_configure_target() {
   sed -e "s|^GIT_VERSION ?.*$|GIT_VERSION := \" ${PKG_VERSION:0:7}\"|" -i Makefile
   sed -i 's/\-O[23]/-Ofast/' ${PKG_BUILD}/Makefile
   case ${DEVICE} in
-    RK3*|S922X*)
+    RK3*|S922X)
       PKG_MAKE_OPTS_TARGET=" platform=${DEVICE}"
     ;;
   esac

--- a/packages/emulators/libretro/parallel-n64-lr/package.mk
+++ b/packages/emulators/libretro/parallel-n64-lr/package.mk
@@ -24,7 +24,7 @@ if [ "${VULKAN_SUPPORT}" = "yes" ]; then
 fi
 
 case ${DEVICE} in
-  RK3*|S922X*)
+  RK3*|S922X)
     PKG_MAKE_OPTS_TARGET+=" platform=${DEVICE}"
   ;;
   AMD64)

--- a/packages/emulators/libretro/yabasanshiro-lr/package.mk
+++ b/packages/emulators/libretro/yabasanshiro-lr/package.mk
@@ -42,7 +42,7 @@ fi
 pre_configure_target() {
   sed -i 's/\-O[23]/-Ofast -ffast-math/' ${PKG_BUILD}/yabause/src/libretro/Makefile
   case ${DEVICE} in
-    RK3*|S922X*)
+    RK3*|S922X)
       PKG_MAKE_OPTS_TARGET+=" -C yabause/src/libretro platform=rockpro64 HAVE_NEON=0 FORCE_GLES=1"
     ;;
     AMD64)

--- a/packages/emulators/standalone/mednafen/package.mk
+++ b/packages/emulators/standalone/mednafen/package.mk
@@ -9,7 +9,7 @@ PKG_URL="${PKG_SITE}/releases/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain SDL2 flac"
 PKG_TOOLCHAIN="configure"
 
-if [ "${DEVICE}" = "S922X*" ]; then
+if [ "${DEVICE}" = "S922X" ]; then
   PKG_DEPENDS_TARGET+=" libegl"
 fi
 
@@ -30,7 +30,7 @@ case ${DEVICE} in
 			 --disable-ss \
 			 --disable-psx"
   ;;
-  S922X*)
+  S922X)
     DISABLED_MODULES+="  --disable-ss \
 			 --disable-snes"
   ;;

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-audio-sdl/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-audio-sdl/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Audio SDL"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -53,7 +53,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X*|RK3399|RK3566*)
+    AMD64|RK3588|S922X|RK3399|RK3566*)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-audio-sdl-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-input-sdl/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-input-sdl/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Input SDL"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -53,7 +53,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X*|RK3399|RK3566*)
+    AMD64|RK3588|S922X|RK3399|RK3566*)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl.so ${PKG_BUILD}/projects/unix/mupen64plus-input-sdl-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-cxd4/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-cxd4/package.mk
@@ -15,7 +15,7 @@ PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="-fpic"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -60,7 +60,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-rsp-cxd4${SUFFIX}.so ${PKG_BUILD}/projects/unix/mupen64plus-rsp-cxd4-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X*|RK3399|RK3566*)
+    AMD64|RK3588|S922X|RK3399|RK3566*)
       PKG_MAKE_OPTS_TARGET+=" cxd4VIDEO=1"
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-hle/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-rsp-hle/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone RSP HLE"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -52,7 +52,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle.so ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X*|RK3399|RK3566*)
+    AMD64|RK3588|S922X|RK3399|RK3566*)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle.so ${PKG_BUILD}/projects/unix/mupen64plus-rsp-hle-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-ui-console/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-ui-console/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Console"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -48,7 +48,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus ${PKG_BUILD}/projects/unix/mupen64plus-base
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X*|RK3399|RK3566*)
+    AMD64|RK3588|S922X|RK3399|RK3566*)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       export CFLAGS="${CFLAGS} -DSIMPLECORE"
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-glide64mk2/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-glide64mk2/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Glide64 Video Driver"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -52,7 +52,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2.so ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X*|RK3399|RK3566*)
+    AMD64|RK3588|S922X|RK3399|RK3566*)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2.so ${PKG_BUILD}/projects/unix/mupen64plus-video-glide64mk2-simple.so

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-gliden64/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-gliden64/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone GLide64 Video Driver"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-rice/package.mk
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-video-rice/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Mupen64Plus Standalone Rice Video Driver"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  AMD64|RK3588|S922X*|RK3399|RK3566*)
+  AMD64|RK3588|S922X|RK3399|RK3566*)
     PKG_DEPENDS_TARGET+=" mupen64plus-sa-simplecore"
   ;;
 esac
@@ -52,7 +52,7 @@ make_target() {
   cp ${PKG_BUILD}/projects/unix/mupen64plus-video-rice.so ${PKG_BUILD}/projects/unix/mupen64plus-video-rice-base.so
 
   case ${DEVICE} in
-    AMD64|RK3588|S922X*|RK3399|RK3566*)
+    AMD64|RK3588|S922X|RK3399|RK3566*)
       export APIDIR=$(get_build_dir mupen64plus-sa-simplecore)/src/api
       make -C projects/unix all ${PKG_MAKE_OPTS_TARGET}
       cp ${PKG_BUILD}/projects/unix/mupen64plus-video-rice.so ${PKG_BUILD}/projects/unix/mupen64plus-video-rice-simple.so

--- a/packages/misc/modules/package.mk
+++ b/packages/misc/modules/package.mk
@@ -35,7 +35,7 @@ post_makeinstall_target() {
   esac
 
   case ${DEVICE} in
-    S922X*)
+    S922X)
       rm -f ${INSTALL}/usr/config/modules/*ScummVM*
       rm -f ${INSTALL}/usr/config/modules/*32bit*
     ;;

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -21,7 +21,7 @@ pre_configure_target() {
 
   # Fix missing dispmanx
   case ${DEVICE} in
-    RK3*|S922X*)
+    RK3*|S922X)
       PKG_MESON_OPTS_TARGET+=" -Dgl-graphene=disabled"
     ;;
   esac

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -52,7 +52,7 @@ case "${DEVICE}" in
     LIBRETRO_CORES+=" flycast-lr geolith-lr uae4arm"
     PKG_RETROARCH+=" retropie-shaders"
   ;;
-  S922X*)
+  S922X)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 pcsx_rearmed-lr wine"
     PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa portmaster yabasanshiro-sa"
     LIBRETRO_CORES+=" beetle-psx-lr bsnes-lr bsnes-hd-lr dolphin-lr geolith-lr flycast-lr uae4arm"
@@ -120,7 +120,7 @@ makeinstall_target() {
 
   ### Nintendo 3DS
   case ${DEVICE} in
-    S922X*)
+    S922X)
       add_emu_core 3ds lime3ds lime3ds-sa true
       add_es_system 3ds
     ;;
@@ -490,7 +490,7 @@ makeinstall_target() {
       add_emu_core gamecube retroarch dolphin false
       add_es_system gamecube
     ;;
-    S922X*|RK3399|RK3588*)
+    S922X|RK3399|RK3588*)
       add_emu_core gamecube dolphin dolphin-sa-gc true
       add_emu_core gamecube retroarch dolphin false
       add_es_system gamecube
@@ -504,7 +504,7 @@ makeinstall_target() {
       add_emu_core wii retroarch dolphin false
       add_es_system wii
     ;;
-    S922X*|RK3399|RK3588*)
+    S922X|RK3399|RK3588*)
       add_emu_core wii dolphin dolphin-sa-wii true
       add_emu_core wii retroarch dolphin false
       add_es_system wii
@@ -815,7 +815,7 @@ makeinstall_target() {
       add_emu_core psx retroarch beetle_psx true
       add_emu_core psx mednafen psx false
     ;;
-    S922X*)
+    S922X)
       add_emu_core psx retroarch pcsx_rearmed true
       add_emu_core psx retroarch beetle_psx false
     ;;
@@ -897,7 +897,7 @@ makeinstall_target() {
 
   ### ScummVM
   case ${DEVICE} in
-    S922X*)
+    S922X)
       add_emu_core scummvm retroarch scummvm true
     ;;
     *)
@@ -1058,7 +1058,7 @@ makeinstall_target() {
   add_emu_core snes retroarch beetle_supafaust false
   add_emu_core snes retroarch bsnes_mercury_performance false
   case ${DEVICE} in
-    AMD64|S922X*|RK3399|RK358*)
+    AMD64|S922X|RK3399|RK358*)
       add_emu_core snes retroarch bsnes false
       add_emu_core snes retroarch bsnes_hd_beta false
 	;;
@@ -1082,7 +1082,7 @@ makeinstall_target() {
   add_emu_core snesh retroarch beetle_supafaust false
   add_emu_core snesh retroarch bsnes_mercury_performance false
   case ${DEVICE} in
-    AMD64|S922X*|RK3399|RK358*)
+    AMD64|S922X|RK3399|RK358*)
       add_emu_core snesh retroarch bsnes false
       add_emu_core snesh retroarch bsnes_hd_beta false
 	;;
@@ -1106,7 +1106,7 @@ makeinstall_target() {
   add_emu_core sfc retroarch beetle_supafaust false
   add_emu_core sfc retroarch bsnes_mercury_performance false
   case ${DEVICE} in
-    AMD64|S922X*|RK3399|RK358*)
+    AMD64|S922X|RK3399|RK358*)
       add_emu_core sfc retroarch bsnes false
       add_emu_core sfc retroarch bsnes_hd_beta false
 	;;


### PR DESCRIPTION
No need for `S922X*` as S922X-PANFROST build uses `DEVICE=S922X`. Just cleaning up to avoid any possible confusion.