### PR TITLE
ogs: fix joypad name (also fixes sway)

### DIFF
--- a/projects/Rockchip/patches/linux/RK3326/000-rk3326-dts.patch
+++ b/projects/Rockchip/patches/linux/RK3326/000-rk3326-dts.patch
@@ -2793,7 +2793,7 @@ index 35bbaf559ca3..d03b3d9cb675 100644
 -		mux-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_LOW>,
 -			    <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
 -	};
-+		joypad-name = "";
++		joypad-name = "odroidgo3_joypad";
 +		joypad-product = <0x0001>;
 +		joypad-revision = <0x0101>;
 +


### PR DESCRIPTION
Fix OGS joypad name.  
Empty name lead to segfault in sway and messed up controls.