### PR TITLE
Refactor of cloud backup function

### DIFF
--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.34"
+PKG_VERSION="1.35"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://salsa.debian.org/clint/fakeroot"
 PKG_URL="http://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_${PKG_VERSION}.orig.tar.gz"

--- a/packages/misc/modules/sources/gamelist.xml
+++ b/packages/misc/modules/sources/gamelist.xml
@@ -39,11 +39,11 @@
     <game>
         <path>./cloud_backup.sh</path>
         <name>RCLONE Backup</name>
-        <desc>Backup your saves to a cloud drive using RCLONE. Please make sure you have followed the steps at jelos.org to set up RCLONE first.</desc>
+        <desc>Backup your saves to a cloud drive using RCLONE. Please make sure you have followed the steps at rocknix.org to set up RCLONE first.</desc>
         <developer>ROCKNIX</developer>
         <publisher>ROCKNIX</publisher>
         <rating>5.0</rating>
-        <releasedate>2022</releasedate>
+        <releasedate>2024</releasedate>
         <genre>Script</genre>
         <players>1</players>
         <image>./images/rclone-backup.svg</image>
@@ -51,11 +51,11 @@
     <game>
         <path>./cloud_restore.sh</path>
         <name>RCLONE Restore</name>
-        <desc>Restores your saves from a cloud drive using RCLONE. Please make sure you have followed the steps at jelos.org to set up RCLONE first.</desc>
+        <desc>Restores your saves from a cloud drive using RCLONE. Please make sure you have followed the steps at rocknix.org to set up RCLONE first.</desc>
         <developer>ROCKNIX</developer>
         <publisher>ROCKNIX</publisher>
         <rating>5.0</rating>
-        <releasedate>2022</releasedate>
+        <releasedate>2024</releasedate>
         <genre>Script</genre>
         <players>1</players>
         <image>./images/rclone-restore.svg</image>

