### PR TITLE
r36s: controls for mupen64plus-sa

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-input-sdl/config/RK3326/default.ini
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-input-sdl/config/RK3326/default.ini
@@ -149,6 +149,31 @@ Rumblepak switch =
 X Axis = button(12,13)axis(0-,0+)
 Y Axis = button(10,11)axis(1-,1+)
 
+[r36s_Gamepad]
+plugged = True
+mouse = False
+AnalogDeadzone = 0,0
+AnalogPeak = 32768,32768
+DPad R = button(16)
+DPad L = button(15)
+DPad D = button(14)
+DPad U = button(13)
+Start = button(9)
+Z Trig = button(6)
+B Button = button(3)
+A Button = button(0)
+C Button R = axis(2+)
+C Button L = axis(2-)
+C Button D = axis(3+)
+C Button U = axis(3-)
+R Trig = button(5)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
+# Analog axis configuration mappings
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
 [XU10 Gamepad]
 plugged = True
 mouse = False


### PR DESCRIPTION
Fix for missing controls since r36s has its own identifier: r36s_Gamepad.