### PR TITLE
S922X - lime3ds-sa config - enable shaders_accurate_mul

### DIFF
--- a/packages/emulators/standalone/lime3ds-sa/config/S922X/sdl2-config.ini
+++ b/packages/emulators/standalone/lime3ds-sa/config/S922X/sdl2-config.ini
@@ -103,7 +103,7 @@ use_hw_shader =
 
 # Whether to use accurate multiplication in hardware shaders
 # 0: Off (Faster, but causes issues in some games) 1: On (Default. Slower, but correct)
-shaders_accurate_mul = Off
+shaders_accurate_mul = 1
 
 # Whether to use the Just-In-Time (JIT) compiler for shader emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)


### PR DESCRIPTION
Tested by @ddrsoul on OGU - allows high performing hardware shaders to be used without graphical issues.