### PR TITLE
Bump and fix gzdoom

### DIFF
--- a/packages/emulators/standalone/gzdoom-sa/package.mk
+++ b/packages/emulators/standalone/gzdoom-sa/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="gzdoom-sa"
-PKG_VERSION="6ce809e"
+PKG_VERSION="71c4043"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ZDoom/gzdoom"
 PKG_URL="${PKG_SITE}.git"
-PKG_GIT_CLONE_BRANCH="4.11"
+PKG_GIT_CLONE_BRANCH="g4.12"
 PKG_DEPENDS_HOST="toolchain SDL2:host zmusic:host libvpx:host libwebp:host"
 PKG_DEPENDS_TARGET="toolchain SDL2 gzdoom-sa:host zmusic libvpx libwebp"
 PKG_LONGDESC="GZDoom is a modder-friendly OpenGL and Vulkan source port based on the DOOM engine"

--- a/packages/emulators/standalone/gzdoom-sa/patches/000-fix-build.patch
+++ b/packages/emulators/standalone/gzdoom-sa/patches/000-fix-build.patch
@@ -126,24 +126,3 @@ index da8ddfb4a..a0e3cc60d 100644
  // Placeholder definitions for strings that are in the game content table where the labels are needed even when that file is not loaded.
  
  // Level names
-diff --git a/wadsrc/static/menudef.txt b/wadsrc/static/menudef.txt
-index 0f384a427..b95961679 100644
---- a/wadsrc/static/menudef.txt
-+++ b/wadsrc/static/menudef.txt
-@@ -667,6 +667,7 @@ OptionMenu "OtherControlsMenu" protected
- 	Control    "$CNTRLMNU_ADJUST_GAMMA"    , "bumpgamma"
- 
- 	StaticText ""
-+	Control    "$CNTRLMNU_OPEN_MAIN"       , "menu_main"
- 	Control    "$CNTRLMNU_OPEN_HELP"       , "menu_help"
- 	Control    "$CNTRLMNU_OPEN_SAVE"       , "menu_save"
- 	Control    "$CNTRLMNU_OPEN_LOAD"       , "menu_load"
-@@ -1778,7 +1779,7 @@ OptionMenu "CompatMapMenu" protected
- 	Option "$CMPTMNU_PUSHWINDOW",					"compat_pushwindow", "YesNo"
- 	Option "$CMPTMNU_CHECKSWITCHRANGE",				"compat_checkswitchrange", "YesNo"
- 	Option "$CMPTMNU_RAILINGHACK",					"compat_railing", "YesNo"
--	Option "$CMPTMNU_NOMBF21",						"compat_nombf21", "YesNo"
-+	Option "$CMPTMNU_NOMBF21",						"compat_nombf21", "YeaNo"
- 	Class "CompatibilityMenu"
- }
- 

--- a/packages/emulators/standalone/gzdoom-sa/scripts/start_gzdoom.sh
+++ b/packages/emulators/standalone/gzdoom-sa/scripts/start_gzdoom.sh
@@ -18,6 +18,10 @@ if [ ! -f "/storage/.config/gzdoom/gzdoom.ini" ]; then
   cp -rf /usr/config/gzdoom/gzdoom.ini /storage/.config/gzdoom/
 fi
 
+if [ /usr/config/gzdoom/gzdoom.pk3 -nt /storage/.config/gzdoom/gzdoom.pk3 ]; then
+  cp /usr/config/gzdoom/*.pk3 /storage/.config/gzdoom/
+fi
+
 # set resolution
 sed -i '/vid_defheight=/c\vid_defheight='$(fbheight) /storage/.config/gzdoom/gzdoom.ini
 sed -i '/vid_defwidth=/c\vid_defwidth='$(fbwidth) /storage/.config/gzdoom/gzdoom.ini


### PR DESCRIPTION
Bump gzdoom to v4.12.2
Fix patch for the new version
Copy pk3 files from gzdoom if they are newer than those in .config.