### PR TITLE
standalone emulator start scripts - fix big / little core settings

### DIFF
--- a/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
+++ b/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
@@ -21,8 +21,20 @@ if [ ! -d "/storage/roms/savestates/ps2" ]; then
     mkdir -p "/storage/roms/savestates/ps2"
 fi
 
+#Emulation Station Features
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+ASPECT=$(get_setting aspect_ratio "${PLATFORM}" "${GAME}")
+FILTER=$(get_setting bilinear_filtering "${PLATFORM}" "${GAME}")
+FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
+RATE=$(get_setting ee_cycle_rate "${PLATFORM}" "${GAME}")
+SKIP=$(get_setting ee_cycle_skip "${PLATFORM}" "${GAME}")
+GRENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
+IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
+VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"
@@ -33,18 +45,6 @@ else
   #All..
   unset EMUPERF
 fi
-
-  #Emulation Station Features
-  GAME=$(echo "${1}"| sed "s#^/.*/##")
-  ASPECT=$(get_setting aspect_ratio ps2 "${GAME}")
-  FILTER=$(get_setting bilinear_filtering ps2 "${GAME}")
-  FPS=$(get_setting show_fps ps2 "${GAME}")
-  RATE=$(get_setting ee_cycle_rate ps2 "${GAME}")
-  SKIP=$(get_setting ee_cycle_skip ps2 "${GAME}")
-  GRENDERER=$(get_setting graphics_backend ps2 "${GAME}")
-  IRES=$(get_setting internal_resolution ps2 "${GAME}")
-  VSYNC=$(get_setting vsync ps2 "${GAME}")
-
 
   #Aspect Ratio
 	if [ "$ASPECT" = "0" ]

--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
@@ -34,8 +34,22 @@ ln -sf /storage/roms/savestates/gamecube /storage/.config/dolphin-emu/StateSaves
 cp -r /usr/config/dolphin-emu/GFX.ini /storage/.config/dolphin-emu.GFX.ini
 cp -r /usr/config/dolphin-emu/Dolphin.ini /storage/.config/dolphin-emu.Dolphin.ini
 
+#Emulation Station Features
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+AA=$(get_setting anti_aliasing "${PLATFORM}" "${GAME}")
+ASPECT=$(get_setting aspect_ratio "${PLATFORM}" "${GAME}")
+CLOCK=$(get_setting clock_speed "${PLATFORM}" "${GAME}")
+RENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
+IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
+FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
+CON=$(get_setting gamecube_controller_profile "${PLATFORM}" "${GAME}")
+SHADERM=$(get_setting shader_mode "${PLATFORM}" "${GAME}")
+SHADERP=$(get_setting shader_precompile "${PLATFORM}" "${GAME}")
+VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"
@@ -46,19 +60,6 @@ else
   ### All..
   unset EMUPERF
 fi
-
-  #Emulation Station Features
-  GAME=$(echo "${1}"| sed "s#^/.*/##")
-  AA=$(get_setting anti_aliasing gamecube "${GAME}")
-  ASPECT=$(get_setting aspect_ratio gamecube "${GAME}")
-  CLOCK=$(get_setting clock_speed gamecube "${GAME}")
-  RENDERER=$(get_setting graphics_backend gamecube "${GAME}")
-  IRES=$(get_setting internal_resolution gamecube "${GAME}")
-  FPS=$(get_setting show_fps gamecube "${GAME}")
-  CON=$(get_setting gamecube_controller_profile gamecube "${GAME}")
-  SHADERM=$(get_setting shader_mode gamecube "${GAME}")
-  SHADERP=$(get_setting shader_precompile gamecube "${GAME}")
-  VSYNC=$(get_setting vsync gamecube "${GAME}")
 
   #Anti-Aliasing
 	if [ "$AA" = "0" ]

--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
@@ -37,8 +37,22 @@ ln -sf /storage/roms/savestates/wii /storage/.config/dolphin-emu/StateSaves
 cp -r /usr/config/dolphin-emu/GFX.ini /storage/.config/dolphin-emu.GFX.ini
 cp -r /usr/config/dolphin-emu/Dolphin.ini /storage/.config/dolphin-emu.Dolphin.ini
 
