### PR TITLE
Fix headphone jack garbled audio - Retro* CM5 Devices

### DIFF
--- a/packages/hardware/quirks/devices/RetrOLED CM5/050-audio_path
+++ b/packages/hardware/quirks/devices/RetrOLED CM5/050-audio_path
@@ -17,4 +17,5 @@ amixer -c 0 -q cset name='Speaker DC Volume' 5
 amixer -c 0 -q cset name='Speaker AC Volume' 5
 amixer -c 0 -q cset name='Left Output Mixer PCM Playback Switch' on
 amixer -c 0 -q cset name='Right Output Mixer PCM Playback Switch' on
+amixer -c 0 -q cset name='DAC Polarity' 'Left Inverted'
 

--- a/packages/hardware/quirks/devices/Retro Lite CM5/050-audio_path
+++ b/packages/hardware/quirks/devices/Retro Lite CM5/050-audio_path
@@ -17,4 +17,5 @@ amixer -c 0 -q cset name='Speaker DC Volume' 5
 amixer -c 0 -q cset name='Speaker AC Volume' 5
 amixer -c 0 -q cset name='Left Output Mixer PCM Playback Switch' on
 amixer -c 0 -q cset name='Right Output Mixer PCM Playback Switch' on
+amixer -c 0 -q cset name='DAC Polarity' 'Left Inverted'
 


### PR DESCRIPTION
Fixes garbled audio through the headphone jack on Retro Lite/LED CM5 devices. 