### PR TITLE
dolphin-sa - wayland - add BIOS dir / messages patch

### DIFF
--- a/packages/emulators/standalone/dolphin-sa/patches/wayland/008-bios-dir.patch
+++ b/packages/emulators/standalone/dolphin-sa/patches/wayland/008-bios-dir.patch
@@ -1,0 +1,54 @@
+diff --git a/Source/Core/Core/Boot/Boot.cpp b/Source/Core/Core/Boot/Boot.cpp
+index b21d15478..5b62db919 100644
+--- a/Source/Core/Core/Boot/Boot.cpp
++++ b/Source/Core/Core/Boot/Boot.cpp
+@@ -423,7 +423,7 @@ bool CBoot::Load_BS2(Core::System& system, const std::string& boot_rom_filename)
+     known_ipl = true;
+     break;
+   default:
+-    PanicAlertFmtT("The IPL file is not a known good dump. (CRC32: {0:x})", ipl_hash);
++    known_ipl = true;
+     break;
+   }
+ 
+@@ -598,7 +598,7 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
+       if (!File::Exists(ipl.path))
+       {
+         if (ipl.disc)
+-          PanicAlertFmtT("Cannot start the game, because the GC IPL could not be found.");
++          PanicAlertFmtT("Gamecube bios not found, please add your IPL.bin to /storage/roms/bios/GC/(USA/JAP/EUR)/.");
+         else
+           PanicAlertFmtT("Cannot find the GC IPL.");
+         return false;
+diff --git a/Source/Core/Core/Config/MainSettings.cpp b/Source/Core/Core/Config/MainSettings.cpp
+index 1a7c523d6..2dc7ba724 100644
+--- a/Source/Core/Core/Config/MainSettings.cpp
++++ b/Source/Core/Core/Config/MainSettings.cpp
+@@ -597,7 +597,7 @@ const char* GetDirectoryForRegion(DiscIO::Region region, RegionDirectoryStyle st
+ std::string GetBootROMPath(const std::string& region_directory)
+ {
+   const std::string path =
+-      File::GetUserPath(D_GCUSER_IDX) + DIR_SEP + region_directory + DIR_SEP GC_IPL;
++      std::string("/storage/roms/bios/GC/") + DIR_SEP + region_directory + DIR_SEP + GC_IPL;
+   if (!File::Exists(path))
+     return File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + region_directory + DIR_SEP GC_IPL;
+   return path;
+diff --git a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+index 12ba27303..5db375f37 100644
+--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
++++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+@@ -327,12 +327,12 @@ void CEXIIPL::TransferByte(u8& data)
+         {
+           if (dev_addr >= 0x001FCF00)
+           {
+-            PanicAlertFmtT("Error: Trying to access Windows-1252 fonts but they are not loaded. "
++            PanicAlertFmtT("Gamecube bios not found, please add your IPL.bin to /storage/roms/bios/GC/(USA/JAP/EUR)/ "
+                            "Games may not show fonts correctly, or crash.");
+           }
+           else
+           {
+-            PanicAlertFmtT("Error: Trying to access Shift JIS fonts but they are not loaded. "
++            PanicAlertFmtT("Gamecube bios not found, please add your IPL.bin to /storage/roms/bios/GC/(USA/JAP/EUR)/ "
+                            "Games may not show fonts correctly, or crash.");
+           }
+           // Don't be a nag


### PR DESCRIPTION
Similar to QT patch: https://github.com/ROCKNIX/distribution/blob/dev/packages/emulators/standalone/dolphin-sa/patches/qt6/008-bios-dir.patch

Tested on my RP Mini and OGU