### PR TITLE
RK3326: Bump kernel version to generic one

### DIFF
--- a/packages/kernel/linux/package.mk
+++ b/packages/kernel/linux/package.mk
@@ -20,11 +20,6 @@ if [ "${DEVICE}" = "S922X" -a "${USE_MALI}" = "no" ]; then
 fi
 
 case ${DEVICE} in
-  RK3326)
-    PKG_VERSION="6.8.9"
-    PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-    PKG_PATCH_DIRS+=" mainline"
-    ;;
   RK3588)
     PKG_VERSION="71039841e6100b280bc90d91b7b6b9d33ec84897"
     PKG_URL="https://github.com/armbian/linux-rockchip/archive/${PKG_VERSION}.tar.gz"

--- a/projects/Rockchip/patches/linux/RK3326/001-panel-updates.patch
+++ b/projects/Rockchip/patches/linux/RK3326/001-panel-updates.patch
@@ -798,9 +798,9 @@ index b55bafd1a8be..c65d9e459f01 100644
 +	{ .compatible = "gameconsole,r36s-panel", .data = &r36s_desc },
 +	{ .compatible = "magicx,xu10-panel", .data = &xu10_desc },
 +	{ .compatible = "anbernic,rg351v-panel-v2", .data = &rg351v2_desc },
+	{ .compatible = "powkiddy,rgb10max3-panel", .data = &rgb10max3_panel_desc },
  	{ .compatible = "powkiddy,rgb30-panel", .data = &rgb30panel_desc },
  	{ .compatible = "rocktech,jh057n00900", .data = &jh057n00900_panel_desc },
- 	{ .compatible = "xingbangda,xbd599", .data = &xbd599_desc },
 @@ -802,6 +1028,6 @@ static struct mipi_dsi_driver st7703_driver = {
  };
  module_mipi_dsi_driver(st7703_driver);


### PR DESCRIPTION
I have tested 6.9.12 and haven't found any issues related to kernel update on RK3326. Tested on R36S and R33S. I assume it's better to keep kernels in sync between devices if possible.