### PR TITLE
SD865: pin to mesa 23.3.6, add missing opp patch

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -4,14 +4,23 @@
 
 PKG_NAME="mesa"
 PKG_LICENSE="OSS"
+PKG_SITE="http://www.mesa3d.org/"
 PKG_DEPENDS_TARGET="toolchain expat libdrm zstd Mako:host pyyaml:host"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
 PKG_TOOLCHAIN="meson"
 PKG_PATCH_DIRS+=" ${DEVICE}"
-PKG_VERSION="24.2.5"
-PKG_BUILD_VERSION="${PKG_VERSION}"
-PKG_SITE="http://www.mesa3d.org/"
-PKG_URL="https://gitlab.freedesktop.org/mesa/mesa/-/archive/mesa-${PKG_VERSION}/mesa-mesa-${PKG_VERSION}.tar.gz"
+
+case ${DEVICE} in
+  SD865)
+    PKG_VERSION="23.3.6"
+    PKG_URL="https://gitlab.freedesktop.org/mesa/mesa/-/archive/mesa-${PKG_VERSION}/mesa-mesa-${PKG_VERSION}.tar.gz"
+  ;;
+  *)
+    PKG_VERSION="24.2.5"
+    PKG_BUILD_VERSION="${PKG_VERSION}"
+    PKG_URL="https://gitlab.freedesktop.org/mesa/mesa/-/archive/mesa-${PKG_VERSION}/mesa-mesa-${PKG_VERSION}.tar.gz"
+  ;;
+esac
 
 get_graphicdrivers
 

--- a/projects/Qualcomm/patches/linux/SD865/0001-add-missing-opp-cpu7.patch
+++ b/projects/Qualcomm/patches/linux/SD865/0001-add-missing-opp-cpu7.patch
@@ -1,0 +1,12 @@
+diff -rupbN linux.orig/arch/arm64/boot/dts/qcom/sm8250.dtsi linux/arch/arm64/boot/dts/qcom/sm8250.dtsi
+--- linux.orig/arch/arm64/boot/dts/qcom/sm8250.dtsi	2024-10-19 13:35:28.332965210 +0000
++++ linux/arch/arm64/boot/dts/qcom/sm8250.dtsi	2024-10-19 17:04:33.824750269 +0000
+@@ -608,7 +608,7 @@
+ 		};
+ 
+ 		cpu7_opp9: opp-1747200000 {
+-			opp-hz = /bits/ 64 <1708800000>;
++			opp-hz = /bits/ 64 <1747200000>;
+ 			opp-peak-kBps = <5412000 42393600>;
+ 		};
+ 


### PR DESCRIPTION
Mesa 23.3.6 seems much more stable for vulkan on the SD865.

Also fixing an upstream kernel bug, one of the opp values has a typo. 