### PR TITLE
RK2023.dtsi: remove always-on from regulators

### DIFF
--- a/projects/Rockchip/patches/linux/RK3566/041-remove-always-on-pk-regulators.patch
+++ b/projects/Rockchip/patches/linux/RK3566/041-remove-always-on-pk-regulators.patch
@@ -1,0 +1,36 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
+index beb4f4376413..d5e2a9a4974b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
+@@ -307,7 +307,6 @@ regulator-state-mem {
+ 
+ 	vcc_sys: regulator-vcc-sys {
+ 		compatible = "regulator-fixed";
+-		regulator-always-on;
+ 		regulator-boot-on;
+ 		regulator-min-microvolt = <3800000>;
+ 		regulator-max-microvolt = <3800000>;
+@@ -447,7 +446,6 @@ regulator-state-mem {
+ 			};
+ 
+ 			vdd_gpu: DCDC_REG2 {
+-				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <500000>;
+ 				regulator-max-microvolt = <1350000>;
+@@ -574,7 +572,6 @@ regulator-state-mem {
+ 			};
+ 
+ 			vcc2v8_dvp: LDO_REG9 {
+-				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <2800000>;
+ 				regulator-max-microvolt = <2800000>;
+@@ -585,7 +582,6 @@ regulator-state-mem {
+ 			};
+ 
+ 			dcdc_boost: BOOST {
+-				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <4700000>;
+ 				regulator-max-microvolt = <5400000>;


### PR DESCRIPTION
This kernel patch remove always-on on as many reguators as possible, without noticeble detrimental effects.
Tested on all affected devices: rk2023. rgb30v1/v2, rgb10max3, rgb20sx