### PR TITLE
wlroots 0.17.4 with rockchip patches

### DIFF
--- a/packages/wayland/lib/wlroots/package.mk
+++ b/packages/wayland/lib/wlroots/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wlroots"
-PKG_VERSION="0.17.3-rk"
-PKG_SHA256="bda9d39c989f27994e6a412228ef6ac3c86d121b38fba04fe4a91eb3b1a7c118"
+PKG_VERSION="0.17.4-rk"
+PKG_SHA256="e9e1e14966c6272ca595307fa817fd0fefae96b13fe36c8084b3a7a55fed20d1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/wlroots/wlroots/"
 PKG_URL="https://github.com/stolen/rockchip-wlroots/archive/refs/tags/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
works on my rg503 with libmali and panfrost