### PR TITLE
Add guide back to mapper.txt

### DIFF
--- a/packages/apps/portmaster/sources/mapper.txt
+++ b/packages/apps/portmaster/sources/mapper.txt
@@ -56,6 +56,7 @@ function map {
     "b")                TR_NAME="${BBUT}";;
     "x")                TR_NAME="${XBUT}";;
     "y")                TR_NAME="${YBUT}";;
+    "hotkeyenable")     TR_NAME="guide";;
     "up")               TR_NAME="dpup";;
     "down")             TR_NAME="dpdown";;
     "left")             TR_NAME="dpleft";;


### PR DESCRIPTION
This enables the use of the home button in gptokeyb for devices that have one like the retroid pocket.