### PR TITLE
Add vulkan renderer wlroot backend compilation for targets with vulkan support

### DIFF
--- a/packages/emulators/libretro/retroarch/sources/AMD64/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/AMD64/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/H700/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/H700/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3326/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3326/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3399/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3399/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3566/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3566/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3588/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3588/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/S922X/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/S922X/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/SD865/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/SD865/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/rocknix/sources/scripts/usbgadget
+++ b/packages/rocknix/sources/scripts/usbgadget
@@ -20,7 +20,7 @@ done
 mkdir -p /storage/.cache/usbgadget
 
 if [ ! -f /storage/.cache/usbgadget/ip_address.conf ] ; then
-	echo "10.1.1.2" > /storage/.cache/usbgadget/ip_address.conf
+	echo "169.254.0.2" > /storage/.cache/usbgadget/ip_address.conf
 fi
 
 UDHCPCONF=/storage/.cache/usbgadget/udhcpd.conf

--- a/packages/rocknix/sources/scripts/usbgadget
+++ b/packages/rocknix/sources/scripts/usbgadget
@@ -20,12 +20,12 @@ done
 mkdir -p /storage/.cache/usbgadget
 
 if [ ! -f /storage/.cache/usbgadget/ip_address.conf ] ; then
-	echo "169.254.0.2" > /storage/.cache/usbgadget/ip_address.conf
+	echo "169.254.0.1" > /storage/.cache/usbgadget/ip_address.conf
 fi
 
 UDHCPCONF=/storage/.cache/usbgadget/udhcpd.conf
 if [ ! -f $UDHCPCONF ] ; then
-	echo -e "interface usbnet\nstart 169.254.0.1\nend 169.254.0.2\nopt subnet 255.255.255.252\nopt lease 86400\nmax_leases 1\nlease_file /dev/null\nremaining no" >> /storage/.cache/usbgadget/udhcpd.conf
+	echo -e "interface usbnet\nstart 169.254.0.2\nend 169.254.0.2\nopt subnet 255.255.255.252\nopt msstaticroutes 169.254.0.1/169.254.0.2\nopt lease 86400\nmax_leases 1\nlease_file /dev/null\nremaining no" >> /storage/.cache/usbgadget/udhcpd.conf
 fi
 # Rename interface in old (pre-bridge) configs
 if ! grep -q usbnet $UDHCPCONF; then

--- a/packages/rocknix/sources/scripts/usbgadget
+++ b/packages/rocknix/sources/scripts/usbgadget
@@ -25,7 +25,7 @@ fi
 
 UDHCPCONF=/storage/.cache/usbgadget/udhcpd.conf
 if [ ! -f $UDHCPCONF ] ; then
-	echo -e "interface usbnet\nstart 10.1.1.1\nend 10.1.1.1\nopt subnet 255.255.255.0\nopt lease 86400\nmax_leases 1\nlease_file /dev/null\nremaining no" >> /storage/.cache/usbgadget/udhcpd.conf
+	echo -e "interface usbnet\nstart 169.254.0.1\nend 169.254.0.2\nopt subnet 255.255.255.252\nopt lease 86400\nmax_leases 1\nlease_file /dev/null\nremaining no" >> /storage/.cache/usbgadget/udhcpd.conf
 fi
 # Rename interface in old (pre-bridge) configs
 if ! grep -q usbnet $UDHCPCONF; then

--- a/packages/wayland/lib/wlroots/package.mk
+++ b/packages/wayland/lib/wlroots/package.mk
@@ -31,14 +31,27 @@ configure_package() {
   if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" ${OPENGLES}"
   fi
+
+  if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+    PKG_DEPENDS_TARGET+=" ${VULKAN}"
+  fi
 }
-# to enable xwayland package: https://gitlab.freedesktop.org/xorg/lib/libxcb-wm/-/tree/master/icccm?ref_type=heads
-PKG_MESON_OPTS_TARGET="-Dxcb-errors=disabled \
+
+# Vulkan Support
+  if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+    PKG_MESON_OPTS_TARGET="-Dxcb-errors=disabled \
+                       -Dxwayland=enabled \
+                       -Dexamples=false \
+                       -Drenderers=vulkan,gles2 \
+                       -Dbackends=drm,libinput"
+  else
+    # to enable xwayland package: https://gitlab.freedesktop.org/xorg/lib/libxcb-wm/-/tree/master/icccm?ref_type=heads
+    PKG_MESON_OPTS_TARGET="-Dxcb-errors=disabled \
                        -Dxwayland=enabled \
                        -Dexamples=false \
                        -Drenderers=gles2 \
                        -Dbackends=drm,libinput"
-
+ fi
 unpack() {
   mkdir -p ${PKG_BUILD}
   tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz -C ${PKG_BUILD}


### PR DESCRIPTION
This adds support for running sway/wlroots with the vulkan backend renderer.  Until  ```sway.sh``` is updated with a case to enable environment variable i.e ```export WLR_RENDERER=vulkan``` gles2 is used by default.

	modified:   packages/wayland/lib/wlroots/package.mk

Tested on SD865