### PR TITLE
modfied post-update to force overwrite of newer `cloud_sync.conf` file when needed

### DIFF
--- a/packages/rocknix/sources/post-update
+++ b/packages/rocknix/sources/post-update
@@ -62,8 +62,8 @@ rsync --ignore-existing /usr/config/rsync.conf /storage/.config/
 
 ### Add cloud sync-related files if missing
 echo "Update cloud sync filter rules..." >>${LOG}
-rsync --ignore-existing /usr/config/cloud_sync-rules.txt /storage/.config/
-rsync --ignore-existing /usr/config/cloud_sync.conf /storage/.config/
+rsync --times --update /usr/config/cloud_sync-rules.txt /storage/.config/
+rsync --times --update /usr/config/cloud_sync.conf /storage/.config/
 
 ### Sync locale data
 tocon "Re-sync locale data..."


### PR DESCRIPTION
For users who upgraded to [20240702](https://github.com/ROCKNIX/distribution/releases/tag/20240702) and then upgraded to a subsequent version, the post-update rsync options held back the improved `.conf` file. The new flags will now overwrite the `.conf` file if the OS has a newer version of that file.

There is a risk that a user may not realize that a new `.conf` file exists if they don't read the release notes, but I think it is worth it to ensure the backup and restore tools function as expected. At some point, I may write a script to preserve existing customizations when a user performs an OS upgrade and the `cloud_sync.conf` file needs to be overwritten. I'll try to do this next time I change the `cloud_sync.conf` file where it would force an upgrade with an OS update. I don't foresee needing to do that for a while, though.

I'm checking for any issues around cloud backup/restore in Discord and haven't seen any complaints...