### PR TITLE
Updates usbgadget addresisng to use IANA Point-to-Point/Link local addressing

### DIFF
--- a/packages/rocknix/sources/scripts/usbgadget
+++ b/packages/rocknix/sources/scripts/usbgadget
@@ -25,7 +25,7 @@ fi
 
 UDHCPCONF=/storage/.cache/usbgadget/udhcpd.conf
 if [ ! -f $UDHCPCONF ] ; then
-	echo -e "interface usbnet\nstart 10.1.1.1\nend 10.1.1.1\nopt subnet 255.255.255.0\nopt lease 86400\nmax_leases 1\nlease_file /dev/null\nremaining no" >> /storage/.cache/usbgadget/udhcpd.conf
+	echo -e "interface usbnet\nstart 169.254.0.1\nend 169.254.0.2\nopt subnet 255.255.255.252\nopt lease 86400\nmax_leases 1\nlease_file /dev/null\nremaining no" >> /storage/.cache/usbgadget/udhcpd.conf
 fi
 # Rename interface in old (pre-bridge) configs
 if ! grep -q usbnet $UDHCPCONF; then


### PR DESCRIPTION
Per RFC8192/6890. Changing from the rout-able 10.1.1.0/24 subnet to 169.254.0.0/30 subnet reserved for link-local/point-to-point networks.

This will prevent the host routing table from being corrupted for routes to the RC1918 network attempting to traverse the Gadget device link and potentially breaking users connectivity if they happen to be using the 10.1.1.0/24 subnet for their internal networks.
It will also potentially avoid polluting any Interior Routing Protocol (BGP/RIP/OSPF) that might happen to exist on the host.

Similarly this will enable autoconf services to be implemented at a later stage without worrying about broadcast beyond the host.