### PR TITLE
fix(rk3588): change default psx emulator to `pcsx_rearmed`

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/RK3588/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/RK3588/SUPPORTED_EMULATORS_AND_CORES.md
@@ -115,7 +115,7 @@ This document describes all available systems emulators and cores available for 
 |SNK|Neo Geo CD (neocd)|1994|`neocd`|.cue .iso .chd|**retroarch:** neocd (default)<br>**retroarch:** fbneo<br>|
 |SNK|Neo Geo Pocket (ngp)|1998|`ngp`|.ngp .ngc .zip .7z|**retroarch:** beetle_ngp (default)<br>**retroarch:** race<br>**mednafen:** ngp<br>|
 |SNK|Neo Geo Pocket Color (ngpc)|1999|`ngpc`|.ngp .ngc .zip .7z|**retroarch:** beetle_ngp (default)<br>**retroarch:** race<br>**mednafen:** ngp<br>|
-|Sony|PlayStation (psx)|1994|`psx`|.bin .cue .img .mdf .pbp .toc .cbn .m3u .ccd .chd .iso|**retroarch:** pcsx_rearmed32 (default)<br>**retroarch:** pcsx_rearmed<br>**retroarch:** beetle_psx<br>**mednafen:** psx<br>**duckstation:** duckstation-sa<br>**retroarch:** duckstation<br>**retroarch:** swanstation<br>|
+|Sony|PlayStation (psx)|1994|`psx`|.bin .cue .img .mdf .pbp .toc .cbn .m3u .ccd .chd .iso|**retroarch:** pcsx_rearmed (default)<br>**retroarch:** pcsx_rearmed32<br>**retroarch:** beetle_psx<br>**mednafen:** psx<br>**duckstation:** duckstation-sa<br>**retroarch:** duckstation<br>**retroarch:** swanstation<br>|
 |Sony|PlayStation 2 (ps2)|2000|`ps2`|.iso .mdf .nrg .bin .img .dump .gz .cso .chd|**aethersx2:** aethersx2-sa (default)<br>|
 |Sony|PlayStation Portable (psp)|2004|`psp`|.iso .cso .pbp .chd|**ppsspp:** ppsspp-sa (default)<br>|
 |Sony|PSP Minis (pspminis)|2004|`pspminis`|.iso .cso .pbp|**ppsspp:** ppsspp-sa (default)<br>**retroarch:** ppsspp<br>|

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -841,8 +841,8 @@ makeinstall_target() {
       add_emu_core psx retroarch beetle_psx false
     ;;
     RK3588*)
-      add_emu_core psx retroarch pcsx_rearmed32 true
-      add_emu_core psx retroarch pcsx_rearmed false
+      add_emu_core psx retroarch pcsx_rearmed true
+      add_emu_core psx retroarch pcsx_rearmed32 false
       add_emu_core psx retroarch beetle_psx false
       add_emu_core psx mednafen psx false
     ;;


### PR DESCRIPTION
The previous default, `pcsx_rearmed32`, performs extremely poor on an Orange Pi 5 (RK3588S), possibly due to `retroarch32` itself running poorly on this system.  Even when pausing emulation and bringing up retroarch's menu, it's barely possible to navigate it, often being necessary to hard reset the SBC.