### PR TITLE
emulators - remove nonexistent gbsp core, add gpsp for S922X

### DIFF
--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -436,12 +436,11 @@ makeinstall_target() {
 
   ### Nintendo GameBoy Advance
   add_emu_core gba retroarch mgba true
-  add_emu_core gba retroarch gbsp false
   add_emu_core gba retroarch vbam false
   add_emu_core gba retroarch vba_next false
   add_emu_core gba retroarch beetle_gba false
   case ${DEVICE} in
-    RK356*|RK3326|H700|SD865)
+    RK356*|RK3326|H700|S922X|SD865)
       add_emu_core gba retroarch gpsp false
     ;;
     RK3399|RK3588*)
@@ -461,7 +460,6 @@ makeinstall_target() {
 
   ### Nintendo GameBoy Advance Hacks
   add_emu_core gbah retroarch mgba true
-  add_emu_core gbah retroarch gbsp false
   add_emu_core gbah retroarch vbam false
   add_emu_core gbah retroarch vba_next false
   add_emu_core gbah retroarch beetle_gba false


### PR DESCRIPTION
Attempting to use the `gbsp` emulator option in ES on my OGU and ACE results in error:
```
[ERROR] [Core]: Frontend is built for dynamic libretro cores, but path is not set. Cannot continue.
[ERROR] Fatal error received in: "init_libretro_symbols()"
```