### PR TITLE
Move to Quad9 instead of Google for DNS.

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -71,7 +71,7 @@ post_makeinstall_target() {
     sed -i ${INSTALL}/etc/connman/main.conf \
         -e "s|^# BackgroundScanning.*|BackgroundScanning = true|g" \
         -e "s|^# UseGatewaysAsTimeservers.*|UseGatewaysAsTimeservers = false|g" \
-        -e "s|^# FallbackNameservers.*|FallbackNameservers = 8.8.8.8,8.8.4.4|g" \
+        -e "s|^# FallbackNameservers.*|FallbackNameservers = 9.9.9.9,149.112.112.112|g" \
         -e "s|^# FallbackTimeservers.*|FallbackTimeservers = 0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org|g" \
         -e "s|^# PreferredTechnologies.*|PreferredTechnologies = ethernet,wifi,cellular|g" \
         -e "s|^# TetheringTechnologies.*|TetheringTechnologies = wifi|g" \

--- a/packages/sysutils/systemd/scripts/network-base-setup
+++ b/packages/sysutils/systemd/scripts/network-base-setup
@@ -22,8 +22,8 @@ elif [ -f /dev/.kernel_ipconfig -a -f /proc/net/pnp ]; then
   cat /proc/net/pnp > /run/rocknix/resolv.conf
 else
   cat << EOF > /run/rocknix/resolv.conf
-nameserver 8.8.8.8
-nameserver 8.8.4.4
+nameserver 9.9.9.9
+nameserver 149.112.112.112
 EOF
 fi
 


### PR DESCRIPTION
For one thing, some sites black-hole Google's public DNS in order to force Chromecast hardware to fallback to local DNS servers. Such sites will be unable to update Rocknix on-line, because Rocknix's pre-update connectivity check will fail.