### PR TITLE
update sway to 1.10 branch, wlroots to 0.18.0 also some deps

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.120"
+PKG_VERSION="2.4.122"
 PKG_LICENSE="GPL"
 PKG_SITE="http://dri.freedesktop.org"
 PKG_URL="http://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/compositor/sway/package.mk
+++ b/packages/wayland/compositor/sway/package.mk
@@ -2,11 +2,12 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sway"
-PKG_VERSION="1.9"
-PKG_SHA256="a63b2df8722ee595695a0ec6c84bf29a055a9767e63d8e4c07ff568cb6ee0b51"
+PKG_VERSION="1.10"
+PKG_SHA256="4d4a71209ea0dde3b52519d5e75e073e0269f5a3356cfa555402624e98fb530e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://swaywm.org/"
-PKG_URL="https://github.com/swaywm/sway/releases/download/${PKG_VERSION}/sway-${PKG_VERSION}.tar.gz"
+#PKG_URL="https://github.com/swaywm/sway/releases/download/${PKG_VERSION}/sway-${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/swaywm/sway/archive/1c992d847d66161a28f12bfc7028966433fb249c.zip" # temporary until 1.10 is released
 PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libinput cairo pango libjpeg-turbo dbus json-c wlroots gdk-pixbuf swaybg foot bemenu xcb-util-wm xwayland xkbcomp"
 PKG_LONGDESC="i3-compatible Wayland compositor"
 PKG_TOOLCHAIN="meson"
@@ -19,7 +20,6 @@ PKG_MESON_OPTS_TARGET="-Ddefault-wallpaper=false \
                        -Dfish-completions=false \
                        -Dswaybar=true \
                        -Dswaynag=true \
-                       -Dxwayland=enabled \
                        -Dtray=disabled \
                        -Dgdk-pixbuf=enabled \
                        -Dman-pages=disabled \

--- a/packages/wayland/compositor/sway/package.mk
+++ b/packages/wayland/compositor/sway/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sway"
-PKG_VERSION="1.10"
-PKG_SHA256="4d4a71209ea0dde3b52519d5e75e073e0269f5a3356cfa555402624e98fb530e"
+PKG_VERSION="1c992d847d66161a28f12bfc7028966433fb249c"
+PKG_SHA256="387d37ede5d56f8474ce5706f78b1ad3311f6e58dcdfa4c495396d2ff0f1544d"
 PKG_LICENSE="MIT"
 PKG_SITE="https://swaywm.org/"
 #PKG_URL="https://github.com/swaywm/sway/releases/download/${PKG_VERSION}/sway-${PKG_VERSION}.tar.gz"
-PKG_URL="https://github.com/swaywm/sway/archive/1c992d847d66161a28f12bfc7028966433fb249c.zip" # temporary until 1.10 is released
+PKG_URL="https://github.com/swaywm/sway/archive/${PKG_VERSION}.zip" # temporary until 1.10 is released
 PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libinput cairo pango libjpeg-turbo dbus json-c wlroots gdk-pixbuf swaybg foot bemenu xcb-util-wm xwayland xkbcomp"
 PKG_LONGDESC="i3-compatible Wayland compositor"
 PKG_TOOLCHAIN="meson"

--- a/packages/wayland/lib/wlroots/package.mk
+++ b/packages/wayland/lib/wlroots/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wlroots"
-PKG_VERSION="0.17.4-rk"
-PKG_SHA256="e9e1e14966c6272ca595307fa817fd0fefae96b13fe36c8084b3a7a55fed20d1"
+PKG_VERSION="0.18.0-rk"
+PKG_SHA256="15855f05acfe32d4c51a4ad4bed988258fbce5c8f140573229d6889ca8503ed1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/wlroots/wlroots/"
 PKG_URL="https://github.com/stolen/rockchip-wlroots/archive/refs/tags/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.25.0"
-PKG_SHA256="193bd592298bd9e369c0ef3e5d83a6a9d68ddc4cd3dfc84bbe77920a8d0d57df"
+PKG_VERSION="1.26.0"
+PKG_SHA256="8c582b86c6865aaee2516ee96b299cef60c98e113d1391bbd2683eac08221a07"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.34"
+PKG_VERSION="1.35"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/${PKG_NAME}/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Update wlroots, sway and their deps.  
Sway 1.10 is not yet tagged, so there is some mess in sway/package.mk.  

Seems working for me. Maybe we should wait for 1.10 release before updating.