### PR TITLE
RK3326: move DT's back to FLASH:/

### DIFF
--- a/packages/apps/device-switch/scripts/RK3326/device-switch
+++ b/packages/apps/device-switch/scripts/RK3326/device-switch
@@ -7,11 +7,11 @@
 mount -o remount,rw /flash
 case $1 in
   R33S)
-    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-gameconsole-r33s.dtb' /flash/boot.ini
+    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r33s.dtb' /flash/boot.ini
     rm -r /storage/remappings/*
   ;;
   R36S)
-    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-gameconsole-r36s.dtb' /flash/boot.ini
+    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r36s.dtb' /flash/boot.ini
     rm -r /storage/remappings/*
   ;;
 esac

--- a/projects/Rockchip/bootloader/mkimage
+++ b/projects/Rockchip/bootloader/mkimage
@@ -50,7 +50,11 @@ EOF
 mkimage_dtb() {
   if [ -d ${RELEASE_DIR}/3rdparty/bootloader/device_trees ]; then
     echo "image: copying device trees..."
-    mcopy -s ${RELEASE_DIR}/3rdparty/bootloader/device_trees ::
+    if [ "${DEVICE}" = "RK3326" ]; then
+      mcopy ${RELEASE_DIR}/3rdparty/bootloader/device_trees/*.dtb ::
+    else
+      mcopy -s ${RELEASE_DIR}/3rdparty/bootloader/device_trees ::
+    fi
   fi
   if [ -d ${RELEASE_DIR}/3rdparty/bootloader/overlays ]; then
     echo "image: copying device tree overlays..."

--- a/projects/Rockchip/devices/RK3326/packages/u-boot/config/a_boot.ini
+++ b/projects/Rockchip/devices/RK3326/packages/u-boot/config/a_boot.ini
@@ -11,26 +11,26 @@ load mmc 1:1 ${loadaddr} KERNEL
 if test ${hwrev} = 'v11'; then
   if gpio input c22; then
     if gpio input d9; then
-      load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-powkiddy-rgb10.dtb
+      load mmc 1:1 ${dtb_loadaddr} rk3326-powkiddy-rgb10.dtb
     else
-      load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-odroid-go2-v11.dtb
+      load mmc 1:1 ${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
     fi
   else
-    load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-anbernic-rg351m.dtb
+    load mmc 1:1 ${dtb_loadaddr} rk3326-anbernic-rg351m.dtb
   fi
 elif test ${hwrev} = 'v10-go3'; then
-  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-odroid-go3.dtb
+  load mmc 1:1 ${dtb_loadaddr} rk3326-odroid-go3.dtb
 elif test ${hwrev} = 'v10'; then
-  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-odroid-go2.dtb
+  load mmc 1:1 ${dtb_loadaddr} rk3326-odroid-go2.dtb
 elif test ${hwrev} = 'rg351v'; then
-  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-anbernic-rg351v.dtb
+  load mmc 1:1 ${dtb_loadaddr} rk3326-anbernic-rg351v.dtb
 elif test ${hwrev} = 'r33s'; then
-#   load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-powkiddy-rgb20s.dtb
-    load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-gameconsole-r33s.dtb
+#   load mmc 1:1 ${dtb_loadaddr} rk3326-powkiddy-rgb20s.dtb
+    load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r33s.dtb
 elif test ${hwrev} = 'xu10'; then
-  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-magicx-xu10.dtb
+  load mmc 1:1 ${dtb_loadaddr} rk3326-magicx-xu10.dtb
 elif test ${hwrev} = 'chi'; then
-  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-gameforce-chi.dtb
+  load mmc 1:1 ${dtb_loadaddr} rk3326-gameforce-chi.dtb
 fi
 
 if load mmc 1:1 ${dtbo_loadaddr} overlays/mipi-panel.dtbo; then

--- a/projects/Rockchip/devices/RK3326/packages/u-boot/config/b_boot.ini
+++ b/projects/Rockchip/devices/RK3326/packages/u-boot/config/b_boot.ini
@@ -9,9 +9,9 @@ setenv dtbo_loadaddr "0x01e00000"
 load mmc 1:1 ${loadaddr} KERNEL
 
 if test ${hwrev} = 'r33s'; then
-  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-powkiddy-rgb10x.dtb
+  load mmc 1:1 ${dtb_loadaddr} rk3326-powkiddy-rgb10x.dtb
 elif test ${hwrev} = 'xu10'; then
-  load mmc 1:1 ${dtb_loadaddr} device_trees/rk3326-magicx-xu-mini-m.dtb
+  load mmc 1:1 ${dtb_loadaddr} rk3326-magicx-xu-mini-m.dtb
 fi
 
 if load mmc 1:1 ${dtbo_loadaddr} overlays/mipi-panel.dtbo; then


### PR DESCRIPTION
Some RK3326 devices have dtb locations hard coded in SPI NOR, I didn't account for this in my previous PR.