### PR TITLE
SD865: Only update battery LED color if state changes

### DIFF
--- a/packages/sysutils/system-utils/sources/devices/SD865/battery_led_status
+++ b/packages/sysutils/system-utils/sources/devices/SD865/battery_led_status
@@ -78,6 +78,7 @@ function bat_led_orange() {
   done
 }
 
+PREV_BATCAP="null"
 while true
   do
   BAT_LED_STATE=$(get_setting led.color)
@@ -99,17 +100,36 @@ while true
           continue
         elif (( ${CAP} <= 20 ))
         then
-          bat_led_red
+          BATCAP="D_RED"
+          if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+            bat_led_red
+          fi
         elif (( ${CAP} <=  30 ))
         then
-          bat_led_orange
+          BATCAP="D_ORANGE"
+          if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+            bat_led_orange
+          fi
         else
-          bat_led_green
+          BATCAP="D_GREEN"
+          if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+            bat_led_green
+          fi
+        fi
+      elif (( ${CAP} <= 94 ))
+      then
+        BATCAP="C_ORANGE"
+        if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+          bat_led_orange
         fi
       elif (( ${CAP} >= 95 ))
       then
-        bat_led_green
+        BATCAP="C_GREEN"
+        if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+          bat_led_green
+        fi
       fi
+      PREV_BATCAP=${BATCAP}
       sleep 15
   fi
 done


### PR DESCRIPTION
This stops the LEDS from flickering when color is not changed. 