### PR TITLE
Remove BTRFS

### DIFF
--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -11,6 +11,9 @@ PKG_LONGDESC="QEMU is a generic and open source machine emulator and virtualizer
 PKG_TOOLCHAIN="configure"
 
 pre_configure_host() {
+
+  sed -i '/HAVE_BTRFS/d' ../meson.build
+
   HOST_CONFIGURE_OPTS="\
     --bindir=${TOOLCHAIN}/bin \
     --extra-cflags=-I${TOOLCHAIN}/include \


### PR DESCRIPTION
Fixes #403

This definitely fixed my issue by compiling qemu without btrfs support.  I highly doubt we're using btrfs support in qemu, but I also doubt this is how this problem should be fixed.  I don't really know much about meson so please let me know if there's a better way.