### PR TITLE
Allwinner/u-boot: workaround memory detection

### DIFF
--- a/projects/Allwinner/packages/u-boot/package.mk
+++ b/projects/Allwinner/packages/u-boot/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="u-boot"
-PKG_VERSION="v2025.01-rc1"
+PKG_VERSION="v2025.01-rc3"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
 PKG_URL="https://github.com/u-boot/u-boot/archive/${PKG_VERSION}.tar.gz"

--- a/projects/Allwinner/packages/u-boot/patches/0002-loop-until-detected-size-is-1Gb.patch
+++ b/projects/Allwinner/packages/u-boot/patches/0002-loop-until-detected-size-is-1Gb.patch
@@ -1,0 +1,35 @@
+From 151a9b80df1dd69d8e83c6d70a20637cbc1518ad Mon Sep 17 00:00:00 2001
+From: Philippe Simons <simons.philippe@gmail.com>
+Date: Sat, 30 Nov 2024 17:47:02 +0100
+Subject: [PATCH] loop until detected size is 1Gb
+
+---
+ arch/arm/mach-sunxi/dram_sun50i_h616.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/mach-sunxi/dram_sun50i_h616.c b/arch/arm/mach-sunxi/dram_sun50i_h616.c
+index 863c4f1d7a..70dd22f6d7 100644
+--- a/arch/arm/mach-sunxi/dram_sun50i_h616.c
++++ b/arch/arm/mach-sunxi/dram_sun50i_h616.c
+@@ -1431,12 +1431,14 @@ unsigned long sunxi_dram_init(void)
+ 	setbits_le32(&prcm->res_cal_ctrl, BIT(8));
+ 	clrbits_le32(&prcm->ohms240, 0x3f);
+ 
+-	mctl_auto_detect_rank_width(&para, &config);
+-	mctl_auto_detect_dram_size(&para, &config);
++	do {
++		mctl_auto_detect_rank_width(&para, &config);
++		mctl_auto_detect_dram_size(&para, &config);
+ 
+-	mctl_core_init(&para, &config);
++		mctl_core_init(&para, &config);
+ 
+-	size = mctl_calc_size(&config);
++		size = mctl_calc_size(&config);
++	} while (size != 1024 * 1024 * 1024);
+ 
+ 	mctl_set_master_priority();
+ 
+-- 
+2.47.1
+


### PR DESCRIPTION
loop sunxi_dram_init until 1Gb is detected