--- a/packages/network/rclone/package.mk
+++ b/packages/network/rclone/package.mk
@@ -37,6 +37,7 @@ makeinstall_target() {
   chmod 0755 ${INSTALL}/usr/bin/*
   cp rsync-rules.conf ${INSTALL}/usr/config/
   cp rsync.conf ${INSTALL}/usr/config/
+  cp rclone-rules.txt ${INSTALL}/usr/config/  
   chmod 755 ${INSTALL}/usr/bin/rclone
   mkdir -p ${INSTALL}/usr/config/modules
   ln -sf /usr/bin/cloud_backup ${INSTALL}/usr/config/modules/cloud_backup.sh

--- a/packages/network/rclone/package.mk
+++ b/packages/network/rclone/package.mk
@@ -37,7 +37,7 @@ makeinstall_target() {
   chmod 0755 ${INSTALL}/usr/bin/*
   cp rsync-rules.conf ${INSTALL}/usr/config/
   cp rsync.conf ${INSTALL}/usr/config/
-  cp rclone-rules.txt ${INSTALL}/usr/config/  
+  cp cloud_backup-rules.txt ${INSTALL}/usr/config/  
   chmod 755 ${INSTALL}/usr/bin/rclone
   mkdir -p ${INSTALL}/usr/config/modules
   ln -sf /usr/bin/cloud_backup ${INSTALL}/usr/config/modules/cloud_backup.sh

--- a/packages/network/rclone/package.mk
+++ b/packages/network/rclone/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="rclone"
-PKG_VERSION="1.65.0"
+PKG_VERSION="1.67.0"
 PKG_DEPENDS_TARGET="toolchain fuse rsync"
 PKG_LONGDESC="rsync for cloud storage"
 PKG_TOOLCHAIN="manual"

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -25,5 +25,5 @@ rsync ${RSYNCOPTSBACKUP} --include-from="${CONFIGPATH}/rsync-rules.conf" ${BACKU
 
 echo "Unmounting ${MOUNTPATH}" 2>&1
 rclonectl unmount ${MOUNTPATH} 2>&1
-sleep 3
+sleep 1
 clear

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -19,7 +19,7 @@ then
   echo "Backing up data from ${BACKUPPATH} to ${REMOTENAME}:${SYNCPATH}" 2>&1
   rclone sync \
     --progress \
-    --log-file /var/log/rclone.log \
+    --log-file /var/log/cloud_backup.log \
     --filter-from /storage/.config/cloud_backup-rules.txt \
     --verbose \
     ${BACKUPPATH}/ ${REMOTENAME}:${SYNCPATH}/

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -1,29 +1,30 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2024 JELOS (https://github.com/ROCKNIX)
+# Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-CONFIGPATH="/storage/.config"
-
-if [ -e "${CONFIGPATH}/rsync.conf" ]
+if [ ! -e "/storage/.config/rclone/rclone.conf" ]
 then
-  source ${CONFIGPATH}/rsync.conf
+  echo "You must configure rclone before using this tool.  Run \`rclone config\` to get started."
+  exit 1
 fi
 
-# If rsync.conf is missing variables set defaults
-MOUNTPATH="${MOUNTPATH:=/storage/cloud}"
-SYNCPATH="${SYNCPATH:=GAMES}"
-BACKUPPATH="${BACKUPPATH:=/storage/roms}"
-RSYNCOPTSBACKUP="${RSYNCOPTSBACKUP:=-raiv --prune-empty-dirs}"
+if [ -e "/storage/.config/rclone/rclone.conf" ]
+then
+  # define locations for source and remote
+  REMOTENAME="dropbox"
+  SYNCPATH="${SYNCPATH:=GAMES}"
+  BACKUPPATH="${BACKUPPATH:=/storage/roms}"
 
-echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
+  echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
+  echo "Backing up data from ${BACKUPPATH} to ${REMOTENAME}:${SYNCPATH}" 2>&1
+  rclone sync \
+    --progress \
+    --log-file /var/log/rclone.log \
+    --filter-from /storage/.config/cloud_backup-rules.txt \
+    --verbose \
+    ${BACKUPPATH}/ ${REMOTENAME}:${SYNCPATH}/
+fi
 
-echo "Mounting ${MOUNTPATH}" 2>&1
-rclonectl mount ${MOUNTPATH} 2>&1
-
-echo "Backing up data from ${BACKUPPATH} to ${MOUNTPATH}/${SYNCPATH}" 2>&1
-rsync ${RSYNCOPTSBACKUP} --include-from="${CONFIGPATH}/rsync-rules.conf" ${BACKUPPATH}/ ${MOUNTPATH}/${SYNCPATH}/ 2>&1
-
-echo "Unmounting ${MOUNTPATH}" 2>&1
-rclonectl unmount ${MOUNTPATH} 2>&1
+echo "Backup complete!"
 sleep 1
 clear

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -5,6 +5,7 @@
 if [ ! -e "/storage/.config/rclone/rclone.conf" ]
 then
   echo "You must configure rclone before using this tool.  Run \`rclone config\` to get started."
+  sleep 2
   exit 1
 fi
 
@@ -16,15 +17,14 @@ then
   BACKUPPATH="${BACKUPPATH:=/storage/roms}"
 
   echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
-  echo "Backing up data from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}" 2>&1
   rclone sync \
     --progress \
     --log-file /var/log/cloud_backup.log \
     --filter-from /storage/.config/cloud_backup-rules.txt \
     --verbose \
-    ${BACKUPPATH}/ ${REMOTENAME}:${SYNCPATH}
+    ${BACKUPPATH}/ ${REMOTENAME}${SYNCPATH}/
 fi
 
 echo "Backup complete!"
-sleep 1
+sleep 2
 clear

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -11,7 +11,7 @@ fi
 if [ -e "/storage/.config/rclone/rclone.conf" ]
 then
   # define locations for source and remote
-  REMOTENAME="dropbox"
+  REMOTENAME="firstLine=`echo "${multiLineVariable}" | head -1`"
   SYNCPATH="${SYNCPATH:=GAMES}"
   BACKUPPATH="${BACKUPPATH:=/storage/roms}"
 

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -17,6 +17,7 @@ then
   BACKUPPATH="${BACKUPPATH:=/storage/roms}"
 
   echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
+  echo "Backing up data from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}" 2>&1  
   rclone sync \
     --progress \
     --log-file /var/log/cloud_backup.log \

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -22,7 +22,7 @@ then
     --log-file /var/log/cloud_backup.log \
     --filter-from /storage/.config/cloud_backup-rules.txt \
     --verbose \
-    ${BACKUPPATH}/ ${REMOTENAME}:${SYNCPATH}/
+    ${BACKUPPATH}/ ${REMOTENAME}:${SYNCPATH}
 fi
 
 echo "Backup complete!"

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2024 JELOS (https://github.com/ROCKNIX)
 
 CONFIGPATH="/storage/.config"
 

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -11,12 +11,12 @@ fi
 if [ -e "/storage/.config/rclone/rclone.conf" ]
 then
   # define locations for source and remote
-  REMOTENAME="firstLine=`echo "${multiLineVariable}" | head -1`"
+  REMOTENAME=`rclone listremotes | head -1`
   SYNCPATH="${SYNCPATH:=GAMES}"
   BACKUPPATH="${BACKUPPATH:=/storage/roms}"
 
   echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
-  echo "Backing up data from ${BACKUPPATH} to ${REMOTENAME}:${SYNCPATH}" 2>&1
+  echo "Backing up data from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}" 2>&1
   rclone sync \
     --progress \
     --log-file /var/log/cloud_backup.log \

--- a/packages/network/rclone/sources/cloud_backup-rules.txt
+++ b/packages/network/rclone/sources/cloud_backup-rules.txt
@@ -1,0 +1,15 @@
+# This is a required rule for subdirectory matching.
++ */
+
+### Do not include BIOS.
+- bios/**
+
+### Retroarch saves
++ *.sav
++ *.srm
++ *.auto
++ *.state*
++ *.dsv*
+
+### This is a required rule to exclude all other file types.
+- *

--- a/packages/network/rclone/sources/rclonectl
+++ b/packages/network/rclone/sources/rclonectl
@@ -40,7 +40,7 @@ function checkconfig() {
 function mount() {
   TARGET=$(rclone listremotes | awk '{printf $1; exit}')
   rclone mount ${TARGET} ${1} \
-    --vfs-cache-mode off \
+    --vfs-cache-mode writes \
     --vfs-cache-max-size 100M \
     --vfs-read-chunk-size-limit 128M \
     --vfs-read-chunk-size-limit off \

--- a/packages/network/rclone/sources/rsync.conf
+++ b/packages/network/rclone/sources/rsync.conf
@@ -4,7 +4,7 @@ MOUNTPATH="/storage/cloud"
 ### This is the path to your game folder on your cloud drive.
 SYNCPATH="GAMES"
 
-### This is the path we are backup up from.
+### This is the path we are backing up from.
 BACKUPPATH="/storage/roms"
 
 ### This allows changes to the rsync options for cloud_backup

--- a/packages/network/rsync/package.mk
+++ b/packages/network/rsync/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsync"
-PKG_VERSION="3.2.7"
+PKG_VERSION="3.3.0"
 PKG_SHA256="4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://rsync.samba.org"

--- a/packages/network/rsync/package.mk
+++ b/packages/network/rsync/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rsync"
 PKG_VERSION="3.3.0"
-PKG_SHA256="4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb"
+PKG_SHA256="7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://rsync.samba.org"
 PKG_URL="https://download.samba.org/pub/rsync/src/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/textproc/bdf2psf/package.mk
+++ b/packages/textproc/bdf2psf/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="bdf2psf"
-PKG_VERSION="1.226"
+PKG_VERSION="1.228"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://packages.debian.org/unstable/${PKG_NAME}"
 PKG_URL="https://deb.debian.org/debian/pool/main/c/console-setup/${PKG_NAME}_${PKG_VERSION}_all.deb"


### PR DESCRIPTION
# Background
The existing cloud backup function layered rsync on top of rclone. The issue with this approach is that it:
1. Required the use of a fusermount via rclone and then synchronization was handled by rsync. rclone has built-in sync functionality for remote destinations, so the use of rsync on top of it introduced unnecessary complexity.
2. The existing method of using rclone to temporarily mount a remote to `/storage/cloud` relied on caching for the virtual file system. This led to errors because the script would copy the files and rsync would begin synchronizing them, but the files hadn't always finished transferring from the temporary cache to the cloud mount. Additionally, the use of caching could eventually lead to the accumulation of stale data in the cache folder.

# Approach
One option would have been to simply disable caching for the VFS so files had to be written directly to `/storage/cloud` before rsync would begin. However, after testing, this proved to significantly slower sync times. So, I decided to create a new backup experience that didn't depend on rsync but still left everything related to `rclonectl` in place. This is because I wanted to ensure that the dev team felt good about this approach, and it means that changes can be rolled out incrementally. For example, I've changed how cloud backups work, but have not modified cloud restore or the ability to save to the cloud on exit.

# Results
I've gone through and tested this on my RG353M and everything is working well:
1. An error message is displayed if rclone hasn't been configured yet
2. The new script automatically will select the first entry in `rclone.conf` if multiple remotes have been set up
3. It is verified to work identically as before with the same file type inclusions and exclusions.
4. It is incredibly speedy, to the point where I added in time so users could read the success message before the script closes. This 2 second delay could be removed to make the process even faster.

I've only been able to test this on my RK3566 device, but I've updated the dependent packages and it should function the same on any aarch64-based build. However, additional testing would be great.