### PR TITLE
Fix r36s controls mapping

### DIFF
--- a/packages/emulators/standalone/pico-8/sources/start_pico8.sh
+++ b/packages/emulators/standalone/pico-8/sources/start_pico8.sh
@@ -40,7 +40,7 @@ else
 fi
 
 # store sdl_controllers in root directory so its shared across devices - will look to revisit this with controller refactor work
-cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${GAME_DIR}/sdl_controllers.txt
+cp -f /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt ${GAME_DIR}/sdl_controllers.txt
 
 # mark the binary executable to cover cases where the user adding the binaries doesn't know or forgets.
 chmod 0755 ${LAUNCH_DIR}/${STATIC_BIN}

--- a/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
+++ b/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
@@ -57,3 +57,9 @@ RightAn.Left = 10-4005
 RightAn.Right = 10-4004
 EOF
 fi
+
+# Remove the line containing odroidgo3_joypad and replace it with R36 mapping.
+if [ -f "/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt" ]; then
+    sed -i '/odroidgo3_joypad/d' /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
+    echo '1900c3ea010000000100000001010000,odroidgo3_joypad,a:b1,b:b0,dpdown:b14,dpleft:b15,+lefty:+a1,-leftx:-a0,+leftx:+a0,-lefty:-a1,leftshoulder:b4,leftstick:b11,lefttrigger:b6,dpright:b16,+righty:+a3,-rightx:-a2,+rightx:+a2,-righty:-a3,rightshoulder:b5,rightstick:b12,righttrigger:b7,back:b8,start:b9,dpup:b13,x:b2,y:b3,platform:Linux,' >>/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
+fi

--- a/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
+++ b/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
@@ -59,7 +59,9 @@ EOF
 fi
 
 # Remove the line containing odroidgo3_joypad and replace it with R36 mapping.
-if [ -f "/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt" ]; then
-    sed -i '/odroidgo3_joypad/d' /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
-    echo '1900c3ea010000000100000001010000,odroidgo3_joypad,a:b1,b:b0,dpdown:b14,dpleft:b15,+lefty:+a1,-leftx:-a0,+leftx:+a0,-lefty:-a1,leftshoulder:b4,leftstick:b11,lefttrigger:b6,dpright:b16,+righty:+a3,-rightx:-a2,+rightx:+a2,-righty:-a3,rightshoulder:b5,rightstick:b12,righttrigger:b7,back:b8,start:b9,dpup:b13,x:b2,y:b3,platform:Linux,' >>/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
-fi
+FILE_DIR="/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt"
+if [ -f ${FILE_DIR} ]; then
+    rm ${FILE_DIR}
+    cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${FILE_DIR}
+    sed -i '/odroidgo3_joypad/d' ${FILE_DIR} 
+    echo '1900c3ea010000000100000001010000,odroidgo3_joypad,a:b1,b:b0,dpdown:b14,dpleft:b15,+lefty:+a1,-leftx:-a0,+leftx:+a0,-lefty:-a1,leftshoulder:b4,leftstick:b11,lefttrigger:b6,dpright:b16,+righty:+a3,-rightx:-a2,+rightx:+a2,-righty:-a3,rightshoulder:b5,rightstick:b12,righttrigger:b7,back:b8,start:b9,dpup:b13,x:b2,y:b3,platform:Linux,' >>${FILE_DIR}

--- a/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
+++ b/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
@@ -59,10 +59,10 @@ EOF
 fi
 
 # Remove the line containing odroidgo3_joypad and replace it with R36 mapping.
-FILE_DIR="/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt"
-if [ -f ${FILE_DIR} ]; then
-    rm ${FILE_DIR}
-    cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${FILE_DIR}
-    sed -i '/odroidgo3_joypad/d' ${FILE_DIR} 
-    echo '1900c3ea010000000100000001010000,odroidgo3_joypad,a:b1,b:b0,dpdown:b14,dpleft:b15,+lefty:+a1,-leftx:-a0,+leftx:+a0,-lefty:-a1,leftshoulder:b4,leftstick:b11,lefttrigger:b6,dpright:b16,+righty:+a3,-rightx:-a2,+rightx:+a2,-righty:-a3,rightshoulder:b5,rightstick:b12,righttrigger:b7,back:b8,start:b9,dpup:b13,x:b2,y:b3,platform:Linux,' >>${FILE_DIR}
+FILE="/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt"
+if [ -f ${FILE} ]; then
+    rm ${FILE}
+    cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${FILE}
+    sed -i '/odroidgo3_joypad/d' ${FILE} 
+    echo '1900c3ea010000000100000001010000,odroidgo3_joypad,a:b1,b:b0,dpdown:b14,dpleft:b15,+lefty:+a1,-leftx:-a0,+leftx:+a0,-lefty:-a1,leftshoulder:b4,leftstick:b11,lefttrigger:b6,dpright:b16,+righty:+a3,-rightx:-a2,+rightx:+a2,-righty:-a3,rightshoulder:b5,rightstick:b12,righttrigger:b7,back:b8,start:b9,dpup:b13,x:b2,y:b3,platform:Linux,' >>${FILE}
 fi

--- a/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
+++ b/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
@@ -65,3 +65,4 @@ if [ -f ${FILE_DIR} ]; then
     cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${FILE_DIR}
     sed -i '/odroidgo3_joypad/d' ${FILE_DIR} 
     echo '1900c3ea010000000100000001010000,odroidgo3_joypad,a:b1,b:b0,dpdown:b14,dpleft:b15,+lefty:+a1,-leftx:-a0,+leftx:+a0,-lefty:-a1,leftshoulder:b4,leftstick:b11,lefttrigger:b6,dpright:b16,+righty:+a3,-rightx:-a2,+rightx:+a2,-righty:-a3,rightshoulder:b5,rightstick:b12,righttrigger:b7,back:b8,start:b9,dpup:b13,x:b2,y:b3,platform:Linux,' >>${FILE_DIR}
+fi


### PR DESCRIPTION
Some inputs do not work well on the standalone emulators on the R36S console, this is mostly due to the device having a hotkey (fn button), which has an id of 10.

This PR aims to fix the mappings so that standalone emulators who rely on SDL mappings get assigned the right buttons, by basically just incrementing by 1 all the buttons that are past the id of 10.

This will also fix pico-8 mapping and will make the dpad work as intended by making rely on the right mapping file.

Already tested and seems to fix PPSSPP and N64 mappings.