### PR TITLE
This adds two dependancies (OpenVR and libXRes) & gamescope package itself

### DIFF
--- a/packages/graphics/openvr/package.mk
+++ b/packages/graphics/openvr/package.mk
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-
 PKG_NAME="openvr"
 #gamescope needs beta/non release tag
 PKG_VERSION="ebd425331229365dc3ec42d1bb8b2cc3c2332f81"

--- a/packages/graphics/openvr/package.mk
+++ b/packages/graphics/openvr/package.mk
@@ -15,7 +15,7 @@ pre_configure_target() {
 }
 
 post_makeinstall_target() {
-:
+  :
 }
 
 post_install() {

--- a/packages/graphics/openvr/package.mk
+++ b/packages/graphics/openvr/package.mk
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+
+PKG_NAME="openvr"
+#gamescope needs beta/non release tag
+PKG_VERSION="ebd425331229365dc3ec42d1bb8b2cc3c2332f81"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/ValveSoftware/openvr"
+PKG_URL="https://github.com/ValveSoftware/openvr.git"
+PKG_DEPENDS_TARGET="toolchain jsoncpp"
+PKG_LONGDESC="API and runtime that allows access to VR hardware from multiple vendors"
+GET_HANDLER_SUPPORT="git"
+PKG_TOOLCHAIN="cmake"
+
+#PKG_MESON_OPTS_TARGET=""
+
+pre_configure_target() {
+  #export TARGET_CFLAGS=$(echo "${TARGET_CFLAGS} -Wno-unused-variable")
+:
+}
+
+post_makeinstall_target() {
+:
+}
+
+post_install() {
+:
+}
+

--- a/packages/graphics/openvr/package.mk
+++ b/packages/graphics/openvr/package.mk
@@ -10,9 +10,6 @@ PKG_DEPENDS_TARGET="toolchain jsoncpp"
 PKG_LONGDESC="API and runtime that allows access to VR hardware from multiple vendors"
 GET_HANDLER_SUPPORT="git"
 PKG_TOOLCHAIN="cmake"
-
-#PKG_MESON_OPTS_TARGET=""
-
 pre_configure_target() {
   #export TARGET_CFLAGS=$(echo "${TARGET_CFLAGS} -Wno-unused-variable")
 :

--- a/packages/graphics/openvr/package.mk
+++ b/packages/graphics/openvr/package.mk
@@ -19,6 +19,6 @@ post_makeinstall_target() {
 }
 
 post_install() {
-:
+  :
 }
 

--- a/packages/graphics/openvr/package.mk
+++ b/packages/graphics/openvr/package.mk
@@ -2,7 +2,6 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="openvr"
-#gamescope needs beta/non release tag
 PKG_VERSION="ebd425331229365dc3ec42d1bb8b2cc3c2332f81"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ValveSoftware/openvr"

--- a/packages/graphics/openvr/package.mk
+++ b/packages/graphics/openvr/package.mk
@@ -11,8 +11,7 @@ PKG_LONGDESC="API and runtime that allows access to VR hardware from multiple ve
 GET_HANDLER_SUPPORT="git"
 PKG_TOOLCHAIN="cmake"
 pre_configure_target() {
-  #export TARGET_CFLAGS=$(echo "${TARGET_CFLAGS} -Wno-unused-variable")
-:
+  :
 }
 
 post_makeinstall_target() {

--- a/packages/wayland/compositor/gamescope/package.mk
+++ b/packages/wayland/compositor/gamescope/package.mk
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-
 PKG_NAME="gamescope"
 PKG_VERSION="426fc5865a5a00339ab17bf006fddcca8a68675f"
 PKG_LICENSE="GPL"

--- a/packages/wayland/compositor/gamescope/package.mk
+++ b/packages/wayland/compositor/gamescope/package.mk
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+
+PKG_NAME="gamescope"
+PKG_VERSION="426fc5865a5a00339ab17bf006fddcca8a68675f"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/ChimeraOS/gamescope/"
+PKG_URL="https://github.com/ChimeraOS/gamescope.git"
+PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libinput json-c wlroots gdk-pixbuf xcb-util-wm xwayland xkbcomp vulkan-headers glslang libXdamage pixman pipewire libdecor lcms2 glm openvr libXRes"
+PKG_LONGDESC="gamescope is a micro wayland compositor useful for games. It creates a virtual environment for a game application to run in that helps solves various headaches such as resolution, alt-tabbing, mouse focusing issues etc. Gamescope also tries to remove as many unneccessary copies as it can and should provide better latency."
+GET_HANDLER_SUPPORT="git"
+PKG_TOOLCHAIN="meson"
+
+#PKG_MESON_OPTS_TARGET=""
+
+pre_configure_target() {
+:
+}
+
+post_makeinstall_target() {
+:
+}
+
+post_install() {
+:
+}
+

--- a/packages/wayland/compositor/gamescope/package.mk
+++ b/packages/wayland/compositor/gamescope/package.mk
@@ -10,18 +10,3 @@ PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libi
 PKG_LONGDESC="gamescope is a micro wayland compositor useful for games. It creates a virtual environment for a game application to run in that helps solves various headaches such as resolution, alt-tabbing, mouse focusing issues etc. Gamescope also tries to remove as many unneccessary copies as it can and should provide better latency."
 GET_HANDLER_SUPPORT="git"
 PKG_TOOLCHAIN="meson"
-
-#PKG_MESON_OPTS_TARGET=""
-
-pre_configure_target() {
-:
-}
-
-post_makeinstall_target() {
-:
-}
-
-post_install() {
-:
-}
-

--- a/packages/x11/lib/libXRes/package.mk
+++ b/packages/x11/lib/libXRes/package.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="libXRes"

--- a/packages/x11/lib/libXRes/package.mk
+++ b/packages/x11/lib/libXRes/package.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+
+PKG_NAME="libXRes"
+PKG_VERSION="860f84072e864832d3a94c365241fe619967b63a"
+PKG_LICENSE="OSS"
+PKG_SITE="https://gitlab.freedesktop.org/xorg/lib/libxres"
+PKG_URL="https://gitlab.freedesktop.org/xorg/lib/libxres.git"
+PKG_DEPENDS_TARGET="toolchain util-macros libX11"
+PKG_LONGDESC="libXRes - X-Resource extension client library"
+GET_HANDLER_SUPPORT="git"
+PKG_TOOLCHAIN="autotools"
+
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-malloc0returnsnull --without-xmlto"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXRes/package.mk
+++ b/packages/x11/lib/libXRes/package.mk
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-
 PKG_NAME="libXRes"
 PKG_VERSION="860f84072e864832d3a94c365241fe619967b63a"
 PKG_LICENSE="OSS"

--- a/packages/x11/lib/libXRes/package.mk
+++ b/packages/x11/lib/libXRes/package.mk
@@ -11,7 +11,6 @@ PKG_LONGDESC="libXRes - X-Resource extension client library"
 GET_HANDLER_SUPPORT="git"
 PKG_TOOLCHAIN="autotools"
 
-
 PKG_CONFIGURE_OPTS_TARGET="--enable-malloc0returnsnull --without-xmlto"
 
 post_configure_target() {


### PR DESCRIPTION
Initial bring-up of gamescope from the ChimeraOS fork of Valves code.

This is not used by anything currently and is provided for debug/test purposes.

	new file:   packages/graphics/openvr/package.mk
	new file:   packages/wayland/compositor/gamescope/package.mk
	new file:   packages/x11/lib/libXRes/package.mk

Dependencies building fine on sd865