+#Emulation Station options
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+AA=$(get_setting anti_aliasing "${PLATFORM}" "${GAME}")
+ASPECT=$(get_setting aspect_ratio "${PLATFORM}" "${GAME}")
+CLOCK=$(get_setting clock_speed "${PLATFORM}" "${GAME}")
+RENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
+IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
+FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
+CON=$(get_setting wii_controller_profile "${PLATFORM}" "${GAME}")
+SHADERM=$(get_setting shader_mode "${PLATFORM}" "${GAME}")
+SHADERP=$(get_setting shader_precompile "${PLATFORM}" "${GAME}")
+VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"
@@ -49,19 +63,6 @@ else
   ### All..
   unset EMUPERF
 fi
-
-  #Emulation Station options
-  GAME=$(echo "${1}"| sed "s#^/.*/##")
-  AA=$(get_setting anti_aliasing wii "${GAME}")
-  ASPECT=$(get_setting aspect_ratio wii "${GAME}")
-  CLOCK=$(get_setting clock_speed wii "${GAME}")
-  RENDERER=$(get_setting graphics_backend wii "${GAME}")
-  IRES=$(get_setting internal_resolution wii "${GAME}")
-  FPS=$(get_setting show_fps wii "${GAME}")
-  CON=$(get_setting wii_controller_profile wii "${GAME}")
-  SHADERM=$(get_setting shader_mode wii "${GAME}")
-  SHADERP=$(get_setting shader_precompile wii "${GAME}")
-  VSYNC=$(get_setting vsync wii "${GAME}")
 
   #Anti-Aliasing
 	if [ "$AA" = "0" ]

--- a/packages/emulators/standalone/duckstation-sa/scripts/start_duckstation.sh
+++ b/packages/emulators/standalone/duckstation-sa/scripts/start_duckstation.sh
@@ -24,8 +24,17 @@ ln -sfv "/storage/roms/savestates/psx" "/storage/.config/duckstation/savestates"
 #Copy gamecontroller db file from the device.
 cp -rf /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt /storage/.config/duckstation/@RESOURCE_FOLDER@/gamecontrollerdb.txt
 
+#Emulation Station Features
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+ASPECT=$(get_setting aspect_ratio "${PLATFORM}" "${GAME}")
+FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
+IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
+RENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
+VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"
@@ -36,14 +45,6 @@ else
   ### All..
   unset EMUPERF
 fi
-
-  #Emulation Station Features
-  GAME=$(echo "${1}"| sed "s#^/.*/##")
-  ASPECT=$(get_setting aspect_ratio psx "${GAME}")
-  FPS=$(get_setting show_fps psx "${GAME}")
-  IRES=$(get_setting internal_resolution psx "${GAME}")
-  RENDERER=$(get_setting graphics_backend psx "${GAME}")
-  VSYNC=$(get_setting vsync psx "${GAME}")
 
   #Aspect Ratio
 	if [ "$ASPECT" = "0" ]

--- a/packages/emulators/standalone/flycast-sa/scripts/start_flycast.sh
+++ b/packages/emulators/standalone/flycast-sa/scripts/start_flycast.sh
@@ -25,8 +25,16 @@ fi
 #Link  .config/flycast to .local
 ln -sf "/storage/roms/bios/dc" "/storage/roms/dreamcast/data"
 
+#Emulation Station Features
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+ASPECT=$(get_setting aspect_ratio "${PLATFORM}" "${GAME}")
+ASKIP=$(get_setting auto_frame_skip "${PLATFORM}" "${GAME}")
+FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
+VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"
@@ -37,13 +45,6 @@ else
   ### All..
   unset EMUPERF
 fi
