### PR TITLE
Fixes retroarch32 core loading behaviour by adding additional lib32 path

### DIFF
--- a/packages/emulators/libretro/retroarch/sources/AMD64/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/AMD64/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/H700/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/H700/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3326/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3326/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3399/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3399/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3566/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3566/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/RK3588/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/RK3588/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/S922X/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/S922X/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro

--- a/packages/emulators/libretro/retroarch/sources/SD865/retroarch32bit-append.cfg
+++ b/packages/emulators/libretro/retroarch/sources/SD865/retroarch32bit-append.cfg
@@ -1,2 +1,3 @@
 audio_filter_dir = "/usr/share/retroarch/filters/32bit/audio"
 video_filter_dir = "/usr/share/retroarch/filters/32bit/video"
+libretro_directory = /usr/lib32/libretro


### PR DESCRIPTION
This adds additional libretro 32bit library config append. Without this default 64 bit lib cores are attempted to be loaded by 32bit retroarch, even when a 32bit core is present, unsuccessfully.

