### PR TITLE
portmaster - clean up S922X libmali egl hacks

### DIFF
--- a/packages/apps/portmaster/package.mk
+++ b/packages/apps/portmaster/package.mk
@@ -8,7 +8,7 @@ PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/PortMaster.zip"
 COMPAT_URL="https://github.com/ROCKNIX/packages/raw/main/compat.zip"
 PKG_LICENSE="MIT"
 PKG_ARCH="arm aarch64"
-PKG_DEPENDS_TARGET="toolchain rocknix-hotkey gamecontrollerdb wget oga_controls control-gen xmlstarlet list-guid libegl"
+PKG_DEPENDS_TARGET="toolchain rocknix-hotkey gamecontrollerdb wget oga_controls control-gen xmlstarlet list-guid"
 PKG_TOOLCHAIN="manual"
 PKG_LONGDESC="Portmaster - a simple tool that allows you to download various game ports"
 

--- a/packages/apps/portmaster/scripts/portmaster_compatibility.sh
+++ b/packages/apps/portmaster/scripts/portmaster_compatibility.sh
@@ -26,15 +26,5 @@ if [[ "${UI_SERVICE}" =~ "weston.service"|"*sway*" ]]; then
       sed -i '/get_controls && export/c\get_controls' "$port"
       echo Fixing: "$port";
     done;
-  else
-    if [ "${HW_DEVICE}" = "S922X" ]; then
-      #Fixing ports on S922X, exclude FNA games
-      for port in /storage/roms/ports/*.sh; do
-        if ! grep -q FNA "$port"; then
-          sed -i '/get_controls/c\get_controls && export SDL_VIDEO_GL_DRIVER=/usr/lib/egl/libGL.so.1 SDL_VIDEO_EGL_DRIVER=/usr/lib/egl/libEGL.so.1' "$port"
-          echo Fixing: "$port";
-        fi
-      done;
-    fi
   fi
 fi

--- a/packages/apps/portmaster/scripts/start_portmaster.sh
+++ b/packages/apps/portmaster/scripts/start_portmaster.sh
@@ -74,18 +74,5 @@ fi
 /usr/bin/portmaster_compatibility.sh
 
 #Start PortMaster
-export SDL_VIDEO_GL_DRIVER=\/usr\/lib\/egl\/libGL.so.1
-export SDL_VIDEO_EGL_DRIVER=\/usr\/lib\/egl\/libEGL.so.1
-
-# Allow PortMaster GUI to launch on S922X platform with panfrost
-if [ "${HW_DEVICE}" = "S922X" ]; then
-  GPUDRIVER=$(/usr/bin/gpudriver)
-
-  if [ "${GPUDRIVER}" = "panfrost" ]; then
-    unset SDL_VIDEO_GL_DRIVER
-    unset SDL_VIDEO_EGL_DRIVER
-  fi
-fi
-
 cd /storage/roms/ports/PortMaster
 ./PortMaster.sh 2>/dev/null


### PR DESCRIPTION
No longer required - in my testing PortMaster runs fine with libmali on S922X.

Edit: any Ports that are broken at runtime with libmali can be run using the Panfrost driver instead.