### PR TITLE
Improve dtb_overlays script

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/RK3566/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/RK3566/SUPPORTED_EMULATORS_AND_CORES.md
@@ -72,6 +72,7 @@ This document describes all available systems emulators and cores available for 
 |Nintendo|Game Boy Color (Hacks) (gbch)|1998|`gbch`|.gb .gbc .zip .7z|**retroarch:** gambatte (default)<br>**retroarch:** sameboy<br>**retroarch:** gearboy<br>**retroarch:** tgbdual<br>**retroarch:** mgba<br>**retroarch:** vbam<br>**retroarch:** DoubleCherryGB<br>**mednafen:** gb<br>|
 |Nintendo|GameCube (gamecube)|2001|`gamecube`|.gcm .iso .gcz .ciso .wbfs .rvz .dol|**dolphin:** dolphin-sa-gc (default)<br>**retroarch:** dolphin<br>|
 |Nintendo|NES (Hacks) (nesh)|1985|`nesh`|.nes .unif .unf .zip .7z|**retroarch:** nestopia (default)<br>**retroarch:** fceumm<br>**retroarch:** quicknes<br>**retroarch:** mesen<br>**mednafen:** nesh<br>|
+|Nintendo|Nintendo 3DS (3ds)|2010|`3ds`|.3ds .3dsx .elf .axf .cci .cxi .app|**retroarch:** panda3ds (default)<br>|
 |Nintendo|Nintendo 64 (n64)|1996|`n64`|.z64 .n64 .v64 .zip .7z|**retroarch:** mupen64plus_next (default)<br>**retroarch:** mupen64plus<br>**retroarch:** parallel_n64<br>**mupen64plus:** mupen64plus-sa<br>|
 |Nintendo|Nintendo DS (nds)|2005|`nds`|.nds .zip .7z|**drastic:** drastic-sa (default)<br>**retroarch:** melonds<br>**retroarch:** melondsds<br>**melonds:** melonds-sa<br>**retroarch:** desmume<br>|
 |Nintendo|Nintendo Entertainment System (nes)|1985|`nes`|.nes .unif .unf .zip .7z|**retroarch:** nestopia (default)<br>**retroarch:** fceumm<br>**retroarch:** quicknes<br>**retroarch:** mesen<br>**mednafen:** nes<br>|

--- a/packages/graphics/libmali/package.mk
+++ b/packages/graphics/libmali/package.mk
@@ -73,13 +73,11 @@ post_makeinstall_target() {
       PAN="panthor"
       DTB_OVERLAY_LOAD="\/usr\/bin\/dtb_overlay set driver-gpu driver-gpu-panthor.dtbo"
       DTB_OVERLAY_UNLOAD="\/usr\/bin\/dtb_overlay set driver-gpu None"
-      DTB_OVERLAY_WRITE="\/usr\/bin\/dtb_overlay write"
     ;;
     *)
       PAN="panfrost"
       DTB_OVERLAY=""
       DTB_OVERLAY_UNLOAD=""
-      DTB_OVERLAY_WRITE=""
     ;;
   esac
 
@@ -90,8 +88,5 @@ post_makeinstall_target() {
       -i  ${INSTALL}/usr/bin/gpudriver
 
   sed -e "s/@DTB_OVERLAY_UNLOAD@/${DTB_OVERLAY_UNLOAD}/g" \
-      -i  ${INSTALL}/usr/bin/gpudriver
-
-  sed -e "s/@DTB_OVERLAY_WRITE@/${DTB_OVERLAY_WRITE}/g" \
       -i  ${INSTALL}/usr/bin/gpudriver
 }

--- a/packages/graphics/libmali/sources/bin/gpudriver
+++ b/packages/graphics/libmali/sources/bin/gpudriver
@@ -58,12 +58,10 @@ case "$1" in
   "libmali")
     set_setting ${GPU_DRIVER_SETTING_KEY} $1
     @DTB_OVERLAY_UNLOAD@
-    @DTB_OVERLAY_WRITE@
     ;;
   "panfrost")
     set_setting ${GPU_DRIVER_SETTING_KEY} $1
     @DTB_OVERLAY_LOAD@
-    @DTB_OVERLAY_WRITE@
     ;;
   "")
     get_current_driver

