### PR TITLE
Write `bluetooth-agent` pid on process start.

### DIFF
--- a/packages/rocknix/sources/scripts/rocknix-bluetooth
+++ b/packages/rocknix/sources/scripts/rocknix-bluetooth
@@ -166,7 +166,6 @@ do_trust() {
 do_enable() {
   set_setting controllers.bluetooth.enabled 1
   systemctl start bluetooth bluetooth-agent
-  pgrep -f rocknix-bluetooth-agent > /run/bluetooth-agent.pid
 }
 
 do_disable() {

--- a/packages/rocknix/sources/scripts/rocknix-bluetooth-agent
+++ b/packages/rocknix/sources/scripts/rocknix-bluetooth-agent
@@ -427,6 +427,10 @@ class Agent(dbus.service.Object):
   def Cancel(self):
     logging.info("agent: Cancel")
 
+def write_pid():
+  with open("/run/bluetooth-agent.pid", "w") as file:
+    file.write(str(os.getpid()))
+
 def do_main_loop(dev_id):
   global gadapter
 
@@ -494,6 +498,7 @@ if __name__ == '__main__':
   manager.RequestDefaultAgent(agentpath)
   agent = Agent(bus, agentpath)
   logging.info("agent registered")
+  write_pid()
 
   # run the agent, allows some tries while hardware can take time to initiate
   time.sleep(5)


### PR DESCRIPTION
Write `bluetooth-agent` pid on process start.

I've experienced the `Pair a Bluetooth device manually` failing to list
any devices.

Upon inspection, `/run/bluetooth-agent.pid` is not getting the PID of
the agent written into it, making `do_devlist` in `rocknix-bluetooth`
fail.

With this change, the pid will be written out by
`rocknix-bluetooth-agent` on start.

I have also cleaned up the call to pgrep in `rocknix-bluetooth` to
ensure that the PID is being set only by the agent.

Tested on a Retroid Pocket 5 by writing bind mounting the two modified
files and starting / stopping bluetooth.