### PR TITLE
S922X-PANFROST - use sway

### DIFF
--- a/distributions/ROCKNIX/options
+++ b/distributions/ROCKNIX/options
@@ -47,10 +47,11 @@
   CLEAN_EMU_32BIT="lib32 box86 pcsx_rearmed-lr arm"
   # Sway depends on it, weston will use it if it's built but we don't want that.
   CLEAN_WESTON="libdisplay-info sway"
-# Packages to clean for S922X platform - all vary based on VULKAN_SUPPORT
-  CLEAN_S922X="beetle-psx-lr dolphin-sa duckstation-sa fileman emulationstation flycast-lr flycast-sa"
-  CLEAN_S922X+=" gmu gzdoom-sa libplacebo lime3ds-sa linux mali-bifrost mesa moonlight parallel-n64-lr"
-  CLEAN_S922X+=" pipewire portmaster ppsspp-sa qt5 retroarch SDL2"
+# Packages to clean for S922X platform - all vary based on VULKAN_SUPPORT or USE_MALI
+  CLEAN_S922X="beetle-psx-lr dolphin-sa drastic-sa duckstation-sa fileman emulationstation"
+  CLEAN_S922X+=" flycast-lr flycast-sa gmu gzdoom-sa libplacebo lime3ds-sa linux mali-bifrost"
+  CLEAN_S922X+=" mesa moonlight parallel-n64-lr pipewire portmaster ppsspp-sa qt5 retroarch"
+  CLEAN_S922X+=" wayland SDL2"
 
 # build and install rocknix joypad driver (yes / no)
   ROCKNIX_JOYPAD="no"

--- a/packages/hardware/quirks/platforms/S922X/090-ui_service
+++ b/packages/hardware/quirks/platforms/S922X/090-ui_service
@@ -3,6 +3,12 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 ### Set the default device configuration
-cat <<EOF >/storage/.config/profile.d/090-ui_service
+if [ -f "/usr/lib/systemd/system/sway.service" ]; then
+    cat <<EOF >/storage/.config/profile.d/090-ui_service
+UI_SERVICE="sway.service essway.service"
+EOF
+else
+    cat <<EOF >/storage/.config/profile.d/090-ui_service
 UI_SERVICE="weston.service"
 EOF
+fi

--- a/packages/wayland/wayland/package.mk
+++ b/packages/wayland/wayland/package.mk
@@ -10,9 +10,14 @@ PKG_LONGDESC="a display server protocol"
 
 case ${DEVICE} in
   S922X)
-    PKG_VERSION="1.21.0"
-    PKG_SHA256="6dc64d7fc16837a693a51cfdb2e568db538bfdc9f457d4656285bb9594ef11ac"
-    PKG_PATCH_DIRS+=" legacy"
+    if [ "${DEVICE}" = "S922X" -a "${USE_MALI}" != "no" ]; then
+      PKG_VERSION="1.21.0"
+      PKG_SHA256="6dc64d7fc16837a693a51cfdb2e568db538bfdc9f457d4656285bb9594ef11ac"
+      PKG_PATCH_DIRS+=" legacy"
+    else
+      PKG_VERSION="1.23.0"
+      PKG_SHA256="05b3e1574d3e67626b5974f862f36b5b427c7ceeb965cb36a4e6c2d342e45ab2"
+    fi
   ;;
   RK3588)
     PKG_VERSION="1.22.0"

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -74,7 +74,11 @@
     DISPLAYSERVER="wl"
 
   # Windowmanager to use (weston / swaywm-env / no)
-    WINDOWMANAGER="weston11"
+    if [ "${USE_MALI}" != "no" ]; then
+      WINDOWMANAGER="weston11"
+    else
+      WINDOWMANAGER="swaywm-env"
+    fi
   
   # kernel serial console
     EXTRA_CMDLINE="rootwait quiet systemd.debug_shell=ttyAML0 console=ttyAML0,115200n8 console=tty0 no_console_suspend net.ifnames=0 consoleblank=0 video=HDMI-A-1:1920x1080@60"


### PR DESCRIPTION
Tested on my OGU. Had to put some logic when generating `090-ui_service` to cater for sway on Panfrost and weston on Mali blob.