### PR TITLE
Performance profile for Mupen64Plus-SA (GLideN64 video plugin) and configuration adjustments for rk3326 and rk3566

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg
@@ -404,7 +404,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.oga
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.oga
@@ -407,7 +407,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.ogabe
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.ogabe
@@ -407,7 +407,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.ogs
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.ogs
@@ -407,7 +407,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.r33s
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.r33s
@@ -407,7 +407,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.rgb10x
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.rgb10x
@@ -407,7 +407,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.xut
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3326/mupen64plus.cfg.xut
@@ -407,7 +407,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3566/mupen64plus.cfg
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3566/mupen64plus.cfg
@@ -404,7 +404,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3566/mupen64plus.cfg.rgarc
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/RK3566/mupen64plus.cfg.rgarc
@@ -404,7 +404,7 @@ Rotate = 0
 
 ###### Hardware Compatibility ######
 # Leave enabled unless a mobile gpu doesn't support it.
-EnableFragmentDepthWrite = 1
+EnableFragmentDepthWrite = 0
 # Hardware per pixel lighting, supposedly good for GLES3.1 devices or higher.
 EnableHWLighting = 0
 

--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -22,6 +22,7 @@ PAK=$(get_setting controller_pak "${PLATFORM}" "${GAME}")
 CON=$(get_setting input_configuration "${PLATFORM}" "${GAME}")
 VPLUGIN=$(get_setting video_plugin "${PLATFORM}" "${GAME}")
 CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
+GLIDEN64CONF=$(get_setting gliden64_profiles "${PLATFORM}" "${GAME}")
 
 # File locations
 SHARE="/usr/local/share/mupen64plus"
@@ -124,6 +125,25 @@ else
     SET_PARAMS+=" --set Video-GLideN64[ShowFPS]=False"
     SET_PARAMS+=" --set Video-Glide64mk2[show_fps]=0"
     SET_PARAMS+=" --set Video-Rice[ShowFPS]=False"
+fi
+
+# GLideN64 Profiles
+if [ "${GLIDEN64CONF}" = "performance" ]; then
+	SET_PARAMS+=" --set Video-GLideN64[EnableLOD]=False"
+	SET_PARAMS+=" --set Video-GLideN64[EnableLegacyBlending]=True"
+	SET_PARAMS+=" --set Video-GLideN64[EnableHybridFilter]=False"
+	SET_PARAMS+=" --set Video-GLideN64[EnableInaccurateTextureCoordinates]=True"
+	SET_PARAMS+=" --set Video-GLideN64[EnableCopyColorToRDRAM]=0"
+	SET_PARAMS+=" --set Video-GLideN64[EnableCopyDepthToRDRAM]=0"
+	SET_PARAMS+=" --set Video-GLideN64[BackgroundsMode]=0"
+	SET_PARAMS+=" --set Video-GLideN64[RDRAMImageDitheringMode]=0"
+	SET_PARAMS+=" --set Video-GLideN64[CorrectTexrectCoords]=0"
+else
+	SET_PARAMS+=" --set Video-GLideN64[EnableLOD]=True"
+	SET_PARAMS+=" --set Video-GLideN64[EnableLegacyBlending]=False"
+	SET_PARAMS+=" --set Video-GLideN64[EnableHybridFilter]=False"
+	SET_PARAMS+=" --set Video-GLideN64[EnableInaccurateTextureCoordinates]=False"
+	SET_PARAMS+=" --set Video-GLideN64[EnableCopyColorToRDRAM]=2"
 fi
 
 # Set the video plugin

--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -265,6 +265,10 @@
         <choice name="yes" value="true"/>
         <choice name="no" value="false"/>
       </feature>
+      <feature name="gliden64 profiles">		
+        <choice name="balanced" value="balanced"/>
+        <choice name="performance" value="performance"/>		
+      </feature>
      </features>
     </core>
    </cores>


### PR DESCRIPTION
There are parameters that can increase the performance of Mupen64Plus (GLideN64 plugin), but they may result in lower graphical accuracy. I created two profiles based on this [Reddit post](https://www.reddit.com/r/R36S/comments/1d6cd2v/standalonegliden64_config_presets/). The improvement is noticeable most of the time, and in my tests, I achieved better results than with RetroArch.

I have also found that disabling the ‘EnableFragmentDepthWrite’ parameter improves the performance of the GLideN64 plugin, at least on the rk3326 and rk3566. There don't seem to be any issues with disabling it, but I currently don't have access to other devices for further testing.