-
-  #Emulation Station Features
-  GAME=$(echo "${1}"| sed "s#^/.*/##")
-  ASPECT=$(get_setting aspect_ratio dreamcast "${GAME}")
-  ASKIP=$(get_setting auto_frame_skip dreamcast "${GAME}")
-  FPS=$(get_setting show_fps dreamcast "${GAME}")
-  VSYNC=$(get_setting vsync dreamcast "${GAME}")
 
   #AspectRatio
         if [ "$ASPECT" = "4/3" ]

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -10,17 +10,18 @@ set_kill set "-9 mupen64plus"
 
 # Emulation Station features
 GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
 SCREENWIDTH=$(fbwidth)
 SCREENHEIGHT=$(fbheight)
-ASPECT=$(get_setting game_aspect_ratio n64 "${GAME}")
-IRES=$(get_setting internal_resolution n64 "${GAME}")
-RSP=$(get_setting rsp_plugin n64 "${GAME}")
-SIMPLECORE=$(get_setting core_plugin n64 "${GAME}")
-FPS=$(get_setting show_fps n64 "${GAME}")
-PAK=$(get_setting controller_pak n64 "${GAME}")
-CON=$(get_setting input_configuration n64 "${GAME}")
-VPLUGIN=$(get_setting video_plugin n64 "${GAME}")
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+ASPECT=$(get_setting game_aspect_ratio "${PLATFORM}" "${GAME}")
+IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
+RSP=$(get_setting rsp_plugin "${PLATFORM}" "${GAME}")
+SIMPLECORE=$(get_setting core_plugin "${PLATFORM}" "${GAME}")
+FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
+PAK=$(get_setting controller_pak "${PLATFORM}" "${GAME}")
+CON=$(get_setting input_configuration "${PLATFORM}" "${GAME}")
+VPLUGIN=$(get_setting video_plugin "${PLATFORM}" "${GAME}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 
 # File locations
 SHARE="/usr/local/share/mupen64plus"

--- a/packages/emulators/standalone/nanoboyadvance-sa/scripts/start_nanoboyadvance.sh
+++ b/packages/emulators/standalone/nanoboyadvance-sa/scripts/start_nanoboyadvance.sh
@@ -23,7 +23,9 @@ if [ ! -f "/storage/roms/bios/gba/gba_bios.bin" ]; then
 fi
 
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+CORES=$(get_setting "cores" ${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"

--- a/packages/emulators/standalone/ppsspp-sa/scripts/start_ppsspp.sh
+++ b/packages/emulators/standalone/ppsspp-sa/scripts/start_ppsspp.sh
@@ -13,8 +13,18 @@ then
   cp -rf ${SOURCE_DIR} ${CONF_DIR}
 fi
 
+#Emulation Station Features
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+FSKIP=$(get_setting frame_skip "${PLATFORM}" "${GAME}")
+FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
+IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
+GRENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
+SKIPB=$(get_setting skip_buffer_effects "${PLATFORM}" "${GAME}")
+VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"
@@ -25,15 +35,6 @@ else
   ### All..
   unset EMUPERF
 fi
-
-  #Emulation Station Features
-  GAME=$(echo "${1}"| sed "s#^/.*/##")
-  FSKIP=$(get_setting frame_skip psp "${GAME}")
-  FPS=$(get_setting show_fps psp "${GAME}")
-  IRES=$(get_setting internal_resolution psp "${GAME}")
-  GRENDERER=$(get_setting graphics_backend psp "${GAME}")
-  SKIPB=$(get_setting skip_buffer_effects psp "${GAME}")
-  VSYNC=$(get_setting vsync psp "${GAME}")
 
   #Frame Skip
         if [ "${FSKIP}" = "0" ]

--- a/packages/emulators/standalone/supermodel-sa/scripts/start_supermodel.sh
+++ b/packages/emulators/standalone/supermodel-sa/scripts/start_supermodel.sh
@@ -28,8 +28,15 @@ if [ ! -d "${CONFIG_DIR}/LocalConfig" ]; then
     mkdir -p "${CONFIG_DIR}/LocalConfig"
 fi
 
+#Emulation Station Features
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+RESOLUTION=$(get_setting resolution "${PLATFORM}" "${GAME}")
+ENGINE=$(get_setting rendering_engine "${PLATFORM}" "${GAME}")
+
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"
@@ -40,12 +47,6 @@ else
   ### All..
   unset EMUPERF
 fi
-
-#Emulation Station Features
-GAME=$(echo "${1}"| sed "s#^/.*/##")
-VSYNC=$(get_setting vsync segamodel3 "${GAME}")
-RESOLUTION=$(get_setting resolution segamodel3 "${GAME}")
-ENGINE=$(get_setting rendering_engine segamodel3 "${GAME}")
 
 OPTIONS=
 

--- a/packages/emulators/standalone/yabasanshiro-sa/scripts/start_yabasanshiro.sh
+++ b/packages/emulators/standalone/yabasanshiro-sa/scripts/start_yabasanshiro.sh
@@ -52,10 +52,11 @@ fi
 
 BIOS=""
 GAME=$(echo "${1}"| sed "s#^/.*/##")
-USE_BIOS=$(get_setting use_hlebios saturn "${GAME}")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+USE_BIOS=$(get_setting use_hlebios "${PLATFORM}" "${GAME}")
 if [ ! "${USE_BIOS}" = 1 ]
 then
-  USE_BIOS=$(get_setting use_hlebios saturn)
+  USE_BIOS=$(get_setting use_hlebios "${PLATFORM}")
 fi
 
 if [ "$USE_BIOS" = 1 ]
@@ -77,7 +78,7 @@ then
 fi
 
 #Set the cores to use
-CORES=$(get_setting "cores" "${PLATFORM}" "${ROMNAME##*/}")
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 if [ "${CORES}" = "little" ]
 then
   EMUPERF="${SLOW_CORES}"

--- a/packages/rocknix/sources/scripts/runemu.sh
+++ b/packages/rocknix/sources/scripts/runemu.sh
@@ -270,20 +270,20 @@ case ${EMULATOR} in
         RUNTHIS='${RUN_SHELL} "${ROMNAME}"'
       ;;
       "gamecube")
-        RUNTHIS='${RUN_SHELL} /usr/bin/start_dolphin_gc.sh "${ROMNAME}"'
+        RUNTHIS='${RUN_SHELL} /usr/bin/start_dolphin_gc.sh "${ROMNAME}" "${PLATFORM}"'
       ;;
       "wii")
-        RUNTHIS='${RUN_SHELL} /usr/bin/start_dolphin_wii.sh "${ROMNAME}"'
+        RUNTHIS='${RUN_SHELL} /usr/bin/start_dolphin_wii.sh "${ROMNAME}" "${PLATFORM}"'
       ;;
       "ports")