--- a/packages/kernel/device-tree-overlays/sources/dtb_overlay
+++ b/packages/kernel/device-tree-overlays/sources/dtb_overlay
@@ -2,18 +2,26 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 . /etc/profile.d/001-functions
-UV_CPU_ID="undervolt-cpu"
-UV_GPU_ID="undervolt-gpu"
-DRIVER_GPU_ID="driver-gpu"
-CUSTOM_TWEAKS="${UV_CPU_ID} ${UV_GPU_ID} ${DRIVER_GPU_ID}"
+SPECIALIZATIONS="undervolt-cpu undervolt-gpu driver-gpu"
+
+check_valid_specialization() {
+    for spec in $SPECIALIZATIONS; do
+        if [ "$spec" = "${1}" ]; then
+            return
+        fi
+    done
+    echo "Unknown specialization: ${1}"
+    echo "Valid specializations are: ${SPECIALIZATIONS}"
+    exit 1
+}
 
 get_current_custom_overlay() {
     fdtoverlaysline=$(grep FDTOVERLAYS /flash/extlinux/extlinux.conf)
     overlays=${fdtoverlaysline##  FDTOVERLAYS}
     for ol in $overlays; do
         match=0
-        for tweak in $CUSTOM_TWEAKS; do
-            if [[ $ol == *"$tweak"* ]]; then
+        for spec in $SPECIALIZATIONS; do
+            if [[ $ol == *"$spec"* ]]; then
                match=1
                break
             fi
@@ -49,8 +57,8 @@ get_current_specialized_overlay() {
 
 list_custom_overlays() {
     for ol in /flash/overlays/*.dtbo; do
-        for tweak in $CUSTOM_TWEAKS; do
-            if [[ $ol == *"$tweak"* ]]; then
+        for spec in $SPECIALIZATIONS; do
+            if [[ $ol == *"$spec"* ]]; then
                 ol=""
         break
             fi
@@ -75,21 +83,18 @@ list_specialized_overlays() {
 
 write_dtbo() {
     PRE=/overlays/
-    CPU=$(get_setting system.${UV_CPU_ID})
-    GPU=$(get_setting system.${UV_GPU_ID})
-    DRIVER_GPU=$(get_setting system.${DRIVER_GPU_ID})
-    CUSTOM=$(get_setting system.custom_dtb)
-    for dtb in $CPU $GPU $DRIVER_GPU $CUSTOM; do
-        if [ ! $dtb = "None" ]; then
-            dtbs+="${PRE}${dtb} "
+    for spec in $SPECIALIZATIONS custom_dtbo; do
+	ol=$(get_setting system.$spec)
+        if [ "$ol" != "None" ] && [[ ! -z $ol ]]; then
+            dtbos+="${PRE}${ol} "
         fi
     done
     mount -o remount,rw /flash
-    if [ $dtbs ];then
+    if [ "$dtbos" ]; then
         if grep --quiet FDTOVERLAYS /flash/extlinux/extlinux.conf; then
-            sed -i "/FDTOVERLAYS/c \ \ FDTOVERLAYS ${dtbs}" /flash/extlinux/extlinux.conf
+            sed -i "/FDTOVERLAYS/c \ \ FDTOVERLAYS ${dtbos}" /flash/extlinux/extlinux.conf
         else
-            sed -i "/FDT/a \ \ FDTOVERLAYS ${dtbs}" /flash/extlinux/extlinux.conf
+            sed -i "/FDT/a \ \ FDTOVERLAYS ${dtbos}" /flash/extlinux/extlinux.conf
         fi
     else
         sed -i "/FDTOVERLAYS/d" /flash/extlinux/extlinux.conf
@@ -104,13 +109,10 @@ case "$1" in
                 list_custom_overlays
                 exit 0
             ;;
-            $UV_CPU_ID|$UV_GPU_ID|$DRIVER_GPU_ID)
+            *)
+                check_valid_specialization $2
                 list_specialized_overlays $2
                 exit 0
-            ;;
-            *)
-                echo "Unknown arguments: ${1} ${2}"
-                exit 1
             ;;
         esac
     ;;
@@ -120,39 +122,42 @@ case "$1" in
                 get_current_custom_overlay
                 exit 0
             ;;
-            $UV_CPU_ID|$UV_GPU_ID|$DRIVER_GPU_ID)
+            *)
+                check_valid_specialization $2
                 get_current_specialized_overlay $2
                 exit 0
             ;;
-            *)
-                echo "Unknown arguments: ${1} ${2}"
-                exit 1
-            ;;
         esac
     ;;
-
    "set")
         case "$2" in
             "custom")
-                set_setting system.custom_dtb $3
-                exit 0
-            ;;
-            $UV_CPU_ID|$UV_GPU_ID|$DRIVER_GPU_ID)
-                set_setting system.$2 $3
-                exit 0
+                for ol in $(list_custom_overlays); do
+		            if [ "$3" = "$ol" ] || [ $3 = None ]; then
+                        set_setting system.custom_dtbo $3
+                        write_dtbo
+                        exit 0
+		            fi
+		        done
+                echo "dtbo doesn't exist: $3"
+                exit 1
             ;;
             *)
-                echo "Unknown arguments: ${1} ${2}"
+                check_valid_specialization $2
+	            for ol in $(list_specialized_overlays $2); do
+		            if [ "$3" = "$ol" ] || [ $3 = None ]; then
+                        set_setting system.$2 $3
+                        write_dtbo
+                        exit 0
+		            fi
+		        done
+                echo "dtbo doesn't exist: $3"
                 exit 1
             ;;
         esac
     ;;
-    "write")
-        write_dtbo
-        exit 0
-    ;;
     *)
-        echo "Unknown arguments $@"
-        exit 0
+        echo "Unknown operation: ${1}"
+        exit 1
     ;;
 esac

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="856d8c9948808ca76e4bc77f2d22b7d1241e3c0f"
+PKG_VERSION="f0189b481e354cf63c88aa223d0a7a8678ffcc63"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation"


### PR DESCRIPTION
* Adding a specialization is now just a matter of appending the identifier to string in the script.
* Displaying it in ES, just requires adding a line specifying the identifier.