### PR TITLE
Add RetroAchievements to Standalone Emulators

### DIFF
--- a/packages/emulators/standalone/aethersx2-sa/package.mk
+++ b/packages/emulators/standalone/aethersx2-sa/package.mk
@@ -21,7 +21,7 @@ makeinstall_target() {
 
   cp -rf ${PKG_BUILD}/usr/share/* ${INSTALL}/usr/share/aethersx2-sa/
 
-  cp -rf ${PKG_DIR}/scripts/start_aethersx2.sh ${INSTALL}/usr/bin
+  cp -rf ${PKG_DIR}/scripts/* ${INSTALL}/usr/bin
   chmod 755 ${INSTALL}/usr/bin/*
 
   mkdir -p ${INSTALL}/usr/config

--- a/packages/emulators/standalone/aethersx2-sa/scripts/cheevos_aethersx2.sh
+++ b/packages/emulators/standalone/aethersx2-sa/scripts/cheevos_aethersx2.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Hector Calvarro (https://github.com/kelvfimer)
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+AETHERSX2_CFG="/storage/.config/aethersx2/inis/PCSX2.ini"
+
+# Extract username and password from emuelec.conf
+username=$(get_setting "global.retroachievements.username")
+password=$(get_setting "global.retroachievements.password")
+token=$(get_setting "global.retroachievements.token")
+
+# Test the token if empty exit 1.
+if [ -z "${token}" ]; then
+    echo "Token is empty you must log in retroachievements first in Emulation Station" > /var/log/cheevos.log
+    exit 1
+fi
+
+# Variables for checking if [Cheevos] or enabled true or false are present.
+zcheevos=$(grep -Fx "[achievements]" ${AETHERSX2_CFG})
+
+if [ -z "${zcheevos}" ]; then
+    sed -i "\$a [Achievements]\nEnabled = true\nUsername = ${username}\nToken = ${token}" ${AETHERSX2_CFG}
+else
+    sed -i '/\[Achievements\]/,/^\s*$/s/Enabled =.*/Enabled = true/' ${AETHERSX2_CFG}
+    if ! grep -q "^UserName = " ${AETHERSX2_CFG}; then
+        sed -i "/^\[Achievements\]/a Username = ${username}" ${AETHERSX2_CFG}
+    else
+        sed -i "/^\[Achievements\]/,/^\[/{s/^Username = .*/Username = ${username}/;}" ${AETHERSX2_CFG}
+    fi
+
+    if ! grep -q "^Token = " ${AETHERSX2_CFG}; then
+        sed -i "/^\[Achievements\]/a Token = ${token}" ${AETHERSX2_CFG}
+    else
+        sed -i "/^\[achievements\]/,/^\[/{s/^Token = .*/Token = ${token}/;}" ${AETHERSX2_CFG}
+    fi
+fi

--- a/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
+++ b/packages/emulators/standalone/aethersx2-sa/scripts/start_aethersx2.sh
@@ -32,6 +32,7 @@ SKIP=$(get_setting ee_cycle_skip "${PLATFORM}" "${GAME}")
 GRENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
 IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
 VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+CHEEVOS=$(get_setting retroachievements "${PLATFORM}" "${GAME}")
 
 #Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
@@ -163,6 +164,13 @@ fi
         then
                 sed -i '/^EECycleSkip =/c\EECycleSkip = 3' /storage/.config/aethersx2/inis/PCSX2.ini
         fi
+
+#Retroachievements
+if [ "$CHEEVOS" = "yes" ]; then
+/usr/bin/cheevos_aethersx2.sh
+else
+  sed -i '/\[Achievements\]/,/^\s*$/s/Enabled =.*/Enabled = false/' /storage/.config/aethersx2/inis/PCSX2.ini
+fi
 
 #Set OpenGL 3.3 on panfrost
   export MESA_GL_VERSION_OVERRIDE=3.3

--- a/packages/emulators/standalone/flycast-sa/package.mk
+++ b/packages/emulators/standalone/flycast-sa/package.mk
@@ -41,5 +41,5 @@ makeinstall_target() {
   cp ${PKG_DIR}/scripts/* ${INSTALL}/usr/bin
   cp -r ${PKG_DIR}/config/${DEVICE}/* ${INSTALL}/usr/config/flycast
 
-  chmod +x ${INSTALL}/usr/bin/start_flycast.sh
+  chmod +x ${INSTALL}/usr/bin/*
 }

--- a/packages/emulators/standalone/flycast-sa/scripts/cheevos_flycast.sh
+++ b/packages/emulators/standalone/flycast-sa/scripts/cheevos_flycast.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Hector Calvarro (https://github.com/kelvfimer)
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+FLYCAST_CFG="/storage/.config/flycast/emu.cfg"
+
+username=$(get_setting "global.retroachievements.username")
+password=$(get_setting "global.retroachievements.password")
+token=$(get_setting "global.retroachievements.token")
+
+# Test the token if empty exit 1.
+if [ -z "${token}" ]; then
+    echo "Token is empty you must log in retroachievements first in Emulation Station" > /var/log/cheevos.log
+    exit 1
+fi
+
+# Variables for checking if [Cheevos] or enabled true or false are present.
+zcheevos=$(grep -Fx "[achievements]" ${FLYCAST_CFG})
+
+if [ -z "${zcheevos}" ]; then
+    sed -i "\$a [achievements]\nEnabled = yes\nUserName = ${username}\nToken = ${token}" ${FLYCAST_CFG}
+else
+    sed -i '/\[achievements\]/,/^\s*$/s/Enabled =.*/Enabled = yes/' ${FLYCAST_CFG}
+    if ! grep -q "^UserName = " ${FLYCAST_CFG}; then
+        sed -i "/^\[achievements\]/a UserName = ${username}" ${FLYCAST_CFG}
+    else
+        sed -i "/^\[achievements\]/,/^\[/{s/^UserName = .*/UserName = ${username}/;}" ${FLYCAST_CFG}
+    fi
+
+    if ! grep -q "^Token = " ${FLYCAST_CFG}; then
+        sed -i "/^\[achievements\]/a Token = ${token}" ${FLYCAST_CFG}
+    else
+        sed -i "/^\[achievements\]/,/^\[/{s/^Token = .*/Token = ${token}/;}" ${FLYCAST_CFG}
+    fi
+fi

--- a/packages/emulators/standalone/flycast-sa/scripts/start_flycast.sh
+++ b/packages/emulators/standalone/flycast-sa/scripts/start_flycast.sh
@@ -34,6 +34,7 @@ FPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
 IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
 RENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
 VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+CHEEVOS=$(get_setting retroachievements "${PLATFORM}" "${GAME}")
 
 #Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
@@ -123,6 +124,13 @@ fi
         then
                 sed -i '/^rend.vsync =/c\rend.vsync = yes' /storage/.config/flycast/emu.cfg
         fi
+
+#Retroachievements
+if [ "$CHEEVOS" = "yes" ]; then
+/usr/bin/cheevos_flycast.sh
+else
+  sed -i '/\[achievements\]/,/^\s*$/s/Enabled =.*/Enabled = no/' /storage/.config/flycast/emu.cfg
+fi
 
 #Run flycast emulator
 ${EMUPERF} /usr/bin/flycast "${1}"

--- a/packages/emulators/standalone/ppsspp-sa/scripts/cheevos_ppsspp.sh
+++ b/packages/emulators/standalone/ppsspp-sa/scripts/cheevos_ppsspp.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Hector Calvarro (https://github.com/kelvfimer)
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+PPSSPP_ACHIEVEMENTS="/storage/.config/ppsspp/PSP/SYSTEM/ppsspp_retroachievements.dat"
+PPSSPP_INI="/storage/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
+
+username=$(get_setting "global.retroachievements.username")
+password=$(get_setting "global.retroachievements.password")
+token=$(get_setting "global.retroachievements.token")
+
+#Test the token if empty exit 1.
+if [ -z "${token}" ]
+then
+      echo "Token is empty you must log in retroachievements first in Emulation Station" > /var/log/cheevos.log
+      exit 1
+fi
+echo "${token}" > ${PPSSPP_ACHIEVEMENTS}
+
+#Variables for checking if [Cheevos] or enabled true or false are presente.
+zcheevos=$(grep -Fx "[Achievements]" ${PPSSPP_INI})
+datets=$(date +%s%N | cut -b1-13)
+
+if ([ -z "${zcheevos}" ])
+then
+    echo -e "[Achievements]\nAchievementsEnable = True\nAchievementsUserName = ${username}\n" >> ${PPSSPP_INI}
+else
+    sed -i '/^AchievementsEnable =/c\AchievementsEnable = True' ${PPSSPP_INI}
+    if ! grep -q "^AchievementsUserName = " ${PPSSPP_INI}; then
+        sed -i "/^\[Achievements\]/a AchievementsUserName = ${username}" ${PPSSPP_INI}
+    else
+        sed -i "/^\[Achievements\]/,/^\[/{s/^AchievementsUserName = .*/AchievementsUserName = ${username}/;}" ${PPSSPP_INI}
+    fi
+fi

--- a/packages/emulators/standalone/ppsspp-sa/scripts/start_ppsspp.sh
+++ b/packages/emulators/standalone/ppsspp-sa/scripts/start_ppsspp.sh
@@ -22,6 +22,7 @@ IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
 GRENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
 SKIPB=$(get_setting skip_buffer_effects "${PLATFORM}" "${GAME}")
 VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+CHEEVOS=$(get_setting retroachievements "${PLATFORM}" "${GAME}")
 
 #Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
@@ -127,6 +128,14 @@ fi
         then
                 sed -i '/^VSyncInterval =/c\VSyncInterval = True' ${CONF_DIR}/${PPSSPP_INI}
         fi
+
+#Retroachievements
+if [ "$CHEEVOS" = "yes" ]; then
+/usr/bin/cheevos_ppsspp.sh
+else
+  sed -i '/^AchievementsEnable =/c\AchievementsEnable = False' ${CONF_DIR}/${PPSSPP_INI}
+fi
+
 
 ARG=${1//[\\]/}
 

--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -342,6 +342,10 @@
         <choice name="3x" value="3"/>
         <choice name="4x" value="4"/>
       </feature>
+      <feature name="retroachievements">
+        <choice name="yes" value="yes"/>
+        <choice name="no" value="no"/>
+      </feature>
       <feature name="show fps">
         <choice name="yes" value="1"/>
         <choice name="no" value="0"/>
@@ -383,6 +387,10 @@
         <choice name="2x (960P)" value="3"/>
         <choice name="2.5x (1200P)" value="4"/>
         <choice name="3x (1440P)" value="5"/>
+      </feature>
+      <feature name="retroachievements">
+        <choice name="yes" value="yes"/>
+        <choice name="no" value="no"/>
       </feature>
       <feature name="show fps">
         <choice name="yes" value="1"/>
@@ -740,6 +748,10 @@
         <choice name="2.5x" value="2.5"/>
         <choice name="2.75x" value="2.75"/>
         <choice name="3x (1080p)" value="3"/>
+      </feature>
+      <feature name="retroachievements">
+        <choice name="yes" value="yes"/>
+        <choice name="no" value="no"/>
       </feature>
       <feature name="show fps">
         <choice name="yes" value="true"/>

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="4e324e1336764e08e50451406fa1443c686742ef"
+PKG_VERSION="8af0be8f1d03c7a258ed59769b5c44c719d1b7fb"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation"


### PR DESCRIPTION
This integrates RetroAchievements into several standalone emulators, uses the ES RetroAchievements token to generate configs.

Supported emulators:
*Flycast SA
*AtherSX2 SA
*PPSSPP SA

Sources:
EmulationStation Changes:  https://github.com/batocera-linux/batocera-emulationstation/commit/f747a4d277d84592ead9bedd8dd6954fb4f57ae7
Scripts: https://github.com/EmuELEC/EmuELEC/commit/b295f809be262514ee39bc78c8b3bfd3bc94e26e