### PR TITLE
SD865 - add yabasanshiro-sa input config quirk

### DIFF
--- a/packages/hardware/quirks/platforms/SD865/061-yabasanshiro_config
+++ b/packages/hardware/quirks/platforms/SD865/061-yabasanshiro_config
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+DEVICE_NAME="Retroid Pocket Gamepad"
+CONFIG_DIR="/storage/.config/yabasanshiro"
+CONFIG_FILE="input.cfg"
+
+if [ ! -d "${CONFIG_DIR}" ]
+then
+  mkdir -p "${CONFIG_DIR}"
+fi
+
+if [ ! -e "${CONFIG_DIR}/${CONFIG_FILE}" ]; then
+    GAMEPADCONFIG=$(xmlstarlet sel -t -c "//inputList/inputConfig[@deviceName='${DEVICE_NAME}']" -n /storage/.emulationstation/es_input.cfg)
+
+    if [ ! -z "${GAMEPADCONFIG}" ]; then
+        cat <<EOF >${CONFIG_DIR}/${CONFIG_FILE}
+<?xml version="1.0"?>
+<inputList>
+${GAMEPADCONFIG}
+</inputList>
+EOF
+    fi
+fi


### PR DESCRIPTION
Code to generate input config for yabasanshiro-sa in `start_yabasanshiro.sh`: https://github.com/ROCKNIX/distribution/blob/2e5f664064e917398a56392092816c027e2bf5e9/packages/emulators/standalone/yabasanshiro-sa/scripts/start_yabasanshiro.sh#L34 does not work as it is looking for `js0`, which does not exist on the Retroid Pocket Mini.

Adding a quirk to read `/storage/.emulationstation/es_input.cfg` for device 'Retroid Pocket Gamepad' and generate `/storage/.config/yabasanshiro/input.cfg`.