### PR TITLE
sway: remove startup hack

### DIFF
--- a/packages/ui/emulationstation/system.d/essway.service
+++ b/packages/ui/emulationstation/system.d/essway.service
@@ -10,9 +10,6 @@ After=sway.service
 Environment=HOME=/storage
 Type=simple
 ExecStart=/usr/bin/start_es.sh
-# This is  hack, ES doesn't immediately detect the builtin gamepad
-# unless an input device is connected while ES is running
-ExecStartPost=/usr/bin/timeout --preserve-status 5 /usr/bin/gptokeyb
 WorkingDirectory=/storage
 Restart=always
 RestartSec=2

--- a/packages/wayland/compositor/sway/scripts/sway.sh
+++ b/packages/wayland/compositor/sway/scripts/sway.sh
@@ -10,8 +10,5 @@ if [ ! -z "$(lsmod | grep 'nvidia')" ]; then
   SWAY_GPU_ARGS="--unsupported-gpu"
 fi
 
-# start sway, even if no input devices are connected
-export WLR_LIBINPUT_NO_DEVICES=1
-
 logger -t Sway "### Starting Sway with -V ${SWAY_GPU_ARGS} ${SWAY_DAEMON_ARGS}"
 /usr/bin/sway -V ${SWAY_GPU_ARGS} ${SWAY_DAEMON_ARGS} > ${SWAY_LOG_FILE} 2>&1


### PR DESCRIPTION
Removes startup hack.
WLR_LIBINPUT_NO_DEVICES=1 flag not only lets sway start without input, but it also doesn't add inputs