### PR TITLE
Cloud sync upgrade improvements

### DIFF
--- a/packages/network/rclone/package.mk
+++ b/packages/network/rclone/package.mk
@@ -39,6 +39,7 @@ makeinstall_target() {
   cp rsync.conf ${INSTALL}/usr/config/
   cp cloud_sync-rules.txt ${INSTALL}/usr/config/
   cp cloud_sync.conf ${INSTALL}/usr/config/
+  cp cloud_sync.conf.defaults ${INSTALL}/usr/config/
   chmod 755 ${INSTALL}/usr/bin/rclone
   mkdir -p ${INSTALL}/usr/config/modules
   ln -sf /usr/bin/cloud_backup ${INSTALL}/usr/config/modules/cloud_backup.sh

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -13,7 +13,7 @@ fi
 # check that the internet is reachable
 ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
 if [ "${ONLINESTATUS}" == "offline" ]
-  then
+then
   echo -e "You're not currently connected to the internet.\nPlease verify your settings and then try again."
   sleep 3
   exit
@@ -21,6 +21,47 @@ fi
 
 # Loads cloud sync config variables from cloud_sync.conf
 source /storage/.config/cloud_sync.conf
+
+# Check if needed default variables from the conf file are present, and add if nececssary
+if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]
+then
+  source /storage/.config/cloud_sync.conf.defaults
+  if [ "${BACKUPPATH}" == "" ]
+  then
+    sed -i -e '$a\\nBACKUPPATH="'"${DEFAULT_BACKUPPATH}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RESTOREPATH}" == "" ]
+  then
+    sed -i -e '$a\\nRESTOREPATH="'"${DEFAULT_RESTOREPATH}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${SYNCPATH}" == "" ]
+  then
+    sed -i -e '$a\\nSYNCPATH="'"${DEFAULT_SYNCPATH}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RCLONEOPTS}" == "" ]
+  then
+    sed -i -e '$a\\nRCLONEOPTS="'"${DEFAULT_RCLONEOPTS}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${BACKUPMETHOD}" == "" ]
+  then
+    sed -i -e '$a\\nBACKUPMETHOD="'"${DEFAULT_BACKUPMETHOD}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RESTOREMETHOD}" == "" ]
+  then
+    sed -i -e '$a\\nRESTOREMETHOD="'"${DEFAULT_RESTOREMETHOD}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RSYNCRMDIR}" == "" ]
+  then
+    sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
+  fi
+  source /storage/.config/cloud_sync.conf
+fi
 
 # backup to rclone remote
 if [ -e "/storage/.config/rclone/rclone.conf" ]

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -22,6 +22,47 @@ fi
 # Loads cloud sync config variables from cloud_sync.conf
 source /storage/.config/cloud_sync.conf
 
+# Check if needed default variables from the conf file are present, and add if nececssary
+if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]
+then
+  source /storage/.config/cloud_sync.conf.defaults
+  if [ "${BACKUPPATH}" == "" ]
+  then
+    sed -i -e '$a\\nBACKUPPATH="'"${DEFAULT_BACKUPPATH}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RESTOREPATH}" == "" ]
+  then
+    sed -i -e '$a\\nRESTOREPATH="'"${DEFAULT_RESTOREPATH}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${SYNCPATH}" == "" ]
+  then
+    sed -i -e '$a\\nSYNCPATH="'"${DEFAULT_SYNCPATH}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RCLONEOPTS}" == "" ]
+  then
+    sed -i -e '$a\\nRCLONEOPTS="'"${DEFAULT_RCLONEOPTS}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${BACKUPMETHOD}" == "" ]
+  then
+    sed -i -e '$a\\nBACKUPMETHOD="'"${DEFAULT_BACKUPMETHOD}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RESTOREMETHOD}" == "" ]
+  then
+    sed -i -e '$a\\nRESTOREMETHOD="'"${DEFAULT_RESTOREMETHOD}"'"' /storage/.config/cloud_sync.conf
+  fi
+ 
+  if [ "${RSYNCRMDIR}" == "" ]
+  then
+    sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
+  fi
+  source /storage/.config/cloud_sync.conf
+fi
+
 # restore from rclone remote
 if [ -e "/storage/.config/rclone/rclone.conf" ]
 then

--- a/packages/network/rclone/sources/cloud_sync.conf
+++ b/packages/network/rclone/sources/cloud_sync.conf
@@ -1,4 +1,4 @@
-### Directory where Retroarch saves, savestates, and screenshots are located
+# Directory where Retroarch saves, savestates, and screenshots are located
 BACKUPPATH="/storage/roms"
 
 # Changing the below to be different from BACKUPPATH will prevent data from being replaced on restore
@@ -8,7 +8,7 @@ RESTOREPATH="/storage/roms"
 SYNCPATH="/GAMES"
 
 # rclone sync rules
-RCLONEOPTS="
+RCLONEOPTS=" \
 --progress \
 --log-file /var/log/cloud_sync.log \
 --filter-from /storage/.config/cloud_sync-rules.txt \

--- a/packages/network/rclone/sources/cloud_sync.conf.defaults
+++ b/packages/network/rclone/sources/cloud_sync.conf.defaults
@@ -1,0 +1,30 @@
+# Directory where Retroarch saves, savestates, and screenshots are located
+DEFAULT_BACKUPPATH="/storage/roms"
+
+# Changing the below to be different from BACKUPPATH will prevent data from being replaced on restore
+DEFAULT_RESTOREPATH="/storage/roms"
+
+# Directory on the remote where save data should be stored
+DEFAULT_SYNCPATH="/GAMES"
+
+# rclone sync rules
+DEFAULT_RCLONEOPTS=" \
+--progress \
+--log-file /var/log/cloud_sync.log \
+--filter-from /storage/.config/cloud_sync-rules.txt \
+--delete-excluded \
+--verbose \
+"
+
+# Backup method
+# The default is "sync", which creates a 1:1 match between the local path and remote
+# Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
+DEFAULT_BACKUPMETHOD="sync"
+
+# Restore method
+# The default is "copy", which will preserve any existing files and folders
+# Switching to "sync" will replace all local files in the restore path with what is on the remote
+DEFAULT_RESTOREMETHOD="copy"
+
+## Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.
+DEFAULT_RSYNCRMDIR="yes"

--- a/packages/rocknix/sources/post-update
+++ b/packages/rocknix/sources/post-update
@@ -62,8 +62,8 @@ rsync --ignore-existing /usr/config/rsync.conf /storage/.config/
 
 ### Add cloud sync-related files if missing
 echo "Update cloud sync filter rules..." >>${LOG}
-rsync --times --update /usr/config/cloud_sync-rules.txt /storage/.config/
-rsync --times --update /usr/config/cloud_sync.conf /storage/.config/
+rsync --ignore-existing /usr/config/cloud_sync-rules.txt /storage/.config/
+rsync --ignore-existing /usr/config/cloud_sync.conf /storage/.config/
 
 ### Sync locale data
 tocon "Re-sync locale data..."

--- a/packages/rocknix/sources/post-update
+++ b/packages/rocknix/sources/post-update
@@ -61,9 +61,10 @@ rsync --ignore-existing /usr/config/rsync-rules.conf /storage/.config/
 rsync --ignore-existing /usr/config/rsync.conf /storage/.config/
 
 ### Add cloud sync-related files if missing
-echo "Update cloud sync filter rules..." >>${LOG}
+echo "Update cloud sync files..." >>${LOG}
 rsync --ignore-existing /usr/config/cloud_sync-rules.txt /storage/.config/
 rsync --ignore-existing /usr/config/cloud_sync.conf /storage/.config/
+rsync --ignore-existing /usr/config/cloud_sync.conf.defaults /storage/.config/
 
 ### Sync locale data
 tocon "Re-sync locale data..."


### PR DESCRIPTION
I decided to redo the logic to ensure that custom configs for different sync-related variables won't get replaced in the future if a new variable type is introduced and the `cloud_sync.conf` file needs updating. I created a `cloud_sync.conf.defaults` file with the default config values, and if, when a user runs backup or restore, a variable is missing in `cloud_sync.conf`, the scripts will create the missing variable in the conf file and set it to the default value.

This change will ensure that any users who set custom params with the newer rclone-only engine don't unexpectedly have their changes overwritten.

I've tested that this is working as expected on my own RK3566 device.