### PR TITLE
Add jansson json library dependency for wayvnc bring up

### DIFF
--- a/packages/devel/jansson/package.mk
+++ b/packages/devel/jansson/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="jansson"
+PKG_VERSION="2.14"
+PKG_LICENSE="MIT"
+PKG_SITE=https://github.com/akheron/jansson
+PKG_URL="${PKG_SITE}/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Jansson is a C library for encoding, decoding and manipulating JSON data"
+PKG_TOOLCHAIN="cmake"
+


### PR DESCRIPTION
* new file:   packages/devel/jansson/package.mk

[Jansson](http://www.digip.org/jansson/) is a C library for encoding, decoding and manipulating JSON data. Its main features and design principles are:

    Simple and intuitive API and data model
    [Comprehensive documentation](http://jansson.readthedocs.io/en/latest/)
    No dependencies on other libraries
    Full Unicode support (UTF-8)
    Extensive test suite

Jansson is licensed under the [MIT license](http://www.opensource.org/licenses/mit-license.php); see LICENSE in the source distribution for details.