### PR TITLE
SD865 - flycast-sa - fix hotkeys

### DIFF
--- a/packages/emulators/standalone/flycast-sa/config/SD865/mappings/SDL_Retroid Pocket Gamepad.cfg
+++ b/packages/emulators/standalone/flycast-sa/config/SD865/mappings/SDL_Retroid Pocket Gamepad.cfg
@@ -17,10 +17,10 @@ bind10 = 13:btn_dpad1_left
 bind11 = 14:btn_dpad1_right
 bind2 = 2:btn_y
 bind3 = 3:btn_x
-bind4 = 5:btn_jump_state
-bind5 = 6:btn_quick_save
-bind6 = 8:btn_start
-bind7 = 9:btn_menu
+bind4 = 4:btn_jump_state
+bind5 = 5:btn_quick_save
+bind6 = 7:btn_start
+bind7 = 8:btn_menu
 bind8 = 11:btn_dpad1_up
 bind9 = 12:btn_dpad1_down
 
@@ -30,4 +30,3 @@ mapping_name = Retroid Pocket Gamepad
 rumble_power = 100
 saturation = 100
 version = 3
-


### PR DESCRIPTION
Map save state (R1), load state (L1), Start (Start) and Menu (Guide).