### PR TITLE
Enable scummvmsa on S922X

### DIFF
--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -53,7 +53,7 @@ case "${DEVICE}" in
   ;;
   S922X)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 pcsx_rearmed-lr wine"
-    PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa portmaster yabasanshiro-sa"
+    PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa portmaster scummvmsa yabasanshiro-sa"
     LIBRETRO_CORES+=" beetle-psx-lr bsnes-lr bsnes-hd-lr dolphin-lr geolith-lr flycast-lr uae4arm"
     [ "${USE_MALI}" != "no" ] && PKG_EMUS+=" lime3ds-sa"
     PKG_RETROARCH+=" retropie-shaders"
@@ -894,15 +894,8 @@ makeinstall_target() {
   add_es_system pokemini
 
   ### ScummVM
-  case ${DEVICE} in
-    S922X)
-      add_emu_core scummvm retroarch scummvm true
-    ;;
-    *)
-      add_emu_core scummvm scummvmsa scummvm true
-      add_emu_core scummvm retroarch scummvm false
-    ;;
-  esac
+  add_emu_core scummvm scummvmsa scummvm true
+  add_emu_core scummvm retroarch scummvm false
   add_es_system scummvm
   install_script "Start ScummVM.sh"
 


### PR DESCRIPTION
scummvmsa has been disabled on S922X a long time ago (it was already in jelos). It was compilable but did not start. The bad thing is that retroarch scummvm uses a script that is part of scummvmsa. So in the end scummvm is completely unusable on the S922X.
I don't know what the problem was but it doesn't exist any more. scummvmsa is compilable and working for S922X and S922X-PANFROST.