### PR TITLE
Change NFS_SUPPORT logic to be explicit no rather than explicit yes

### DIFF
--- a/packages/graphics/gammastep/package.mk
+++ b/packages/graphics/gammastep/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="gammastep"
+PKG_VERSION="master"
+PKG_LICENSE="GPL"
+PKG_SITE="https://gitlab.com/chinstrap/gammastep"
+PKG_URL="https://gitlab.com/chinstrap/gammastep/-/archive/master/gammastep-{PKG_VERSION}.tar.gz"
+#https://gitlab.com/chinstrap/gammastep/-/archive/master/gammastep-master.tar.gz
+PKG_DEPENDS_TARGET="toolchain libdrm libxcb xrandr wayland"
+PKG_LONGDESC="Adjust the color temperature of your screen according to your surroundings. This may help your eyes hurt less if you are working in front of the screen at night."
+PKG_TOOLCHAIN="autotools"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-gui \
+			   --disable-geoclue2 \ 
+			   --with-systemduserunitdir=no \
+		           --disable-nls"
+
+post_makeinstall_target() {
+:
+}

--- a/packages/kernel/linux/package.mk
+++ b/packages/kernel/linux/package.mk
@@ -130,7 +130,7 @@ pre_make_target() {
   fi
 
   # disable nfs support if not enabled
-  if [ ! "${NFS_SUPPORT}" = yes ]; then
+  if [ "${NFS_SUPPORT}" = no ]; then
     ${PKG_BUILD}/scripts/config --disable CONFIG_NFS_FS
   fi
 


### PR DESCRIPTION
This prevents removal of NFS_FS kernel support when building by default unless NFS_SUPPORT is explicitly set to no.