### PR TITLE
r36s-device-switch-option

### DIFF
--- a/packages/apps/device-switch/scripts/RK3326/device-switch
+++ b/packages/apps/device-switch/scripts/RK3326/device-switch
@@ -7,11 +7,11 @@
 mount -o remount,rw /flash
 case $1 in
   R33S)
-    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r33s.dtb' /flash/boot.ini
+    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-gameconsole-r33s.dtb' /flash/boot.ini
     rm -r /storage/remappings/*
   ;;
   R36S)
-    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r36s.dtb' /flash/boot.ini
+    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-gameconsole-r36s.dtb' /flash/boot.ini
     rm -r /storage/remappings/*
   ;;
 esac


### PR DESCRIPTION
According to the changes made in [PR #1041](https://github.com/ROCKNIX/distribution/pull/1041), it seems that it is necessary to update the tool to enable the controls in r36s.