### PR TITLE
usbgadget: do not switch role when there is a connected device

### DIFF
--- a/packages/rocknix/sources/scripts/usbgadget
+++ b/packages/rocknix/sources/scripts/usbgadget
@@ -301,6 +301,8 @@ cleanup_usb_mtp() {
 usb_start() {
 	if [ "$verbose" -gt "0" ];then echo "STORED=${USB_MODE}, CURRENT=${CURRENT_MODE}, DESIRED=$1"; fi
 
+	grep -q configured /sys/bus/usb/devices/1-0\:1.0/usb1-port1/state && exit 3
+
 	# with no argument setup previous mode
 	[[ -n "$1" ]] && USB_MODE=$1
 


### PR DESCRIPTION
Generic 3326 fix for missing wi-fi, gamepad or anything else on USB.  
Gadget will just fail if there is any device connected.  
