### PR TITLE
Retro* CM5: Set default audio sink in quirks

### DIFF
--- a/packages/hardware/quirks/devices/RetrOLED CM5/050-audio_path
+++ b/packages/hardware/quirks/devices/RetrOLED CM5/050-audio_path
@@ -7,6 +7,7 @@ pactl set-default-sink ${SPEAKER}
 
 cat <<EOF >/storage/.config/profile.d/002-audio_path
 DEVICE_PLAYBACK_PATH="Playback Mux"
+DEFAULT_SINK=${SPEAKER}
 EOF
 
 ### Set sound properties

--- a/packages/hardware/quirks/devices/Retro Lite CM5/050-audio_path
+++ b/packages/hardware/quirks/devices/Retro Lite CM5/050-audio_path
@@ -7,6 +7,7 @@ pactl set-default-sink ${SPEAKER}
 
 cat <<EOF >/storage/.config/profile.d/002-audio_path
 DEVICE_PLAYBACK_PATH="Playback Mux"
+DEFAULT_SINK=${SPEAKER}
 EOF
 
 ### Set sound properties


### PR DESCRIPTION
This works around HDMI sense script picking up the first non-HDMI sink, which sometimes happens to be DP.