### PR TITLE
MPV: Volume control with gamepad

### DIFF
--- a/packages/multimedia/mpv/config/input.conf
+++ b/packages/multimedia/mpv/config/input.conf
@@ -1,0 +1,2 @@
+GAMEPAD_LEFT_SHOULDER add volume -2     #L1/LB = Volume -2
+GAMEPAD_RIGHT_SHOULDER add volume +2    #R1/RB = Volume +2

--- a/packages/multimedia/mpv/config/mpv.conf
+++ b/packages/multimedia/mpv/config/mpv.conf
@@ -1,0 +1,2 @@
+# Enable gamepad support
+input-gamepad=yes

--- a/packages/multimedia/mpv/config/mpv.conf
+++ b/packages/multimedia/mpv/config/mpv.conf
@@ -1,2 +1,0 @@
-# Enable gamepad support
-input-gamepad=yes

--- a/packages/multimedia/mpv/package.mk
+++ b/packages/multimedia/mpv/package.mk
@@ -31,4 +31,6 @@ PKG_MESON_OPTS_TARGET+=" -Dsdl2=enabled"
 post_makeinstall_target() {
   cp ${PKG_DIR}/scripts/* ${INSTALL}/usr/bin
   chmod 0755 ${INSTALL}/usr/bin/* 2>/dev/null ||:
+  mkdir -p ${INSTALL}/usr/config/mpv
+  cp -rf ${PKG_DIR}/config/* ${INSTALL}/usr/config/mpv/
 }

--- a/packages/multimedia/mpv/scripts/start_mplayer.sh
+++ b/packages/multimedia/mpv/scripts/start_mplayer.sh
@@ -21,6 +21,6 @@ case ${ASPECT} in
   ;;
 esac
 
-/usr/bin/mpv --fullscreen --geometry=${RES} --hwdec=auto-safe --input-ipc-server=/tmp/mpvsocket "${1}"
+/usr/bin/mpv --fullscreen --geometry=${RES} --hwdec=auto-safe --input-gamepad=yes --input-ipc-server=/tmp/mpvsocket "${1}"
 systemctl stop mpv
 exit 0


### PR DESCRIPTION
Why? 
Because whenever when I watch something via MPV, I had to have my keyboard nearby just to change the volume, now I can do that just using my gamepad.
I compiled it and it's working perfectly, I just don't know if this is the best approach.

Test Setup: 
RK3588, Generic Xbox Gamepad, SSH

edit: 
This just adds the volume option "natively", but the old remaps still work.