### PR TITLE
automount: use ntfs3 driver for ntfs volumes -- makes partition writeable

### DIFF
--- a/packages/rocknix/sources/scripts/automount
+++ b/packages/rocknix/sources/scripts/automount
@@ -141,6 +141,13 @@ function mount_games() {
         ;;
       esac
 
+      # busybox has some weird behaviour with helpers.
+      # Despite mount.ntfs is present, it is not used, so just a stupid rewrite to use newer kernel ntfs3 driver
+      case ${FSTYPE} in
+        ntfs)   MOUNT_ARGS="-t ntfs3" ;;
+        *)      true ;;
+      esac
+
       if [ ! -d "${MOUNT_PATH}" ]
       then
         log $0 "Create directory ${MOUNT_PATH}"
@@ -160,7 +167,7 @@ function mount_games() {
         fsck -Mly ${1} >/dev/null 2>&1
 
         log $0 "Mounting ${1} on ${MOUNT_PATH}"
-        /usr/bin/busybox mount ${1} ${MOUNT_PATH} >/dev/null 2>&1
+        /usr/bin/busybox mount ${MOUNT_ARGS} ${1} ${MOUNT_PATH} >/dev/null 2>&1
       fi
       start_ms external
       create_game_dirs


### PR DESCRIPTION
Simple hack to mount ntfs as ntfs3.  
FUSE and ntfs-3g are not used, and seems OK for now.  
busybox tries mount helpers only if simple mount failed, thus mount.ntfs never gets called.  
It was possible to fix with a full-blown mount, but currently I prefer to not check what that upgrade would break.  

If this approach is not enough (will see), we can just follow LE path with util-linux mount: https://github.com/LibreELEC/LibreELEC.tv/pull/8497