### PR TITLE
mednafen: wip s922x and s865

### DIFF
--- a/packages/emulators/standalone/mednafen/package.mk
+++ b/packages/emulators/standalone/mednafen/package.mk
@@ -10,16 +10,16 @@ PKG_DEPENDS_TARGET="toolchain SDL2 flac"
 PKG_TOOLCHAIN="configure"
 
 case ${DEVICE} in
-  H700)
+  H700|SD865)
     PKG_PATCH_DIRS+=" sdl-input"
   ;;
 esac
 
 pre_configure_target() {
 
-export CFLAGS="${CFLAGS} -flto -fipa-pta"
-export CXXFLAGS="${CXXFLAGS} -flto -fipa-pta"
-export LDFLAGS="${LDFLAGS} -flto -fipa-pta"
+export CFLAGS="${CFLAGS} -flto -fipa-pta --param max-gcse-memory=256351"
+export CXXFLAGS="${CXXFLAGS} -flto -fipa-pta --param max-gcse-memory=256351"
+export LDFLAGS="${LDFLAGS} -flto -fipa-pta --param max-gcse-memory=256351"
 
 # unsupported modules
 DISABLED_MODULES+=" --disable-apple2 \
@@ -34,6 +34,10 @@ case ${DEVICE} in
   ;;
   RK3588*)
     DISABLED_MODULES+=" --disable-snes"
+  ;;
+  S922X)
+    DISABLED_MODULES+="  --disable-ss \
+			 --disable-snes"
   ;;
 esac
 

--- a/packages/emulators/standalone/mednafen/scripts/mednafen_gen_config.sh
+++ b/packages/emulators/standalone/mednafen/scripts/mednafen_gen_config.sh
@@ -152,6 +152,40 @@ done
 
 fi
 
+# Retroid pocket has analog triggers, set them before mapping the rest of the GPIO controller
+if [[ "${NAME}" = "PocketGamepad" ]]
+then
+
+DEVICE_BTN_TL2="abs_4+"
+DEVICE_BTN_TR2="abs_5+"
+# No other GPIO device has analog triggers (I think), Just set them to the same
+DEVICE_BTN_TL2_MINUS=${DEVICE_BTN_TL2}
+DEVICE_BTN_TR2_MINUS=${DEVICE_BTN_TR2}
+
+# Left analog
+DEVICE_BTN_AL_DOWN="abs_1+"
+DEVICE_BTN_AL_UP="abs_1-"
+DEVICE_BTN_AL_LEFT="abs_0-"
+DEVICE_BTN_AL_RIGHT="abs_0+"
+
+# Right analog
+DEVICE_BTN_AR_DOWN="abs_3+"
+DEVICE_BTN_AR_UP="abs_3-"
+DEVICE_BTN_AR_LEFT="abs_4-"
+DEVICE_BTN_AR_RIGHT="abs_4+"
+
+
+for CONTROL in DEVICE_BTN_TL2 DEVICE_BTN_TR2    \
+               DEVICE_BTN_TL2_MINUS DEVICE_BTN_TR2_MINUS \
+               DEVICE_BTN_AL_DOWN DEVICE_BTN_AL_UP DEVICE_BTN_AL_LEFT    \
+               DEVICE_BTN_AL_RIGHT DEVICE_BTN_AR_DOWN DEVICE_BTN_AR_UP   \
+               DEVICE_BTN_AR_LEFT DEVICE_BTN_AR_RIGHT
+do
+    sed -i -e "s/@${CONTROL}@/${!CONTROL}/g" $MEDNAFEN_HOME/mednafen.cfg
+done
+
+fi
+
 # These are the inputs prefixed with button_
 for CONTROL in DEVICE_BTN_SOUTH DEVICE_BTN_EAST DEVICE_BTN_NORTH         \
                DEVICE_BTN_WEST DEVICE_BTN_TL DEVICE_BTN_TR               \

