### PR TITLE
Add's Displayport (DP) check into the sway-init script.

### DIFF
--- a/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -25,7 +25,7 @@ else
     systemctl unmask essway.service
 fi
 # get the card number, this may not be a safe way to derive it...
-card_no=$(ls /sys/class/drm/ | grep -E "HDMI|DSI" | head -n 1 | cut -b 5)
+card_no=$(ls /sys/class/drm/ | grep -E "DP|HDMI|DSI" | head -n 1 | cut -b 5)
 
 env_file=/storage/.config/profile.d/095-sway
 
@@ -45,7 +45,7 @@ do
             dsi=$(basename $connector)
             dsi=${dsi: +6}
         fi
-    # Simply prioritize later connectors, meaning HDMI priority
+    # Simply prioritize later connectors, meaning HDMI/DP priority
 	con=$(basename $connector)
 	con=${con: +6}
     fi


### PR DESCRIPTION
Required for USB-C DP-Alt mode capable output devices. i.e rp5/rp5mini/amd64

	modified:   wayland/compositor/sway/autostart/111-sway-init