### PR TITLE
portmaster - sway fullscreen

### DIFF
--- a/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Will be called by PortMaster mod_ROCKNIX.txt
+
+# Call the function to fullscreen the window for app_id asynchronously
+. /etc/profile.d/001-functions
+sway_fullscreen "${1}" &

--- a/packages/rocknix/profile.d/001-functions
+++ b/packages/rocknix/profile.d/001-functions
@@ -204,3 +204,32 @@ function get_aspect_ratio() {
   esac
   echo ${ASPECT}
 }
+
+# Utility function to enable fullscreen on a window for an input app_id
+function sway_fullscreen {
+  local APPID="${1}"
+  local QUERY_LIMIT=5
+  local QUERY_COUNT=0
+
+  if [ -n "$(pgrep sway)" ]; then
+    while [ $QUERY_COUNT -lt $QUERY_LIMIT ]
+    do
+      # loop, attempting to fullscreen window for app_id
+      ((QUERY_COUNT++))
+
+      echo "Attempting to fullscreen app_id=${APPID}"
+      swaymsg '[app_id='"${APPID}"'] fullscreen enable'
+      local RESULT=$?
+
+      if [ $RESULT -eq 0 ]; then
+        echo "Successful, exiting"
+        break
+      else
+        echo "Failed, waiting to try again"
+        sleep 1
+      fi
+    done
+  else
+    echo "sway is not running, exiting"
+  fi
+}


### PR DESCRIPTION
Adds `sway_fullscreen` function with `app_id` parameter, useful for ports that don't render fullscreen correctly