### PR TITLE
cemu-sa: fix get_setting issue in the start script

### DIFF
--- a/packages/emulators/standalone/cemu-sa/scripts/start_cemu.sh
+++ b/packages/emulators/standalone/cemu-sa/scripts/start_cemu.sh
@@ -61,7 +61,7 @@ then
   mkdir -p ${CEMU_CONFIG_ROOT}/controllerProfiles
 fi
 
-FILE=$(echo $@ | sed "s#^/.*/##g")
+FILE=$(echo $1 | sed "s#^/.*/##g")
 ONLINE=$(get_setting online_enabled wiiu "${FILE}")
 FPS=$(get_setting show_fps wiiu "${FILE}")
 CON=$(get_setting wiiu_controller_profile wiiu "${FILE}")


### PR DESCRIPTION
When a WiiU game is launched from ES, it runs `/usr/bin/start_cemu.sh /storage/roms/wiiu/legitrom.wux wiiu`

Then in `start_cemu.sh` line [#64](https://github.com/ROCKNIX/distribution/blob/610a82de576ea0750840f710199ba2a4bbce94e6/packages/emulators/standalone/cemu-sa/scripts/start_cemu.sh#L64) `FILE=$(echo $@ | sed "s#^/.*/##g")` sets `FILE` to `"legitrom.wux wiiu"`

In the next 5 lines following, `get_setting` can't get anything for this entry because it should be `"legitrom.wux"` which causes the game settings such as `SHOW FPS` not working.

The correct way to set FILE is like it is done in `start_dolphin_wii.sh`:
`FILE=$(echo $1 | sed "s#^/.*/##g")`