### PR TITLE
File Manager: fix set_kill parameter in launch script with the right process name

### DIFF
--- a/packages/misc/modules/sources/fileman.sh
+++ b/packages/misc/modules/sources/fileman.sh
@@ -7,7 +7,7 @@
 gptokeyb fileman textinput &
 
 . /etc/profile
-set_kill set "FileMan"
+set_kill set "fileman"
 
 fileman
 


### PR DESCRIPTION
Exit command (L1+SELECT+START) is not working otherwise.