--- a/packages/emulators/standalone/mednafen/scripts/start_mednafen.sh
+++ b/packages/emulators/standalone/mednafen/scripts/start_mednafen.sh
@@ -40,6 +40,9 @@ then
   if [ "${HW_DEVICE}" = "RK3588" ]; then
     FEATURES_CMDLINE+=" -affinity.emu 0x30 "
     FEATURES_CMDLINE+=" -ss.affinity.vdp2 0xc0 "
+  elif [ "${HW_DEVICE}" = "SD865" ]; then
+    FEATURES_CMDLINE+=" -affinity.emu 0x40 "
+    FEATURES_CMDLINE+=" -ss.affinity.vdp2 0x80 "
   fi
 else
   ### All..

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -8,7 +8,7 @@ PKG_SECTION="emulation" # Do not change to virtual or makeinstall_target will no
 PKG_LONGDESC="Emulation metapackage."
 PKG_TOOLCHAIN="manual"
 
-PKG_EMUS="amiberry flycast-sa gzdoom-sa hatarisa hypseus-singe moonlight mupen64plus-sa openbor pico-8 ppsspp-sa vice-sa"
+PKG_EMUS="amiberry flycast-sa gzdoom-sa hatarisa hypseus-singe moonlight mupen64plus-sa openbor pico-8 ppsspp-sa vice-sa mednafen"
 
 PKG_RETROARCH="core-info libretro-database retroarch retroarch-assets retroarch-joypads retroarch-overlays slang-shaders"
 
@@ -29,26 +29,26 @@ LIBRETRO_CORES="81-lr a5200-lr arduous-lr atari800-lr beetle-gba-lr beetle-lynx-
 case "${DEVICE}" in
   AMD64)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="wine"
-    PKG_EMUS+=" cemu-sa dolphin-sa lime3ds-sa mednafen melonds-sa minivmacsa mupen64plus-sa nanoboyadvance-sa pcsx2-sa     \
+    PKG_EMUS+=" cemu-sa dolphin-sa lime3ds-sa melonds-sa minivmacsa mupen64plus-sa nanoboyadvance-sa pcsx2-sa     \
                rpcs3-sa scummvmsa vita3k-sa xemu-sa"
     LIBRETRO_CORES+=" beetle-psx-lr beetle-saturn-lr bsnes-lr bsnes-hd-lr desmume-lr dolphin-lr flycast-lr lrps2-lr play-lr"
   ;;
   RK3588)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 desmume-lr gpsp-lr pcsx_rearmed-lr wine"
-    PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa mednafen melonds-sa portmaster scummvmsa supermodel-sa yabasanshiro-sa"
+    PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa melonds-sa portmaster scummvmsa supermodel-sa yabasanshiro-sa"
     LIBRETRO_CORES+=" beetle-psx-lr beetle-saturn-lr bsnes-lr bsnes-hd-lr dolphin-lr flycast-lr geolith-lr panda3ds-lr pcsx_rearmed-lr uae4arm"
     PKG_RETROARCH+=" retropie-shaders"
   ;;
   RK3399)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 desmume-lr gpsp-lr pcsx_rearmed-lr"
-    PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa mednafen melonds-sa nanoboyadvance-sa portmaster scummvmsa yabasanshiro-sa"
+    PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa melonds-sa nanoboyadvance-sa portmaster scummvmsa yabasanshiro-sa"
     LIBRETRO_CORES+=" beetle-psx-lr bsnes-lr bsnes-hd-lr dolphin-lr geolith-lr flycast-lr pcsx_rearmed-lr uae4arm"
     PKG_RETROARCH+=" retropie-shaders"
   ;;
   RK3566*)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 desmume-lr gpsp-lr pcsx_rearmed-lr wine"
     PKG_DEPENDS_TARGET+=" common-shaders glsl-shaders"
-    PKG_EMUS+=" box64 dolphin-sa drastic-sa mednafen melonds-sa portmaster scummvmsa yabasanshiro-sa"
+    PKG_EMUS+=" box64 dolphin-sa drastic-sa melonds-sa portmaster scummvmsa yabasanshiro-sa"
     LIBRETRO_CORES+=" dolphin-lr flycast-lr geolith-lr uae4arm"
     PKG_RETROARCH+=" retropie-shaders"
   ;;
