### PR TITLE
run script - fix launch of scripts with spaces in the filename

### DIFF
--- a/packages/rocknix/sources/scripts/run
+++ b/packages/rocknix/sources/scripts/run
@@ -21,8 +21,7 @@ then
 elif echo "${UI_SERVICE}" | grep "sway"; then
   if [ -f "${*}" ]
   then
-    RUN=$(echo ${*} | sed 's# #\\ #g')
-    foot -F ${RUN}  
+    foot -F "${*}"
   else
     foot -F ${*}
   fi


### PR DESCRIPTION
Managed to capture foot logging:
```
RK3588:~/.config/modules # cat /var/log/run.log 
info: main.c:411: version: 1.17.1 -pgo -ime -graphemes -assertions
info: main.c:418: arch: Linux aarch64/64-bit
info: main.c:435: locale: en_US.UTF-8
info: config.c:3236: loading configuration from /etc/xdg/foot/foot.ini
info: fcft.c:338: fcft: 3.1.7 -graphemes -runs +svg(nanosvg) -assertions
info: fcft.c:377: fontconfig: 2.14.2, freetype: 2.13.3
info: fcft.c:840: /usr/share/fonts/liberation/LiberationMono-Regular.ttf: size=8.00pt/8px, dpi=75.00
info: wayland.c:1575: DSI-1: 1080x1920+0x0@60Hz Unknown 0.00" scale=1, DPI=0.00/0.00 (physical/scaled)
 err: slave.c:507: /storage/.config/modules/Start\ PPSSPP.sh: failed to execute: No such file or directory
 err: fdm.c:215: no such FD: 6
info: main.c:656: goodbye
```

It does not like the escaping, but does require quoting.

I think this only affects RK3588 platform at the moment. Is broken in the 20241029 release builds, but not sure if it's worth cherry-picking into `main` and doing some updated RK3588 builds.