### PR TITLE
S922X - remove modules restrictions

### DIFF
--- a/packages/misc/modules/package.mk
+++ b/packages/misc/modules/package.mk
@@ -34,13 +34,6 @@ post_makeinstall_target() {
     ;;
   esac
 
-  case ${DEVICE} in
-    S922X)
-      rm -f ${INSTALL}/usr/config/modules/*ScummVM*
-      rm -f ${INSTALL}/usr/config/modules/*32bit*
-    ;;
-  esac
-
   if [ ! "${INSTALLER_SUPPORT}" = "yes" ] || \
      [ ! "${DISPLAYSERVER}" = "wl" ]
   then


### PR DESCRIPTION
32-bit libs now included in the build, will work with Panfrost GPU driver