@@ -61,14 +61,14 @@ case "${DEVICE}" in
   RK3326)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 desmume-lr gpsp-lr pcsx_rearmed-lr wine"
     PKG_DEPENDS_TARGET+=" common-shaders glsl-shaders"
-    PKG_EMUS+=" box64 drastic-sa mednafen portmaster scummvmsa yabasanshiro-sa"
+    PKG_EMUS+=" box64 drastic-sa portmaster scummvmsa yabasanshiro-sa"
     LIBRETRO_CORES+=" flycast-lr flycast2021-lr geolith-lr uae4arm"
     PKG_RETROARCH+=" retropie-shaders"
   ;;
   H700)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 desmume-lr gpsp-lr pcsx_rearmed-lr wine"
     PKG_DEPENDS_TARGET+=" common-shaders glsl-shaders"
-    PKG_EMUS+=" box64 drastic-sa mednafen portmaster scummvmsa yabasanshiro-sa"
+    PKG_EMUS+=" box64 drastic-sa portmaster scummvmsa yabasanshiro-sa"
     LIBRETRO_CORES+=" flycast-lr flycast2021-lr geolith-lr uae4arm"
     PKG_RETROARCH+=" retropie-shaders"
   ;;
@@ -361,11 +361,7 @@ makeinstall_target() {
   add_emu_core famicom retroarch fceumm false
   add_emu_core famicom retroarch quicknes false
   add_emu_core famicom retroarch mesen false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core famicom mednafen nes false
-    ;;
-  esac
+  add_emu_core famicom mednafen nes false
   add_es_system famicom
 
   ### Nintendo Famicom Disk System
@@ -373,11 +369,7 @@ makeinstall_target() {
   add_emu_core fds retroarch fceumm false
   add_emu_core fds retroarch quicknes false
   add_emu_core fds retroarch mesen false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core fds mednafen nes false
-    ;;
-  esac
+  add_emu_core fds mednafen nes false
   add_es_system fds
 
   ### Final Burn Neo
@@ -412,11 +404,7 @@ makeinstall_target() {
   add_emu_core gb retroarch mgba false
   add_emu_core gb retroarch vbam false
   add_emu_core gb retroarch DoubleCherryGB false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core gb mednafen gb false
-    ;;
-  esac
+  add_emu_core gb mednafen gb false
   add_es_system gb
 
   ### Nintendo GameBoy Hacks
@@ -427,11 +415,7 @@ makeinstall_target() {
   add_emu_core gbh retroarch mgba false
   add_emu_core gbh retroarch vbam false
   add_emu_core gbh retroarch DoubleCherryGB false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core gbh mednafen gb false
-    ;;
-  esac
+  add_emu_core gbh mednafen gb false
   add_es_system gbh
 
   ### Nintendo GameBoy Advance
@@ -451,11 +435,7 @@ makeinstall_target() {
       add_emu_core gba nanoboyadvance nanoboyadvance-sa false
     ;;
   esac
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core gba mednafen gba false
-    ;;
-  esac
+  add_emu_core gba mednafen gba false
   add_es_system gba
 
   ### Nintendo GameBoy Advance Hacks
@@ -463,11 +443,7 @@ makeinstall_target() {
   add_emu_core gbah retroarch vbam false
   add_emu_core gbah retroarch vba_next false
   add_emu_core gbah retroarch beetle_gba false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core gbah mednafen gba false
-    ;;
-  esac
+  add_emu_core gbah mednafen gba false
   add_es_system gbah
 
   ### Nintendo GameBoy Color
@@ -478,11 +454,7 @@ makeinstall_target() {
   add_emu_core gbc retroarch mgba false
   add_emu_core gbc retroarch vbam false
   add_emu_core gbc retroarch DoubleCherryGB false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core gbc mednafen gb false
-    ;;
-  esac
+  add_emu_core gbc mednafen gb false
   add_es_system gbc
 
   ### Nintendo GameBoy Color Hacks
@@ -493,11 +465,7 @@ makeinstall_target() {
   add_emu_core gbch retroarch mgba false
   add_emu_core gbch retroarch vbam false
   add_emu_core gbch retroarch DoubleCherryGB false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core gbch mednafen gb false
-    ;;
-  esac
+  add_emu_core gbch mednafen gb false
   add_es_system gbch
 
   ### Nintendo GameCube
@@ -544,11 +512,7 @@ makeinstall_target() {
   add_emu_core gamegear retroarch genesis_plus_gx false
   add_emu_core gamegear retroarch picodrive false
   add_emu_core gamegear retroarch smsplus false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core gamegear mednafen gg false
-    ;;
-  esac
+  add_emu_core gamegear mednafen gg false
   add_es_system gamegear
 
   ### Sega GameGear Hacks
@@ -556,11 +520,7 @@ makeinstall_target() {
   add_emu_core ggh retroarch genesis_plus_gx false
   add_emu_core ggh retroarch picodrive false
   add_emu_core ggh retroarch smsplus false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core ggh mednafen gg false
-    ;;
-  esac
+  add_emu_core ggh mednafen gg false
   add_es_system ggh
 
   ### Intellivision
@@ -578,11 +538,7 @@ makeinstall_target() {
   ### Atari Lynx
   add_emu_core atarilynx retroarch handy true
   add_emu_core atarilynx retroarch beetle_lynx false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core atarilynx mednafen lynx false
-    ;;
-  esac
+  add_emu_core atarilynx mednafen lynx false
   add_es_system atarilynx
 
   ### Infocom Z-Machine
@@ -603,11 +559,7 @@ makeinstall_target() {
   add_emu_core megadrive-japan retroarch genesis_plus_gx true
   add_emu_core megadrive-japan retroarch genesis_plus_gx_wide false
   add_emu_core megadrive-japan retroarch picodrive
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core megadrive-japan mednafen md false
-    ;;
-  esac
+  add_emu_core megadrive-japan mednafen md false
   add_es_system megadrive-japan
 
   ### Sega Model 3
@@ -626,11 +578,7 @@ makeinstall_target() {
   ### Nintendo MSU-1
   add_emu_core snesmsu1 retroarch snes9x true
   add_emu_core snesmsu1 retroarch beetle_supafaust false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core snesmsu1 mednafen snes_faust false
-    ;;
-  esac
+  add_emu_core snesmsu1 mednafen snes_faust false
   add_es_system snesmsu1
 
   ### Microsoft MSX
@@ -691,21 +639,13 @@ makeinstall_target() {
   ### SNK NeoGeo Pocket
   add_emu_core ngp retroarch beetle_ngp true
   add_emu_core ngp retroarch race false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core ngp mednafen ngp false
-    ;;
-  esac
+  add_emu_core ngp mednafen ngp false
   add_es_system ngp
 
   ### SNK NeoGeo Pocket Color
   add_emu_core ngpc retroarch beetle_ngp true
   add_emu_core ngpc retroarch race false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core ngpc mednafen ngp false
-    ;;
-  esac
+  add_emu_core ngpc mednafen ngp false
   add_es_system ngpc
 
   ### Nintendo 64
@@ -759,11 +699,7 @@ makeinstall_target() {
   add_emu_core nes retroarch fceumm false
   add_emu_core nes retroarch quicknes false
   add_emu_core nes retroarch mesen false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core nes mednafen nes false
-    ;;
-  esac
+  add_emu_core nes mednafen nes false
   add_es_system nes
 
   ### Nintendo NES Hacks
@@ -771,11 +707,7 @@ makeinstall_target() {
   add_emu_core nesh retroarch fceumm false
   add_emu_core nesh retroarch quicknes false
   add_emu_core nesh retroarch mesen false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core nesh mednafen nesh false
-    ;;
-  esac
+  add_emu_core nesh mednafen nesh false
   add_es_system nesh
 
   ### Magnavox Odyssey
@@ -798,33 +730,21 @@ makeinstall_target() {
   add_emu_core pcengine retroarch beetle_pce_fast true
   add_emu_core pcengine retroarch beetle_pce false
   add_emu_core pcengine retroarch beetle_supergrafx false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core pcengine mednafen pce false
-      add_emu_core pcengine mednafen pce_fast false
-    ;;
-  esac
+  add_emu_core pcengine mednafen pce false
+  add_emu_core pcengine mednafen pce_fast false
   add_es_system pcengine
 
   ### NEC PC Engine CD
   add_emu_core pcenginecd retroarch beetle_pce_fast true
   add_emu_core pcenginecd retroarch beetle_pce false
   add_emu_core pcenginecd retroarch beetle_supergrafx false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core pcenginecd mednafen pce false
-      add_emu_core pcenginecd mednafen pce_fast false
-    ;;
-  esac
+  add_emu_core pcenginecd mednafen pce false
+  add_emu_core pcenginecd mednafen pce_fast false
   add_es_system pcenginecd
 
   ### NEC PC-FX
   add_emu_core pcfx retroarch beetle_pcfx true
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core pcfx mednafen pcfx false
-    ;;
-  esac
+  add_emu_core pcfx mednafen pcfx false
   add_es_system pcfx
 
   ### Lexaloffle PICO-8
@@ -852,6 +772,7 @@ makeinstall_target() {
       add_emu_core psx retroarch pcsx_rearmed32 true
       add_emu_core psx retroarch pcsx_rearmed false
       add_emu_core psx retroarch beetle_psx false
+      add_emu_core psx mednafen psx false
     ;;
     RK3566*)
       add_emu_core psx retroarch pcsx_rearmed32 true
@@ -942,22 +863,14 @@ makeinstall_target() {
   add_emu_core genesis retroarch genesis_plus_gx true
   add_emu_core genesis retroarch genesis_plus_gx_wide false
   add_emu_core genesis retroarch picodrive false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core genesis mednafen md false
-    ;;
-  esac
+  add_emu_core genesis mednafen md false
   add_es_system genesis
 
   ### Sega Genesis Hacks
   add_emu_core genh retroarch genesis_plus_gx true
   add_emu_core genh retroarch genesis_plus_gx_wide false
   add_emu_core genh retroarch picodrive false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core genh mednafen md false
-    ;;
-  esac
+  add_emu_core genh mednafen md false
   add_es_system genh
 
   ### Sega MasterSystem
@@ -965,33 +878,21 @@ makeinstall_target() {
   add_emu_core mastersystem retroarch genesis_plus_gx false
   add_emu_core mastersystem retroarch picodrive false
   add_emu_core mastersystem retroarch smsplus false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core mastersystem mednafen sms false
-    ;;
-  esac
+  add_emu_core mastersystem mednafen sms false
   add_es_system mastersystem
 
   ### Sega MegaDrive
   add_emu_core megadrive retroarch genesis_plus_gx true
   add_emu_core megadrive retroarch genesis_plus_gx_wide false
   add_emu_core megadrive retroarch picodrive false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core megadrive mednafen md false
-    ;;
-  esac
+  add_emu_core megadrive mednafen md false
   add_es_system megadrive
 
   ### Sega MegaDrive Hacks
   add_emu_core megadriveh retroarch genesis_plus_gx true
   add_emu_core megadriveh retroarch genesis_plus_gx_wide false
   add_emu_core megadriveh retroarch picodrive false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core megadriveh mednafen md false
-    ;;
-  esac
+  add_emu_core megadriveh mednafen md false
   add_es_system megadriveh
 
   ### Welback Holdings Mega Duck
@@ -1026,7 +927,7 @@ makeinstall_target() {
 
   ### Sega ST-V
   case ${DEVICE} in
-    RK3588*|AMD64)
+    RK3588*|AMD64|SD865)
       add_emu_core st-v mednafen ss true
     ;;
   esac
@@ -1062,12 +963,8 @@ makeinstall_target() {
   ### NEC Super Grafx
   add_emu_core supergrafx retroarch beetle_supergrafx
   add_emu_core supergrafx retroarch beetle_pce
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core supergrafx mednafen pce false
-      add_emu_core supergrafx mednafen pce_fast false
-    ;;
-  esac
+  add_emu_core supergrafx mednafen pce false
+  add_emu_core supergrafx mednafen pce_fast false
   add_es_system supergrafx
 
   ### Nintendo SNES
@@ -1085,14 +982,11 @@ makeinstall_target() {
       add_emu_core snes retroarch bsnes_hd_beta false
 	;;
   esac
+  add_emu_core snes mednafen snes_faust false
   case ${DEVICE} in
-    AMD64)
-      add_emu_core snes mednafen snes_faust false
+    AMD64|SD865|RK3588)
       add_emu_core snes mednafen snes false
     ;;
-    RK33*|RK35*|H700)
-      add_emu_core snes mednafen snes_faust false
-	;;
   esac
   add_es_system snes
 
@@ -1111,14 +1005,11 @@ makeinstall_target() {
       add_emu_core snesh retroarch bsnes_hd_beta false
 	;;
   esac
+  add_emu_core snesh mednafen snes_faust false
   case ${DEVICE} in
-    AMD64)
+    AMD64|RK3588|SD865)
       add_emu_core snesh mednafen snes false
-      add_emu_core snesh mednafen snes_faust false
     ;;
-    RK3*|H700)
-      add_emu_core snesh mednafen snes_faust false
-	;;
   esac
   add_es_system snesh
 
@@ -1137,14 +1028,11 @@ makeinstall_target() {
       add_emu_core sfc retroarch bsnes_hd_beta false
 	;;
   esac
+  add_emu_core sfc mednafen snes_faust false
   case ${DEVICE} in
-    AMD64)
+    AMD64|RK3588|SD865)
       add_emu_core sfc mednafen snes false
-      add_emu_core sfc mednafen snes_faust false
     ;;
-    RK3*|H700)
-      add_emu_core snes mednafen snes_faust false
-	;;
   esac
   add_es_system sfc
 
@@ -1175,24 +1063,16 @@ makeinstall_target() {
   add_emu_core tg16 retroarch beetle_pce_fast true
   add_emu_core tg16 retroarch beetle_pce false
   add_emu_core tg16 retroarch beetle_supergrafx false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core tg16 mednafen pce false
-      add_emu_core tg16 mednafen pce_fast false
-    ;;
-  esac
+  add_emu_core tg16 mednafen pce false
+  add_emu_core tg16 mednafen pce_fast false
   add_es_system tg16
 
   ### NEC TurboGrafx CD
   add_emu_core tg16cd retroarch beetle_pce_fast true
   add_emu_core tg16cd retroarch beetle_pce false
   add_emu_core tg16cd retroarch beetle_supergrafx false
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core tg16cd mednafen pce false
-      add_emu_core tg16cd mednafen pce_fast false
-    ;;
-  esac
+  add_emu_core tg16cd mednafen pce false
+  add_emu_core tg16cd mednafen pce_fast false
   add_es_system tg16cd
 
   ### Belogic Uzebox
@@ -1213,29 +1093,17 @@ makeinstall_target() {
 
   ### Nintendo VirtualBoy
   add_emu_core virtualboy retroarch beetle_vb true
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core virtualboy mednafen vb false
-    ;;
-  esac
+  add_emu_core virtualboy mednafen vb false
   add_es_system virtualboy
 
   ### Bandai Wonderswan
   add_emu_core wonderswan retroarch beetle_wswan true
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core wonderswan mednafen wswan false
-    ;;
-  esac
+  add_emu_core wonderswan mednafen wswan false
   add_es_system wonderswan
 
   ### Bandai Wonderswan Color
   add_emu_core wonderswancolor retroarch beetle_wswan true
-  case ${DEVICE} in
-    RK3399|AMD64|RK3326|RK3588*|RK356*|H700)
-      add_emu_core wonderswancolor mednafen wswan false
-    ;;
-  esac
+  add_emu_core wonderswancolor mednafen wswan false
   add_es_system wonderswancolor
 
   ### Sharp x68000


### PR DESCRIPTION
I get no sound on SD865, and controls needs some further tuning.

S922X may have some issues with the GL renderer, but I have no s922x on hand yet. 

Additionally there is performance regression, also in last release. Happens on rk3588 and sd865 but not rk3566. Fps drops as times goes, but performs normally if you disable sound in mednafen config

Feel free to pick it up, I am not going to have time in the coming week.
