### PR TITLE
Update hotkey for "pause emulation" on Mupen64-SA on ARC-S

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3566/mupen64plus.cfg.rgarc
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3566/mupen64plus.cfg.rgarc
@@ -128,7 +128,7 @@ Joy Mapping Speed Up = ""
 # Joystick event string for taking a screenshot
 Joy Mapping Screenshot = "J0B8/B3"
 # Joystick event string for pausing the emulator
-Joy Mapping Pause = "J0B12/B1"
+Joy Mapping Pause = "J0B8/B1"
 # Joystick event string for muting/unmuting the sound
 Joy Mapping Mute = ""
 # Joystick event string for increasing the volume


### PR DESCRIPTION
Change the "pause emulation" hotkey from "UP+A" to "L2+A" to match all the other hotkeys that start with "L2+key"

The [wiki](https://rocknix.org/devices/anbernic/rgarc/#mupen64plus-sa-nintendo-64) lists mappings for the emulator but they are not correct. Here is the actual list with working hotkeys mapped in the configuration files:

```
Save state:
L2+Z

Load State:
L2+Y

Reset:
L2+B

Screenshot
L2+X

Pause:
Up+A

Fast-Forward:
L2+R1

"# Joystick event string for pressing the game shark button"
L2+C

Quit emulator:
L2+R2
```

