### PR TITLE
bdf2psf: bump version 230->232 (fixes a build problem)

### DIFF
--- a/packages/textproc/bdf2psf/package.mk
+++ b/packages/textproc/bdf2psf/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="bdf2psf"
-PKG_VERSION="1.230"
+PKG_VERSION="1.232"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://packages.debian.org/unstable/${PKG_NAME}"
 PKG_URL="https://deb.debian.org/debian/pool/main/c/console-setup/${PKG_NAME}_${PKG_VERSION}_all.deb"


### PR DESCRIPTION
Hi,

this PR bumps the version of bdf2psf from version 230 to 232. It appears that the file for 230 is no longer available, causing a build failure. Bumping the version to either 231 or 232 fixes the build.
The changelog of the  deb indicates that the changes are regarding translations.

I've tested the changes on a RG552, the psfu versions of the spleen font seem to be correctly installed.