### PR TITLE
Change default UI shader from slangp to glslp for RK3326

### DIFF
--- a/packages/hardware/quirks/platforms/RK3326/091-ui_shader
+++ b/packages/hardware/quirks/platforms/RK3326/091-ui_shader
@@ -4,5 +4,5 @@
 
 ### Set the default device configuration
 cat <<EOF >/storage/.config/profile.d/091-ui_shader
-UI_SHADER="slangp"
+UI_SHADER="glslp"
 EOF


### PR DESCRIPTION
Setting default shaders in ES was not working and I noticed Vulkan was not being used anymore in multiple emulators (in May 17 release, using RG351P)