### PR TITLE
Fix Qt6

### DIFF
--- a/packages/graphics/qt6/package.mk
+++ b/packages/graphics/qt6/package.mk
@@ -119,7 +119,9 @@ pre_configure_target(){
                            -DQT_GENERATE_SBOM=OFF"
 }
 
-makeinstall_target() {
+post_makeinstall_target() {
+  rm -rf ${INSTALL}/usr
+
   mkdir -p ${INSTALL}/usr/lib
   mkdir -p ${INSTALL}/usr/plugins
   mkdir -p ${INSTALL}/usr/qml


### PR DESCRIPTION
We need to install qt6 files to the toolchain for build dependencies. But we only need to include libs, plugins, qml.