### PR TITLE
S922X - mupen64plus-sa - update controls and hotkeys to match wiki

### DIFF
--- a/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/S922X/mupen64plus.cfg
+++ b/packages/emulators/standalone/mupen64plus-sa/mupen64plus-sa-core/config/S922X/mupen64plus.cfg
@@ -126,9 +126,9 @@ Joy Mapping Speed Down = ""
 # Joystick event string for speeding up the emulator
 Joy Mapping Speed Up = ""
 # Joystick event string for taking a screenshot
-Joy Mapping Screenshot = "J0B11/B1"
+Joy Mapping Screenshot = "J0B11/B4"
 # Joystick event string for pausing the emulator
-Joy Mapping Pause = "J0B6/B0"
+Joy Mapping Pause = ""
 # Joystick event string for muting/unmuting the sound
 Joy Mapping Mute = ""
 # Joystick event string for increasing the volume
@@ -140,7 +140,7 @@ Joy Mapping Fast Forward = ""
 # Joystick event string for advancing by one frame when paused
 Joy Mapping Frame Advance = ""
 # Joystick event string for pressing the game shark button
-Joy Mapping Gameshark = "J0B6/B2"
+Joy Mapping Gameshark = ""
 # SDL keysym for save slot 0
 Kbd Mapping Slot 0 = 48
 # SDL keysym for save slot 1
@@ -197,8 +197,8 @@ Z Trig = button(5) button(8)
 B Button = button(4)
 A Button = button(0)
 C Button R = axis(2+)
-C Button L = axis(2-) button (2)
-C Button D = axis(3+) button (1)
+C Button L = axis(2-)
+C Button D = axis(3+)
 C Button U = axis(3-)
 R Trig = button(6)
 L Trig = button(7)


### PR DESCRIPTION
Hotkey changes:
- update screenshot hotkey to match wiki
- remove pause emulation and gameshark hotkeys

Control changes:
- C button mappings - update to match wiki