### PR TITLE
SD865 - fix aethersx2 controls

### DIFF
--- a/packages/emulators/standalone/aethersx2-sa/config/SD865/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/SD865/aethersx2/inis/PCSX2.ini
@@ -3,6 +3,7 @@ SettingsVersion = 1
 StartFullscreen = true
 RenderToSeparateWindow = true
 
+
 [EmuCore]
 CdvdVerboseReads = false
 CdvdDumpBlocks = false
@@ -345,15 +346,15 @@ Right = SDL-0/DPadRight
 Down = SDL-0/DPadDown
 Left = SDL-0/DPadLeft
 Triangle = SDL-0/X
-Circle = SDL-0/B
-Cross = SDL-0/A
+Circle = SDL-0/A
+Cross = SDL-0/B
 Square = SDL-0/Y
 Select = SDL-0/Back
 Start = SDL-0/Start
 L1 = SDL-0/LeftShoulder
-L2 = SDL-0/+RightTrigger
+L2 = SDL-0/+LeftTrigger
 R1 = SDL-0/RightShoulder
-R2 = SDL-0/+LeftTrigger
+R2 = SDL-0/+RightTrigger
 L3 = SDL-0/LeftStick
 R3 = SDL-0/RightStick
 LUp = SDL-0/-LeftY
@@ -364,6 +365,7 @@ RUp = SDL-0/-RightY
 RRight = SDL-0/+RightX
 RDown = SDL-0/+RightY
 RLeft = SDL-0/-RightX
+ButtonDeadzone = 0.1
 
 
 [Pad2]


### PR DESCRIPTION
Fix up aethersx2 controls for the RP Mini. I had to add a button deadzone, or the L2 button (mapped to left trigger) would trigger when not pressed.