### PR TITLE
mkimage: fix booting from 2tb+ drives

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -91,7 +91,7 @@ dd if="${DISK}" of="${LE_TMP}/part2.ext4" bs=512 count=0 seek="${STORAGE_PART_CO
 
 # create filesystem on part2
 echo "image: creating filesystem on part2..."
-mke2fs -F -q -t ext4 -m 0 -O ^orphan_file "${LE_TMP}/part2.ext4"
+mke2fs -F -q -t ext4 -m 0 -O ^orphan_file -b 4096 "${LE_TMP}/part2.ext4"
 tune2fs -L "${DISTRO_DISKLABEL}" -U ${UUID_STORAGE} "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 e2fsck -n "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 sync


### PR DESCRIPTION
mke2fs was using a default block size of 1kb, this caused 2tb+ drives to fail initial resizing script with the following error.

resize2fs: New size results in too many block group descriptors.