### PR TITLE
Remove battery calibration logic rk817 and power saving in suspend RK3566

### DIFF
--- a/packages/kernel/linux/patches/mainline/0006-rk817-remove-capacity-calibration.patch
+++ b/packages/kernel/linux/patches/mainline/0006-rk817-remove-capacity-calibration.patch
@@ -1,0 +1,38 @@
+diff --git a/drivers/power/supply/rk817_charger.c b/drivers/power/supply/rk817_charger.c
+index 658683d625db..c5eeb0beb9ef 100644
+--- a/drivers/power/supply/rk817_charger.c
++++ b/drivers/power/supply/rk817_charger.c
+@@ -324,33 +324,6 @@ static int rk817_bat_calib_cap(struct rk817_charger *charger)
+ 		}
+ 	}
+ 
+-	/*
+-	 * Calibrate the fully charged capacity when we previously had a full
+-	 * battery (soc_cal = 1) and are now empty (at or below minimum design
+-	 * voltage). If our columb counter is still positive, subtract that
+-	 * from our fcc value to get a calibrated fcc, and if our columb
+-	 * counter is negative add that to our fcc (but not to exceed our
+-	 * design capacity).
+-	 */
+-	if (charger->volt_avg_uv <= charger->bat_voltage_min_design_uv &&
+-	    charger->soc_cal) {
+-		regmap_bulk_read(rk808->regmap, RK817_GAS_GAUGE_Q_PRES_H3,
+-				 bulk_reg, 4);
+-		charge_now_adc = get_unaligned_be32(bulk_reg);
+-		charge_now = ADC_TO_CHARGE_UAH(charge_now_adc,
+-					       charger->res_div);
+-		/*
+-		 * Note, if charge_now is negative this will add it (what we
+-		 * want) and if it's positive this will subtract (also what
+-		 * we want).
+-		 */
+-		charger->fcc_mah = charger->fcc_mah - (charge_now / 1000);
+-
+-		dev_dbg(charger->dev,
+-			"Recalibrating full charge capacity to %d uah\n",
+-			charger->fcc_mah * 1000);
+-	}
+-
+ 	/*
+ 	 * Set the SOC to 0 if we are below the minimum system voltage.
+ 	 */

--- a/projects/Rockchip/patches/linux/RK3566/038-device-tree-power-savings.patch
+++ b/projects/Rockchip/patches/linux/RK3566/038-device-tree-power-savings.patch
@@ -1,0 +1,78 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
+index 18b8c2e7befa..f24a4fa44b46 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
+@@ -322,8 +322,7 @@ vcc_3v3: DCDC_REG4 {
+ 				regulator-initial-mode = <0x2>;
+ 				regulator-name = "vcc_3v3";
+ 				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
++					regulator-off-in-suspend;
+ 				};
+ 			};
+ 
+@@ -392,7 +391,7 @@ vcc3v3_pmu: LDO_REG6 {
+ 				regulator-name = "vcc3v3_pmu";
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
++					regulator-suspend-microvolt = <3000000>;
+ 				};
+ 			};
+ 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
+index 3ab751a01cb2..dc811b1eb3ca 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
+@@ -481,8 +481,7 @@ vcc_3v3: DCDC_REG4 {
+ 				regulator-initial-mode = <0x2>;
+ 				regulator-name = "vcc_3v3";
+ 				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
++					regulator-off-in-suspend;
+ 				};
+ 			};
+ 
+@@ -551,7 +550,7 @@ vcc3v3_pmu: LDO_REG6 {
+ 				regulator-name = "vcc3v3_pmu";
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
++					regulator-suspend-microvolt = <3000000>;
+ 				};
+ 			};
+ 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-x55.dts b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-x55.dts
+index 4786b19fd017..6940c2bc3b19 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-x55.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-x55.dts
+@@ -516,8 +516,7 @@ vcc_3v3: DCDC_REG4 {
+ 				regulator-initial-mode = <0x2>;
+ 				regulator-name = "vcc_3v3";
+ 				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
++					regulator-off-in-suspend;
+ 				};
+ 			};
+ 
+@@ -586,7 +585,7 @@ vcc3v3_pmu: LDO_REG6 {
+ 				regulator-name = "vcc3v3_pmu";
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
++					regulator-suspend-microvolt = <3000000>;
+ 				};
+ 			};
+ 
+@@ -608,7 +607,7 @@ vcc1v8_dvp: LDO_REG8 {
+ 				regulator-max-microvolt = <1800000>;
+ 				regulator-name = "vcc1v8_dvp";
+ 				regulator-state-mem {
+-					regulator-on-in-suspend;
++					regulator-off-in-suspend;
+ 				};
+ 			};
+ 


### PR DESCRIPTION
@macromorgan suspect the battery reporting error may come from the calibration logic in rk817.  Since testing it I haven't seen any reporting issues, I will let this PR rest a bit until I have more data. But so that more can test if they want it's available here.

Additionally some power savings that could be done in suspend on rk3566, verified to work on RG-ARC and RGB10Max3 but not x55.