### PR TITLE
Allwinner/linux: drop RG28XX DTB

### DIFF
--- a/projects/Allwinner/bootloader/dtb.xml
+++ b/projects/Allwinner/bootloader/dtb.xml
@@ -4,7 +4,6 @@
     <file>sun50i-h700-anbernic-rg35xx-h</file>
     <file>sun50i-h700-anbernic-rg35xx-sp</file>
     <file>sun50i-h700-anbernic-rg35xx-2024</file>
-    <file>sun50i-h700-anbernic-rg28xx</file>
     <file>sun50i-h700-anbernic-rg40xx-hv</file>
   </H700>
 </dtb>


### PR DESCRIPTION
RG28XX crash very quickly currently, need to investigate