### PR TITLE
Add gamepad calibration tool (GPcal) for SD865

### DIFF
--- a/packages/apps/gamepadcalibration/package.mk
+++ b/packages/apps/gamepadcalibration/package.mk
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="gamepadcalibration"
+PKG_VERSION="973bf8c4d72068e3e2383450c76b0cb2fa078cb1"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/cdeletre/GPcal"
+PKG_URL="https://github.com/cdeletre/GPcal/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="Python3 SDL2 gamecontrollerdb"
+PKG_LONGDESC="A gamepad calibration tool for the Retroid Pocket 5 and Mini"
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+  :
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/local/share
+
+  tar -xzf ${PKG_BUILD}/rocknix/gpcal.tgz -C ${INSTALL}/usr/local/share
+  chmod 0755 ${INSTALL}/usr/local/share/gpcal/main.py
+
+  mkdir -p ${INSTALL}/usr/config/modules
+  cp -rf ${PKG_DIR}/scripts/* ${INSTALL}/usr/config/modules
+  chmod 0755 ${INSTALL}/usr/config/modules/*
+}

--- a/packages/apps/gamepadcalibration/scripts/GPcal.sh
+++ b/packages/apps/gamepadcalibration/scripts/GPcal.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
+
+GPCAL_PATH="/usr/local/share/gpcal"
+
+source /etc/profile
+
+set_kill set "python3"
+
+sway_fullscreen "python3" &
+
+# Enable the python3 venv that has the pyxel library installed
+# Note: the activate script relies on the CWD, thus the cd 
+# before
+cd "$GPCAL_PATH"
+source pyxel/bin/activate
+
+# PYTHONDONTWRITEBYTECODE: We don't expect to do write files
+# on a readonly mount point. Thus we tell Python to not try to
+# write .pyc files on the import of source modules.
+PYTHONDONTWRITEBYTECODE=1 python3 main.py


### PR DESCRIPTION
This PR adds the gamepad calibration tool package for SD865 (GPcal). This tool enables the user to calibrate the analog stick and triggers on the Retroid Pocket 5/Mini. It requires the last patch done on the kernel driver (see https://github.com/ROCKNIX/distribution/pull/1005).

The `/usr/config/module/gamelist.xml` will need to be updated to have the tool listed in the menu (I don't know if this should be part of this PR). I have already done some work for this here https://github.com/cdeletre/GPcal/tree/dev/rocknix/modules.

Note: the tool can run on other hardware (even you computer) without trouble, it will use the SDL reading instead of event reading and obviously won't calibrate anything (it will fake it).