### PR TITLE
dtb_overlay script bugfixes

### DIFF
--- a/packages/kernel/device-tree-overlays/sources/dtb_overlay
+++ b/packages/kernel/device-tree-overlays/sources/dtb_overlay
@@ -82,13 +82,15 @@ write_dtb() {
             dtbs+="${PRE}${dtb} "
         fi
     done
+    mount -o remount,rw /flash
     if [ $dtbs ];then
-        mount -o remount,rw /flash
         if grep --quiet FDTOVERLAYS /flash/extlinux/extlinux.conf; then
             sed -i "/FDTOVERLAYS/c \ \ FDTOVERLAYS ${dtbs}" /flash/extlinux/extlinux.conf
         else
-            sed -i "/FDTDIR \//a \ \ FDTOVERLAYS ${dtbs}" /flash/extlinux/extlinux.conf
+            sed -i "/FDT/a \ \ FDTOVERLAYS ${dtbs}" /flash/extlinux/extlinux.conf
         fi
+    else
+        sed -i "/FDTOVERLAYS/d" /flash/extlinux/extlinux.conf
     fi
     mount -o remount,ro /flash
 }


### PR DESCRIPTION
1. Overlays not being applied on rgb30v2 and rgb20sx. Due to not having FDTDIR entry in extlinux. Fixed.
2. Not removing overlays in extlinux when None is picked. Fixed.