### PR TITLE
Update Art Book Next

### DIFF
--- a/packages/ui/themes/es-theme-art-book-next/package.mk
+++ b/packages/ui/themes/es-theme-art-book-next/package.mk
@@ -11,7 +11,7 @@ PKG_LONGDESC="Art Book Next"
 PKG_TOOLCHAIN="manual"
 
 if [ "${ES_WIP}" ]; then
-  PKG_VERSION="b4d4f573ddb790c397d0a78bef8c35cb4e927464"
+  PKG_VERSION="01f083bd38a34a1b29a514dedac4c35fd285f8bb"
   PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 else
   PKG_VERSION="e1561c28b0a97b5b58303c775d16d357b7b9ede5"


### PR DESCRIPTION
fixed the following in prep for rocknix es-next:
- theme customization path update: ~/roms/_userdata/theme-customizations/
- missing art: palm
- missing art: megadriveh
- broken art: stv logo
- missing art: moto
- missing art: chip-8
- missing art: vircon32