### PR TITLE
bdf2psf: bump version 232->233

### DIFF
--- a/packages/textproc/bdf2psf/package.mk
+++ b/packages/textproc/bdf2psf/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="bdf2psf"
-PKG_VERSION="1.232"
+PKG_VERSION="1.233"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://packages.debian.org/unstable/${PKG_NAME}"
 PKG_URL="https://deb.debian.org/debian/pool/main/c/console-setup/${PKG_NAME}_${PKG_VERSION}_all.deb"


### PR DESCRIPTION
Bump bdf2psf from version 232 to 233. 
232 version is no longer available, causing a build failure -> https://github.com/tiopex/distribution/actions/runs/12292355744/

source:  https://ftp.debian.org/debian/pool/main/c/console-setup/
