### PR TITLE
ES WIP runs, can be picked at build time by setting ES_WIP=1

### DIFF
--- a/packages/ui/rocknix-emulationstation/package.mk
+++ b/packages/ui/rocknix-emulationstation/package.mk
@@ -99,6 +99,13 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
   cp -rf ${PKG_BUILD}/emulationstation ${INSTALL}/usr/bin
 
+  mkdir -p ${INSTALL}/usr/bin
+  cp ${PKG_BUILD}/es_settings ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/es_settings
+
+  cp ${PKG_BUILD}/start_es.sh ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/start_es.sh
+
   mkdir -p ${INSTALL}/etc/emulationstation/
   ln -sf /storage/.config/emulationstation/themes ${INSTALL}/etc/emulationstation/
 
@@ -136,3 +143,13 @@ EOF
   ln -sf /storage/.cache/system_timezone ${INSTALL}/etc/timezone
 }
 
+post_install() {
+  mkdir -p ${INSTALL}/usr/share
+  ln -sf /storage/.config/locale ${INSTALL}/usr/share/locale
+
+  mkdir -p ${INSTALL}/usr/lib
+  ln -sf /usr/share/locale ${INSTALL}/usr/lib/locale
+
+  ln -sf /usr/share/locale  ${INSTALL}/usr/config/emulationstation/locale
+
+}

--- a/packages/ui/rocknix-emulationstation/sources/es_settings
+++ b/packages/ui/rocknix-emulationstation/sources/es_settings
@@ -1,0 +1,52 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+# Source predefined functions and variables
+. /etc/profile
+
+export SDL_AUDIODRIVER=pulseaudio
+
+TZ=$(get_setting system.timezone)
+echo -n "TIMEZONE=${TZ}" > /storage/.cache/timezone
+echo -n "${TZ}" >/storage/.cache/system_timezone
+systemctl restart tz-data.service
+
+MYLOCALE=$(get_setting system.language)
+if [[ -n "${MYLOCALE}" ]]
+then
+
+  unset I18NPATH LANG LANGUAGE LOCPATH
+
+  MYCHARMAP="UTF-8"
+  MYLANG="${MYLOCALE}.${MYCHARMAP}"
+  MYLOCPATH="/storage/.config/emulationstation"
+
+  if [ ! -e "${MYLOCPATH}/locale/${MYLANG}/LC_NAME" ]; then
+    performance
+ I18NPATH="/usr/share/i18n"
+ localedef -i ${MYLOCALE} \
+           -c \
+           -v \
+           -f ${MYCHARMAP} \
+           ${MYLOCPATH}/locale/${MYLANG} >/var/log/start_es.log 2>&1
+    ${DEVICE_CPU_GOVERNOR}
+  fi
+
+  export LOCPATH="${MYLOCPATH}/locale"
+  export LANG=${MYLANG}
+  export LANGUAGE=${MYLANG}
+  systemctl import-environment LANG
+  systemctl import-environment LOCPATH
+  systemctl import-environment I18NPATH
+  systemctl import-environment LANGUAGE
+fi
+
+### Import quirk variables.
+for VARIABLE in $(cat /etc/profile.d/999-export | grep _ | sed 's/export//g; s/^\W//g; s/\\//g')
+do
+  systemctl import-environment ${VARIABLE}
+done
+
+set_kill set "emulationstation"

--- a/packages/ui/rocknix-emulationstation/sources/start_es.sh
+++ b/packages/ui/rocknix-emulationstation/sources/start_es.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
+
+### setup is the same
+. $(dirname $0)/es_settings
+
+emulationstation --log-path /var/log --no-splash

--- a/packages/ui/rocknix-emulationstation/system.d/es.service
+++ b/packages/ui/rocknix-emulationstation/system.d/es.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=EmulationStation-service-for-any-compositor
+PartOf=graphical.target
+
+[Service]
+Environment=HOME=/storage
+Type=simple
+ExecStart=/usr/bin/start_es.sh
+WorkingDirectory=/storage
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=rocknix.target

--- a/packages/ui/rocknix-emulationstation/system.d/essway.service
+++ b/packages/ui/rocknix-emulationstation/system.d/essway.service
@@ -1,0 +1,1 @@
+es.service

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -15,7 +15,12 @@ PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host 
                     bash coreutils modules system-utils autostart quirks powerstate gnupg \
                     gzip six lynx xmlstarlet vim pyudev dialog dbus-python network rocknix"
 
-PKG_UI="emulationstation es-themes textviewer"
+if [ ${ES_WIP} ]; then
+  PKG_UI="rocknix-emulationstation "
+else
+  PKG_UI="emulationstation "
+fi
+PKG_UI+="es-themes textviewer"
 
 PKG_UI_TOOLS="fileman fbgrab"
 


### PR DESCRIPTION
Tested on Sway.

New es.service, ideally on the long run we should switch weston to also use es.service. Hopefully current setup works on weston but it's untested as of now.