### PR TITLE
Fixes to rclone

### DIFF
--- a/packages/network/rclone/sources/rclonectl
+++ b/packages/network/rclone/sources/rclonectl
@@ -39,7 +39,7 @@ function checkconfig() {
 
 function mount() {
   TARGET=$(rclone listremotes | awk '{printf $1; exit}')
-  rclone mount ${TARGET}/ ${1} \
+  rclone mount ${TARGET} ${1} \
     --vfs-cache-mode writes \
     --vfs-cache-max-size 100M \
     --vfs-read-chunk-size-limit 128M \

--- a/packages/network/rclone/sources/rsync-rules.conf
+++ b/packages/network/rclone/sources/rsync-rules.conf
@@ -9,6 +9,7 @@
 + *.srm
 + *.auto
 + *.state*
++ *.dsv*
 
 ### This is a required rule to exclude all other file types.
 - *


### PR DESCRIPTION
- Add Drastic save file extension to rsync rules
-  Fix trailing slash on rclonectl mount which breaks environments that do not have access to / (i.e. Hetzner storage box)