### PR TITLE
s922x: add back older rk817 patches to improve battery reporting

### DIFF
--- a/projects/Amlogic/patches/linux/S922X/00001-rk817-charger-fix-bad-PMIC-read-for-current-voltage.patch
+++ b/projects/Amlogic/patches/linux/S922X/00001-rk817-charger-fix-bad-PMIC-read-for-current-voltage.patch
@@ -1,0 +1,76 @@
+diff --git a/drivers/power/supply/rk817_charger.c b/drivers/power/supply/rk817_charger.c
+index 7ca91739c6cc..658683d625db 100644
+--- a/drivers/power/supply/rk817_charger.c
++++ b/drivers/power/supply/rk817_charger.c
+@@ -240,9 +240,29 @@ static int rk817_record_battery_nvram_values(struct rk817_charger *charger)
+ static int rk817_bat_calib_cap(struct rk817_charger *charger)
+ {
+ 	struct rk808 *rk808 = charger->rk808;
+-	int tmp, charge_now, charge_now_adc, volt_avg;
++	int charge_now, charge_now_adc;
+ 	u8 bulk_reg[4];
+ 
++	/*
++	 * When resuming from suspend, sometimes the voltage value would be
++	 * incorrect. BSP would simply wait two seconds and try reading the
++	 * values again. Do not do any sort of calibration activity when the
++	 * reported value is incorrect. The next scheduled update of battery
++	 * vaules should then return valid data and the driver can continue.
++	 * Use 2.7v as the sanity value because per the datasheet the PMIC
++	 * can in no way support a battery voltage lower than this. BSP only
++	 * checked for values too low, but I'm adding in a check for values
++	 * too high just in case; again the PMIC can in no way support
++	 * voltages above 4.45v, so this seems like a good value.
++	 */
++	if ((charger->volt_avg_uv < 2700000) || (charger->volt_avg_uv > 4450000)) {
++		dev_warn(charger->dev,
++			 "Battery voltage of %d is invalid, ignoring.\n",
++			 charger->volt_avg_uv);
++		return -EINVAL;
++	}
++
++
+ 	/* Calibrate the soc and fcc on a fully charged battery */
+ 
+ 	if (charger->charge_status == CHARGE_FINISH && (!charger->soc_cal)) {
+@@ -312,11 +332,7 @@ static int rk817_bat_calib_cap(struct rk817_charger *charger)
+ 	 * counter is negative add that to our fcc (but not to exceed our
+ 	 * design capacity).
+ 	 */
+-	regmap_bulk_read(charger->rk808->regmap, RK817_GAS_GAUGE_BAT_VOL_H,
+-			 bulk_reg, 2);
+-	tmp = get_unaligned_be16(bulk_reg);
+-	volt_avg = (charger->voltage_k * tmp) + 1000 * charger->voltage_b;
+-	if (volt_avg <= charger->bat_voltage_min_design_uv &&
++	if (charger->volt_avg_uv <= charger->bat_voltage_min_design_uv &&
+ 	    charger->soc_cal) {
+ 		regmap_bulk_read(rk808->regmap, RK817_GAS_GAUGE_Q_PRES_H3,
+ 				 bulk_reg, 4);
+@@ -338,7 +354,7 @@ static int rk817_bat_calib_cap(struct rk817_charger *charger)
+ 	/*
+ 	 * Set the SOC to 0 if we are below the minimum system voltage.
+ 	 */
+-	if (volt_avg <= charger->bat_voltage_min_design_uv) {
++	if (charger->volt_avg_uv <= charger->bat_voltage_min_design_uv) {
+ 		charger->soc = 0;
+ 		charge_now_adc = CHARGE_TO_ADC(0, charger->res_div);
+ 		put_unaligned_be32(charge_now_adc, bulk_reg);
+@@ -346,7 +362,8 @@ static int rk817_bat_calib_cap(struct rk817_charger *charger)
+ 				  RK817_GAS_GAUGE_Q_INIT_H3, bulk_reg, 4);
+ 		dev_warn(charger->dev,
+ 			 "Battery voltage %d below minimum voltage %d\n",
+-			 volt_avg, charger->bat_voltage_min_design_uv);
++			 charger->volt_avg_uv,
++			 charger->bat_voltage_min_design_uv);
+ 		}
+ 
+ 	rk817_record_battery_nvram_values(charger);
+@@ -715,7 +732,7 @@ static int rk817_read_battery_nvram_values(struct rk817_charger *charger)
+ 	 * correct it.
+ 	 */
+ 	if ((charger->fcc_mah < 500) ||
+-	   ((charger->fcc_mah * 1000) > charger->bat_charge_full_design_uah)) {
++	   (charger->fcc_mah > (charger->bat_charge_full_design_uah / 1000))) {
+ 		dev_info(charger->dev,
+ 			 "Invalid NVRAM max charge, setting to %u uAH\n",
+ 			 charger->bat_charge_full_design_uah);

--- a/projects/Amlogic/patches/linux/S922X/00002-rk817-remove-capacity-calibration.patch
+++ b/projects/Amlogic/patches/linux/S922X/00002-rk817-remove-capacity-calibration.patch
@@ -1,0 +1,38 @@
+diff --git a/drivers/power/supply/rk817_charger.c b/drivers/power/supply/rk817_charger.c
+index 658683d625db..c5eeb0beb9ef 100644
+--- a/drivers/power/supply/rk817_charger.c
++++ b/drivers/power/supply/rk817_charger.c
+@@ -324,33 +324,6 @@ static int rk817_bat_calib_cap(struct rk817_charger *charger)
+ 		}
+ 	}
+ 
+-	/*
+-	 * Calibrate the fully charged capacity when we previously had a full
+-	 * battery (soc_cal = 1) and are now empty (at or below minimum design
+-	 * voltage). If our columb counter is still positive, subtract that
+-	 * from our fcc value to get a calibrated fcc, and if our columb
+-	 * counter is negative add that to our fcc (but not to exceed our
+-	 * design capacity).
+-	 */
+-	if (charger->volt_avg_uv <= charger->bat_voltage_min_design_uv &&
+-	    charger->soc_cal) {
+-		regmap_bulk_read(rk808->regmap, RK817_GAS_GAUGE_Q_PRES_H3,
+-				 bulk_reg, 4);
+-		charge_now_adc = get_unaligned_be32(bulk_reg);
+-		charge_now = ADC_TO_CHARGE_UAH(charge_now_adc,
+-					       charger->res_div);
+-		/*
+-		 * Note, if charge_now is negative this will add it (what we
+-		 * want) and if it's positive this will subtract (also what
+-		 * we want).
+-		 */
+-		charger->fcc_mah = charger->fcc_mah - (charge_now / 1000);
+-
+-		dev_dbg(charger->dev,
+-			"Recalibrating full charge capacity to %d uah\n",
+-			charger->fcc_mah * 1000);
+-	}
+-
+ 	/*
+ 	 * Set the SOC to 0 if we are below the minimum system voltage.
+ 	 */


### PR DESCRIPTION
Add back the older rk817 for s922x, as they were improving battery reporting.

These are temporary until we rewrite the upstream patches, but I don't think there is much difference functionally.