### PR TITLE
fix: fix N64 standalone start script

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/scripts/start_mupen64plus.sh
@@ -37,7 +37,7 @@ mkdir -p ${GAMEDATA}
 
 # Copy files to GAMEDATA
 if [[ ! -f "${M64PCONF}" ]]; then
-    cp ${SHARE}/mupen64plus.cfg* ${M64PCONF}
+    cp ${SHARE}/mupen64plus.cfg ${M64PCONF}
 fi
 if [[ ! -f "${CUSTOMINP}" ]]; then
     cp ${SHARE}/default.ini ${CUSTOMINP}


### PR DESCRIPTION
Running the line with the "*" on the terminal gives the following output:

```bash
RK3566-X55:~ # cp /usr/local/share/mupen64plus/mupen64plus.cfg* /storage/.config/mupen64plus/mupen64plus.cfg
cp: can't create '/storage/.config/mupen64plus/mupen64plus.cfg/mupen64plus.cfg': Path does not exist
cp: can't create '/storage/.config/mupen64plus/mupen64plus.cfg/mupen64plus.cfg.rgarc': Path does not exist
```

I think this was added to support a device (instead of platform) specific configuration at some point but if we want to support this we need need further modification(s) for the install script/launch script. The current implementation breaks for all platforms and all systems.
