### PR TITLE
lime3ds-sa - accurate hardware shaders ES feature

### DIFF
--- a/packages/emulators/standalone/lime3ds-sa/config/S922X/sdl2-config.ini
+++ b/packages/emulators/standalone/lime3ds-sa/config/S922X/sdl2-config.ini
@@ -103,7 +103,7 @@ use_hw_shader =
 
 # Whether to use accurate multiplication in hardware shaders
 # 0: Off (Faster, but causes issues in some games) 1: On (Default. Slower, but correct)
-shaders_accurate_mul = 1
+shaders_accurate_mul = Off
 
 # Whether to use the Just-In-Time (JIT) compiler for shader emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)

--- a/packages/emulators/standalone/lime3ds-sa/scripts/start_lime3ds.sh
+++ b/packages/emulators/standalone/lime3ds-sa/scripts/start_lime3ds.sh
@@ -35,7 +35,7 @@ ROTATE=$(get_setting rotate_screen "${PLATFORM}" "${GAME}")
 SLAYOUT=$(get_setting screen_layout "${PLATFORM}" "${GAME}")
 CSHADERS=$(get_setting cache_shaders "${PLATFORM}" "${GAME}")
 HSHADERS=$(get_setting hardware_shaders "${PLATFORM}" "${GAME}")
-
+ACCURATE_HW_SHADERS=$(get_setting accurate_hardware_shaders "${PLATFORM}" "${GAME}")
 
 # CPU Underclock
 case "${CPU}" in
@@ -70,6 +70,12 @@ esac
 case "${HSHADERS}" in
   1) sed -i '/use_hw_shader =/c\use_hw_shader = 1' /storage/.config/lime3ds/sdl2-config.ini;;
   *) sed -i '/use_hw_shader =/c\use_hw_shader = 0' /storage/.config/lime3ds/sdl2-config.ini;;
+esac
+
+# Use accurate multiplication in hardware shaders
+case "${ACCURATE_HW_SHADERS}" in
+  1) sed -i '/shaders_accurate_mul =/c\shaders_accurate_mul = 1' /storage/.config/lime3ds/sdl2-config.ini;;
+  *) sed -i '/shaders_accurate_mul =/c\shaders_accurate_mul = 0' /storage/.config/lime3ds/sdl2-config.ini;;
 esac
 
 # Screen Layout

--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -626,6 +626,10 @@
         <choice name="on" value="1"/>
         <choice name="off" value="0"/>
       </feature>
+      <feature name="accurate hardware shaders">
+        <choice name="on" value="1"/>
+        <choice name="off" value="0"/>
+      </feature>
       <feature name="resolution scale">
         <choice name="Native 3DS" value="1"/>
         <choice name="2x" value="2"/>


### PR DESCRIPTION
Revert S922X-specific PR https://github.com/ROCKNIX/distribution/pull/893 and implement lime3ds-sa `accurate_hardware_shaders` ES feature