### PR TITLE
util-linux - remove disable-all-programs flag

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -18,7 +18,6 @@ UTILLINUX_CONFIG_DEFAULT="--disable-gtk-doc \
                           --disable-nls \
                           --disable-rpath \
                           --enable-tls \
-                          --disable-all-programs \
                           --enable-chsh-only-listed \
                           --disable-bash-completion \
                           --disable-colors-default \


### PR DESCRIPTION
Particularly want `lsblk`. Inspecting build results shows:

```
$ ls -l build.ROCKNIX-S922X.aarch64/util-linux-2.39.2/.install_pkg/usr/bin/
cal           dmesg         hardlink      last          lsfd          mesg          renice        uname26       whereis
chmem         eject         hexdump       lastb         lsipc         mount         rev           unshare       
choom         fadvise       ionice        linux32       lsirq         mountpoint    scriptreplay  utmpdump      
chrt          fallocate     ipcmk         linux64       lslocks       namei         setarch       uuidgen       
col           fincore       ipcrm         logger        lslogins      nsenter       setsid        uuidparse     
colcrt        findmnt       ipcs          look          lsmem         pipesz        taskset       waitpid       
colrm         flock         isosize       lsblk         lsns          prlimit       uclampset     wall          
column        getopt        kill          lscpu         mcookie       rename        umount        wdctl
```

```
$ ls build.ROCKNIX-S922X.aarch64/util-linux-2.39.2/.install_pkg/usr/sbin/
addpart     blkzone     fdisk       fstrim    mkfs.bfs    pivot_root   sfdisk     switch_root
agetty      blockdev    findfs      hwclock   mkfs.minix  readprofile  sulogin    uuidd
blkdiscard  chcpu       fsck        ldattach  mkswap      resizepart   swaplabel  wipefs
blkid       ctrlaltdel  fsck.minix  losetup   nologin     rfkill       swapoff    zramctl
blkpr       delpart     fsfreeze    mkfs      partx       rtcwake      swapon
```