### PR TITLE
sway_fullscreen - fix sway window manager check

### DIFF
--- a/packages/rocknix/profile.d/001-functions
+++ b/packages/rocknix/profile.d/001-functions
@@ -205,15 +205,14 @@ function get_aspect_ratio() {
   echo ${ASPECT}
 }
 
-# Utility function to enable fullscreen on a window for an input app_id
+# sway window manager utility function to enable fullscreen on a window for an input app_id
 function sway_fullscreen {
   local APPID="${1}"
   local QUERY_LIMIT=5
   local QUERY_COUNT=0
 
-  if [ -n "$(pgrep sway)" ]; then
-    while [ $QUERY_COUNT -lt $QUERY_LIMIT ]
-    do
+  if echo "${UI_SERVICE}" | grep "sway"; then
+    while [ $QUERY_COUNT -lt $QUERY_LIMIT ]; do
       # loop, attempting to fullscreen window for app_id
       ((QUERY_COUNT++))
 


### PR DESCRIPTION
The existing `pgrep "sway"` check was matching incorrect processes, resulting in `swaymsg: command not found` log noise.

Tested on my ACE, plays nice with both libmali (weston) and panfrost (sway).