### PR TITLE
Added definiton for NFS_SUPPORT to virutal image package 

### DIFF
--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -75,6 +75,9 @@ fi
 # EXFAT support
 [ "${EXFAT}" = "yes" ] && PKG_DEPENDS_TARGET+=" exfat exfatprogs"
 
+# NFS support
+[ "${NFS_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" nfs-utils"
+
 # NTFS 3G support
 [ "${NTFS3G}" = "yes" ] && PKG_DEPENDS_TARGET+=" ntfs-3g_ntfsprogs"
 


### PR DESCRIPTION
Looks like at some point the NFS_SUPPORT define to pull in nfs-utils dependency was removed from the base virtual package. This re-adds it.