### PR TITLE
Changes default sh prompt to use normal terminal FG color

### DIFF
--- a/packages/sysutils/busybox/profile.d/098-busybox
+++ b/packages/sysutils/busybox/profile.d/098-busybox
@@ -7,7 +7,7 @@
 export HOME="/storage"
 export PATH="/usr/bin:/usr/sbin"
 export HOSTNAME=`cat /etc/hostname`
-export PS1='\[\e[1;30m\]\h:\[\e[1;30m\]\w \[\e[0m\]\$\[\e[0m\] '
+export PS1='\[\e[1m\]\h:\[\e[1m\]\w \[\e[0m\]\$\[\e[0m\] '
 
 # Redirect requests for sudo to nowhere.
 alias sudo=''


### PR DESCRIPTION
When I first sshed into my X55, I was confused by the prompt. For me it looked like this:

![image](https://github.com/user-attachments/assets/2285b39d-03de-4707-90ba-a269d7881ee7)

I dug in a little and found that the prompt has been hard-coded to use black as the FG color. I changed this by overwriting `PS1` in `~/.config/profile.d/900-prompt`, but I thought this could be nice to have in upstream.

This just removes the `;30` from the escape code that set the FG color to black. Now it will use the default FG color (white in my setup, but maybe black on others). I left the `1` part of the escape code that makes parts of the prompt bold.

Cheers, and thanks for this great OS! :beers: