### PR TITLE
cpufreq schedutils fix latency of transition states calculation for aarch64/arm

### DIFF
--- a/packages/kernel/linux/patches/mainline/0007-schedutil-latency-fix.patch
+++ b/packages/kernel/linux/patches/mainline/0007-schedutil-latency-fix.patch
@@ -1,0 +1,58 @@
+diff --git a/drivers/cpufreq/cpufreq.c b/drivers/cpufreq/cpufreq.c
+index 04fc786dd2c0..f98c9438760c 100644
+--- a/drivers/cpufreq/cpufreq.c
++++ b/drivers/cpufreq/cpufreq.c
+@@ -575,30 +575,11 @@ unsigned int cpufreq_policy_transition_delay_us(struct cpufreq_policy *policy)
+ 		return policy->transition_delay_us;
+ 
+ 	latency = policy->cpuinfo.transition_latency / NSEC_PER_USEC;
+-	if (latency) {
+-		unsigned int max_delay_us = 2 * MSEC_PER_SEC;
++	if (latency)
++		/* Give a 50% breathing room between updates */
++		return latency + (latency >> 1);
+ 
+-		/*
+-		 * If the platform already has high transition_latency, use it
+-		 * as-is.
+-		 */
+-		if (latency > max_delay_us)
+-			return latency;
+-
+-		/*
+-		 * For platforms that can change the frequency very fast (< 2
+-		 * us), the above formula gives a decent transition delay. But
+-		 * for platforms where transition_latency is in milliseconds, it
+-		 * ends up giving unrealistic values.
+-		 *
+-		 * Cap the default transition delay to 2 ms, which seems to be
+-		 * a reasonable amount of time after which we should reevaluate
+-		 * the frequency.
+-		 */
+-		return min(latency * LATENCY_MULTIPLIER, max_delay_us);
+-	}
+-
+-	return LATENCY_MULTIPLIER;
++	return USEC_PER_MSEC;
+ }
+ EXPORT_SYMBOL_GPL(cpufreq_policy_transition_delay_us);
+ 
+diff --git a/include/linux/cpufreq.h b/include/linux/cpufreq.h
+index d4d2f4d1d7cb..e0e19d9c1323 100644
+--- a/include/linux/cpufreq.h
++++ b/include/linux/cpufreq.h
+@@ -577,12 +577,6 @@ static inline unsigned long cpufreq_scale(unsigned long old, u_int div,
+ #define CPUFREQ_POLICY_POWERSAVE	(1)
+ #define CPUFREQ_POLICY_PERFORMANCE	(2)
+ 
+-/*
+- * The polling frequency depends on the capability of the processor. Default
+- * polling frequency is 1000 times the transition latency of the processor.
+- */
+-#define LATENCY_MULTIPLIER		(1000)
+-
+ struct cpufreq_governor {
+ 	char	name[CPUFREQ_NAME_LEN];
+ 	int	(*init)(struct cpufreq_policy *policy);
+-- 
+2.34.1


### PR DESCRIPTION
Changes the way latency is used for calculating cpufreq state transistion and significantly improves schedutil performance on aarch64/armhf targets. And potentially makes schedutils a better choice than ondemand for most of our targets again (requires in-depth testing).

Applies cleanly to current 6.9 and 6.10 kernels.

Details at lkml : https://lore.kernel.org/linux-pm/20240728192659.58115-1-qyousef@layalina.io/

Tested on rgb30,rg353m,rg353v,x55,rk3588

 Changes to be committed:
	new file:   0007-schedutil-latency-fix.patch