-        RUNTHIS='${RUN_SHELL} "${ROMNAME}"'
+        RUNTHIS='${EMUPERF} ${RUN_SHELL} "${ROMNAME}"'
 	sed -i "/^ACTIVE_GAME=/c\ACTIVE_GAME=\"${ROMNAME}\"" /storage/.config/PortMaster/mapper.txt
       ;;
       "shell")
         RUNTHIS='${RUN_SHELL} "${ROMNAME}"'
       ;;
       *)
-        RUNTHIS='${RUN_SHELL} "start_${CORE%-*}.sh" "${ROMNAME}"'
+        RUNTHIS='${RUN_SHELL} "start_${CORE%-*}.sh" "${ROMNAME}" "${PLATFORM}"'
       ;;
     esac
   ;;
@@ -389,7 +389,7 @@ ${VERBOSE} && log $0 "Set emulation performance mode to (${CPU_GOVERNOR})"
 ${CPU_GOVERNOR}
 
 # If the rom is a shell script just execute it, useful for DOSBOX and ScummVM scan scripts
-if [[ "${ROMNAME}" == *".sh" ]]; then
+if [[ "${ROMNAME}" == *".sh" ]] && [ ! "${PLATFORM}" = "ports" ]; then
         ${VERBOSE} && log $0 "Executing shell script ${ROMNAME}"
         "${ROMNAME}" &>>${OUTPUT_LOG}
         ret_error=$?


### PR DESCRIPTION
System and game-level big / little core config for standalone emulators were broken. Reason being that `PLATFORM` and `ROMNAME` used in the standalone emulator start scripts are undefined, so fix to match other `get_setting` calls in the scripts.