### PR TITLE
S922X - use sway for panfrost

### DIFF
--- a/packages/hardware/quirks/platforms/S922X/090-ui_service
+++ b/packages/hardware/quirks/platforms/S922X/090-ui_service
@@ -4,5 +4,14 @@
 
 ### Set the default device configuration
 cat <<EOF >/storage/.config/profile.d/090-ui_service
-UI_SERVICE="weston.service"
+GPUDRIVER=$(/usr/bin/gpudriver)
+
+case \${GPUDRIVER} in
+  "libmali")
+    UI_SERVICE="weston.service"
+  ;;
+  "panfrost")
+     UI_SERVICE="sway.service essway.service"
+  ;;
+esac
 EOF

--- a/packages/rocknix/sources/scripts/run
+++ b/packages/rocknix/sources/scripts/run
@@ -21,9 +21,9 @@ then
 elif echo "${UI_SERVICE}" | grep "sway"; then
   if [ -f "${*}" ]
   then
-    foot -F "${*}"
+    foot "${*}"
   else
-    foot -F ${*}
+    foot ${*}
   fi
 else
   ui_state stop

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -57,7 +57,7 @@
     DISPLAYSERVER="wl"
 
   # Windowmanager to use (weston / swaywm-env / no)
-    WINDOWMANAGER="weston11"
+    WINDOWMANAGER="weston11 swaywm-env"
   
   # build and install rocknix joypad driver (yes / no)
     ROCKNIX_JOYPAD="yes"


### PR DESCRIPTION
Similar to RK3588 platform - use weston11 for libmali-vulkan and sway for panfrost.

With `foot -F` in `packages/rocknix/sources/scripts/run` the wrong window was ending up focused (blank foot terminal instead of the actual launched application). Regression tested on RK3588.