### PR TITLE
Add cheat.db file for PPSSPP

### DIFF
--- a/packages/emulators/standalone/ppsspp-sa/package.mk
+++ b/packages/emulators/standalone/ppsspp-sa/package.mk
@@ -6,6 +6,7 @@ PKG_NAME="ppsspp-sa"
 PKG_SITE="https://github.com/hrydgard/ppsspp"
 PKG_URL="${PKG_SITE}.git"
 PKG_VERSION="d479b74ed9c3e321bc3735da29bc125a2ac3b9b2" # 1.17.1
+CHEAT_DB_VERSION="31d7280ed5bad454df5bddc6d953de84f34c9ef5" # Update cheat.db (26/06/2024)
 PKG_LICENSE="GPLv2"
 PKG_DEPENDS_TARGET="toolchain ffmpeg libzip SDL2 zlib zip"
 PKG_LONGDESC="PPSSPPDL"
@@ -95,4 +96,5 @@ makeinstall_target() {
   fi
   rm ${INSTALL}/usr/config/ppsspp/assets/gamecontrollerdb.txt
   ln -sf NotoSansJP-Regular.ttf ${INSTALL}/usr/config/ppsspp/assets/Roboto-Condensed.ttf
+  curl -Lo ${INSTALL}/usr/config/ppsspp/PSP/Cheats/cheat.db https://raw.githubusercontent.com/Saramagrean/CWCheat-Database-Plus-/${CHEAT_DB_VERSION}/cheat.db
 }


### PR DESCRIPTION
This includes the cheat.db from [https://github.com/Saramagrean/CWCheat-Database-Plus-](https://github.com/Saramagrean/CWCheat-Database-Plus-) in Rocknix. This db includes fixes, optimizations and frame limit patches for a lot of games which is beneficial for a lot of lower powered Rocknix devices.

According to [this](https://github.com/Saramagrean/CWCheat-Database-Plus-/issues/7) the authors have no issues with other projects including this.