### PR TITLE
Bump kernel-firmware and wpa_supplicant

### DIFF
--- a/packages/kernel/firmware/kernel-firmware/package.mk
+++ b/packages/kernel/firmware/kernel-firmware/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20240220"
+PKG_VERSION="20240909"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${PKG_VERSION}.tar.gz"
@@ -69,12 +69,6 @@ makeinstall_target() {
 
   # brcm pcie firmware is only needed by x86_64
   [ "${TARGET_ARCH}" != "x86_64" ] && rm -fr ${FW_TARGET_DIR}/brcm/*-pcie.*
-
-  # Upstream doesn't name the file correctly so we need to symlink it
-  if [ -f "${FW_TARGET_DIR}/rtl_bt/rtl8723bs_config-OBDA8723.bin" ]; then
-    #cd "${FW_TARGET_DIR}/rtl_bt"
-    ln -s "rtl8723bs_config-OBDA8723.bin" "${FW_TARGET_DIR}/rtl_bt/rtl8723bs_config.bin"
-  fi
 
   # The BSP kernel for RK3588 reformats the vendor firmware path for Realtek BT devices,
   # so symlink the firmware.

--- a/packages/network/wpa_supplicant/package.mk
+++ b/packages/network/wpa_supplicant/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wpa_supplicant"
-PKG_VERSION="2.10"
+PKG_VERSION="2.11"
 PKG_LICENSE="GPL"
 PKG_SITE="https://w1.fi/wpa_supplicant/"
 PKG_URL="https://w1.fi/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/wpa_supplicant/package.mk
+++ b/packages/network/wpa_supplicant/package.mk
@@ -4,7 +4,6 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wpa_supplicant"
-PKG_VERSION="2.11"
 PKG_LICENSE="GPL"
 PKG_SITE="https://w1.fi/wpa_supplicant/"
 PKG_URL="https://w1.fi/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -12,6 +11,16 @@ PKG_DEPENDS_TARGET="toolchain dbus libnl openssl"
 PKG_LONGDESC="A free software implementation of an IEEE 802.11i supplicant."
 PKG_TOOLCHAIN="make"
 PKG_BUILD_FLAGS="+lto-parallel"
+
+case ${DEVICE} in
+  RK3588)
+    PKG_VERSION="2.10"
+  ;;
+  *)
+    PKG_VERSION="2.11"
+  ;;
+esac
+PKG_URL="https://w1.fi/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 
 PKG_MAKE_OPTS_TARGET="-C wpa_supplicant V=1 LIBDIR=/usr/lib BINDIR=/usr/bin"
 PKG_MAKEINSTALL_OPTS_TARGET="-C wpa_supplicant V=1 LIBDIR=/usr/lib BINDIR=/usr/bin"


### PR DESCRIPTION
I bumped these while doing other things.

Should be tested widely I suppose.

Tested Wifi on rgb30, and it works fine.