### PR TITLE
rockchip: install new dtbs also on update

### DIFF
--- a/projects/Rockchip/bootloader/update.sh
+++ b/projects/Rockchip/bootloader/update.sh
@@ -19,11 +19,14 @@ fi
 # mount $BOOT_ROOT rw
 mount -o remount,rw $BOOT_ROOT
 
-for all_dtb in $BOOT_ROOT/*.dtb; do
-  dtb=$(basename $all_dtb)
-  if [ -f $SYSTEM_ROOT/usr/share/bootloader/$dtb ]; then
-    echo "Updating $dtb..."
-    cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT
+for dtb in $SYSTEM_ROOT/usr/share/bootloader/*.dtb; do
+  dtb_base=$(basename $dtb)
+  if [ -f $BOOT_ROOT/$dtb_base ]; then
+    echo "Updating $dtb_base..."
+    cp -p $dtb $BOOT_ROOT
+  else
+    echo "Installing $dtb_base..."
+    cp -p $dtb $BOOT_ROOT
   fi
 done
 


### PR DESCRIPTION
Install also new DTBs on an update.

Powkiddy shipped a version with rgb20sx where it identifies as an rgb30. Updating (which they should have disabled) breaks the device. This fixes that by, also installing new DTBs which includes the 20sx dtb that is required to boot on current ROCKNIX.