### PR TITLE
SD865: Hack to set fan speed to only 25% at boot

### DIFF
--- a/projects/Qualcomm/patches/linux/SD865/9997-set-boot-fanspeed.patch
+++ b/projects/Qualcomm/patches/linux/SD865/9997-set-boot-fanspeed.patch
@@ -1,0 +1,12 @@
+diff -rupbN linux.orig/drivers/hwmon/pwm-fan.c linux/drivers/hwmon/pwm-fan.c
+--- linux.orig/drivers/hwmon/pwm-fan.c	2024-10-19 13:35:29.516991617 +0000
++++ linux/drivers/hwmon/pwm-fan.c	2024-11-18 15:41:47.343729846 +0000
+@@ -530,7 +530,7 @@ static int pwm_fan_probe(struct platform
+ 	 * Set duty cycle to maximum allowed and enable PWM output as well as
+ 	 * the regulator. In case of error nothing is changed
+ 	 */
+-	ret = set_pwm(ctx, MAX_PWM);
++	ret = set_pwm(ctx, 70);
+ 	if (ret) {
+ 		dev_err(dev, "Failed to configure PWM: %d\n", ret);
+ 		return ret;


### PR DESCRIPTION
This has no effect on the actual user space fan control. 