### PR TITLE
wireplumber - fix matching rule for bluez5 auto-connect / hw-volume

### DIFF
--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -64,7 +64,7 @@ monitor.bluez.rules = [
     matches = [
       {
         ## This matches all bluetooth devices.
-        device.name = "~bluez_card.*"
+        device.name = "~bluez_output.*"
       }
     ]
     actions = {


### PR DESCRIPTION
Have done more testing today, matching rule seems to need to be `bluez_output.*` not `bluez_card.*`.

Edit: still unsure if this is needed.