### PR TITLE
box86 / box64 - SD865 build profile

### DIFF
--- a/packages/compat/box64/package.mk
+++ b/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="b29e9b706e00f4650cbce4b2c0b6fe27b6cccad4"
+PKG_VERSION="3ba91a651384b0ea4207e91e206440cae2684db2"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"
@@ -14,8 +14,11 @@ PKG_TOOLCHAIN="cmake"
 PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_BUILD_TYPE=Release"
 
 case ${DEVICE} in
-  RK3588|SD865)
+  RK3588)
     PKG_CMAKE_OPTS_TARGET+=" -DRK3588=On"
+  ;;
+  SD865)
+    PKG_CMAKE_OPTS_TARGET+=" -DSD865=On"
   ;;
 esac
 

--- a/packages/compat/box64/package.mk
+++ b/packages/compat/box64/package.mk
@@ -28,7 +28,7 @@ makeinstall_target() {
 
   mkdir -p ${INSTALL}/usr/bin
   cp ${PKG_BUILD}/.${TARGET_NAME}/box64 ${INSTALL}/usr/bin
-  cp ${PKG_BUILD}/tests/bash ${INSTALL}/usr/bin/bash-x64
+  cp ${PKG_BUILD}/tests/box64-bash ${INSTALL}/usr/bin/bash-x64
 
   mkdir -p ${INSTALL}/usr/config
   cp ${PKG_DIR}/config/box64.box64rc ${INSTALL}/usr/config/box64.box64rc

--- a/packages/compat/box86/package.mk
+++ b/packages/compat/box86/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box86"
-PKG_VERSION="a7855d3bcbc59e2952c8231a3c04896cd45301e6"
+PKG_VERSION="ce0b4d1884d75ac774b3390c76316e91867c7638"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box86"
 PKG_URL="${PKG_SITE}.git"
@@ -29,8 +29,11 @@ case ${TARGET_ARCH} in
 esac
 
 case ${DEVICE} in
-  RK3588|SD865)
+  RK3588)
     PKG_CMAKE_OPTS_TARGET+=" -DRK3588=On"
+  ;;
+  SD865)
+    PKG_CMAKE_OPTS_TARGET+=" -DSD865=On"
   ;;
   RK3399)
     PKG_CMAKE_OPTS_TARGET+=" -DRK3399=On"


### PR DESCRIPTION
- bump box86 / box64 packages
- add the SD865 build profile to box86 / box64 packages
- align box64 `/usr/bin/bash-x64` installation with upstream change