### PR TITLE
Build SD865 as cortex-a76.cortex-55, enable 32bit

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -18,7 +18,7 @@
       # This only makes sense for 8.0-a, later revisions have LSE
       TARGET_CFLAGS=" -mno-outline-atomics"
       ;;
-      cortex-a55|cortex-a76.cortex-a55|cortex-a77)
+      cortex-a55|cortex-a76.cortex-a55)
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8.2-a
       TARGET_ABI=eabi

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -47,12 +47,6 @@
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       TARGET_FEATURES+=" neon"
       ;;
-      cortex-a77)
-      TARGET_SUBARCH=armv8.2-a
-      TARGET_ABI=eabi
-      TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
-      TARGET_FEATURES+=" neon"
-      ;;
   esac
 
 #  if [ "${TARGET_FLOAT}" = "hard" ]; then

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -16,7 +16,7 @@ case "${DEVICE}" in
   RK3588*)
     OPT_ENABLE_KERNEL=5.10.0
   ;;
-  RK3566)
+  RK3566|SD865)
     OPT_ENABLE_KERNEL=6.10.0
   ;;
   *)

--- a/projects/Qualcomm/devices/SD865/options
+++ b/projects/Qualcomm/devices/SD865/options
@@ -8,7 +8,8 @@
       aarch64)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
-        TARGET_CPU="cortex-a77"
+        # cortex-a77.cortex-a55 not supported
+        TARGET_CPU="cortex-a76.cortex-a55"
         TARGET_CPU_FLAGS="+crypto+crc+fp+simd"
         TARGET_FPU="fp-armv8"
         TARGET_FLOAT="hard"
@@ -17,9 +18,10 @@
       arm)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
-        TARGET_CPU="cortex-a77"
+	# cortex-a76.cortex-a55 not supported
+        TARGET_CPU="cortex-a76.cortex-a55"
         TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="fp-armv8"
+        TARGET_FPU="crypto-neon-fp-armv8"
         TARGET_FLOAT="hard"
         TARGET_FEATURES="32bit"
         ;;
@@ -85,7 +87,7 @@
     ADDITIONAL_DRIVERS=""
 
   # Disable 32BIT support
-    ENABLE_32BIT="false"
+    ENABLE_32BIT="true"
 
   # debug tty path
     DEBUG_TTY="/dev/ttyFIQ0"


### PR DESCRIPTION
Cortex-a77.cortex-a55 is currently broken in gcc / glibc. Cortex 76 is close enough to the 77 as an alternative. 