### PR TITLE
Add expiremental aarch64 cemu support (retroid devices)

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/SM8250/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/SM8250/SUPPORTED_EMULATORS_AND_CORES.md
@@ -75,7 +75,7 @@ This document describes all available systems emulators and cores available for 
 |Nintendo|GameCube (gamecube)|2001|`gamecube`|.gcm .iso .gcz .ciso .wbfs .rvz .dol|**dolphin:** dolphin-qt-gc (default)<br>**dolphin:** dolphin-sa-gc<br>**retroarch:** dolphin<br>|
 |Nintendo|NES (Hacks) (nesh)|1985|`nesh`|.nes .unif .unf .zip .7z|**retroarch:** nestopia (default)<br>**retroarch:** fceumm<br>**retroarch:** quicknes<br>**retroarch:** mesen<br>|
 |Nintendo|Nintendo 3DS (3ds)|2010|`3ds`|.3ds .3dsx .elf .axf .cci .cxi .app|**lime3ds:** lime3ds-sa (default)<br>**retroarch:** panda3ds<br>|
-|Nintendo|Nintendo 64 (n64)|1996|`n64`|.z64 .n64 .v64 .zip .7z|**retroarch:** mupen64plus_next (default)<br>**retroarch:** parallel_n64<br>**mupen64plus:** mupen64plus-sa<br>|
+|Nintendo|Nintendo 64 (n64)|1996|`n64`|.z64 .n64 .v64 .zip .7z|**retroarch:** mupen64plus_next (default)<br>**retroarch:** parallel_n64<br>**mupen64plus:** mupen64plus-sa<br>**daedalus:** daedalus-sa<br>|
 |Nintendo|Nintendo DS (nds)|2005|`nds`|.nds .zip .7z|**drastic:** drastic-sa<br>**retroarch:** melonds<br>**retroarch:** melondsds<br>**melonds:** melonds-sa (default)<br>**retroarch:** desmume<br>|
 |Nintendo|Nintendo Entertainment System (nes)|1985|`nes`|.nes .unif .unf .zip .7z|**retroarch:** nestopia (default)<br>**retroarch:** fceumm<br>**retroarch:** quicknes<br>**retroarch:** mesen<br>|
 |Nintendo|Pokémon Mini (pokemini)|2001|`pokemini`|.min .zip .7z|**retroarch:** pokemini (default)<br>|
@@ -86,6 +86,7 @@ This document describes all available systems emulators and cores available for 
 |Nintendo|Super Nintendo (snes)|1991|`snes`|.smc .fig .sfc .swc .zip .7z|**retroarch:** snes9x (default)<br>**retroarch:** snes9x2010<br>**retroarch:** snes9x2002<br>**retroarch:** snes9x2005_plus<br>**retroarch:** beetle_supafaust<br>**retroarch:** bsnes_mercury_accuracy<br>**retroarch:** bsnes_mercury_balanced<br>**retroarch:** bsnes_mercury_performance<br>**retroarch:** bsnes<br>**retroarch:** bsnes_hd_beta<br>**retroarch:** bsnes_mercury_accuracy<br>**retroarch:** bsnes_mercury_balanced<br>**retroarch:** bsnes_mercury_accuracy<br>**retroarch:** bsnes_mercury_balanced<br>|
 |Nintendo|Virtual Boy (virtualboy)|1995|`virtualboy`|.vb .zip .7z|**retroarch:** beetle_vb (default)<br>|
 |Nintendo|Wii (wii)|2006|`wii`|.gcm .iso .gcz .ciso .wbfs .rvz .dol .wad|**dolphin:** dolphin-qt-wii (default)<br>**dolphin:** dolphin-sa-wii<br>**retroarch:** dolphin<br>|
+|Nintendo|Wii U (wiiu)|2012|`wiiu`|.wud .wux .wua .rpx|**cemu:** cemu-sa (default)<br>|
 |Palm, Inc.|Palm OS (palm)|1996|`palm`|.prc .pqa .img .pdb .zip|**retroarch:** mu (default)<br>|
 |Panasonic|3DO (3do)|1993|`3do`|.iso .bin .chd .cue|**retroarch:** opera (default)<br>|
 |Philips|CD-i (cdi)|1991|`cdi`|.chd .cue .iso|**retroarch:** same_cdi (default)<br>|

--- a/packages/emulators/standalone/cemu-sa/patches/aarch64/001-cemu-gpu-emulation-fixes.patch
+++ b/packages/emulators/standalone/cemu-sa/patches/aarch64/001-cemu-gpu-emulation-fixes.patch
@@ -1,0 +1,738 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025 Cyril Delétré (https://github.com/cdeletre)
+# Copyright (C) 2025 Romain Tisserand (https://github.com/REG-Linux)
+# Copyright (C) 2025 Exzap (https://github.com/Exzap)
+# Copyright (C) 2025 SSimco (https://github.com/SSimco)
+# Copyright (C) 2025 exverge-0 (https://github.com/exverge-0)
+
+From c8fe2428a027a075c4a1c4b6814a86ae65030849 Mon Sep 17 00:00:00 2001
+From: SSimco <37044560+SSimco@users.noreply.github.com>
+Date: Wed, 25 Sep 2024 09:13:18 +0300
+Subject: [PATCH] Added check for alernative R8G8B8A8 format
+
+---
+ src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+index 434d7395e..2ba693018 100644
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+@@ -323,12 +323,12 @@ VkSurfaceFormatKHR SwapchainInfoVk::ChooseSurfaceFormat(const std::vector<VkSurf
+ 
+ 		if (useSRGB)
+ 		{
+-			if (format.format == VK_FORMAT_B8G8R8A8_SRGB && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
++			if ((format.format == VK_FORMAT_B8G8R8A8_SRGB || format.format == VK_FORMAT_R8G8B8A8_SRGB) && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+ 				return format;
+ 		}
+ 		else
+ 		{
+-			if (format.format == VK_FORMAT_B8G8R8A8_UNORM && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
++			if ((format.format == VK_FORMAT_B8G8R8A8_UNORM || format.format == VK_FORMAT_R8G8B8A8_UNORM) && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+ 				return format;
+ 		}
+ 	}
+From 99a5db20eb0aaa52b58c37b945c6edddc3cc99ca Mon Sep 17 00:00:00 2001
+From: SSimco <37044560+SSimco@users.noreply.github.com>
+Date: Thu, 26 Sep 2024 09:06:07 +0300
+Subject: [PATCH] Decode unsuported formats
+
+---
+ src/Cafe/HW/Latte/Core/LatteTextureLoader.h   | 240 ++++++++++++++++++
+ .../Latte/Renderer/Vulkan/VulkanRenderer.cpp  | 130 ++++++++--
+ .../HW/Latte/Renderer/Vulkan/VulkanRenderer.h |   5 +
+ 3 files changed, 355 insertions(+), 20 deletions(-)
+
+diff --git a/src/Cafe/HW/Latte/Core/LatteTextureLoader.h b/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
+index f6de57d68..31b049044 100644
+--- a/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
++++ b/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
+@@ -1640,6 +1640,99 @@ class TextureDecoder_BC1 : public TextureDecoder, public SingletonClass<TextureD
+ 	}
+ };
+ 
++class TextureDecoder_BC1_To_R8G8B8A8 : public TextureDecoder, public SingletonClass<TextureDecoder_BC1_To_R8G8B8A8>
++{
++public:
++
++	sint32 getBytesPerTexel(LatteTextureLoaderCtx* textureLoader) override
++	{
++		return 4;
++	}
++
++	void decode(LatteTextureLoaderCtx* textureLoader, uint8* outputData) override
++	{
++		for (sint32 y = 0; y < textureLoader->height; y += textureLoader->stepY)
++		{
++			for (sint32 x = 0; x < textureLoader->width; x += textureLoader->stepX)
++			{
++				uint8* blockData = LatteTextureLoader_GetInput(textureLoader, x, y);
++				sint32 blockSizeX = (std::min)(4, textureLoader->width - x);
++				sint32 blockSizeY = (std::min)(4, textureLoader->height - y);
++				// decode 4x4 pixels at once
++				float rgbaBlock[4 * 4 * 4];
++				decodeBC1Block(blockData, rgbaBlock);
++				for (sint32 py = 0; py < blockSizeY; py++)
++				{
++					sint32 yc = y + py;
++					for (sint32 px = 0; px < blockSizeX; px++)
++					{
++						sint32 pixelOffset = (x + px + yc * textureLoader->width) * 4; // write to target buffer
++						float red = rgbaBlock[(px + py * 4) * 4 + 0];
++						float green = rgbaBlock[(px + py * 4) * 4 + 1];
++						float blue = rgbaBlock[(px + py * 4) * 4 + 2];
++						float alpha = rgbaBlock[(px + py * 4) * 4 + 3];
++						*(outputData + pixelOffset + 0) = red * 255;
++						*(outputData + pixelOffset + 1) = green * 255;
++						*(outputData + pixelOffset + 2) = blue * 255;
++						*(outputData + pixelOffset + 3) = alpha * 255;
++					}
++				}
++			}
++		}
++	}
++	void decodePixelToRGBA(uint8* blockData, uint8* outputPixel, uint8 blockOffsetX, uint8 blockOffsetY) override
++	{
++		return;
++	}
++};
++
++class TextureDecoder_BC2_To_R8G8B8A8 : public TextureDecoder, public SingletonClass<TextureDecoder_BC2_To_R8G8B8A8>
++{
++public:
++
++	sint32 getBytesPerTexel(LatteTextureLoaderCtx* textureLoader) override
++	{
++		return 4;
++	}
++
++	void decode(LatteTextureLoaderCtx* textureLoader, uint8* outputData) override
++	{
++		for (sint32 y = 0; y < textureLoader->height; y += textureLoader->stepY)
++		{
++			for (sint32 x = 0; x < textureLoader->width; x += textureLoader->stepX)
++			{
++				uint8* blockData = LatteTextureLoader_GetInput(textureLoader, x, y);
++				sint32 blockSizeX = (std::min)(4, textureLoader->width - x);
++				sint32 blockSizeY = (std::min)(4, textureLoader->height - y);
++				// decode 4x4 pixels at once
++				float rgbaBlock[4 * 4 * 4];
++				decodeBC2Block_UNORM(blockData, rgbaBlock);
++				for (sint32 py = 0; py < blockSizeY; py++)
++				{
++					sint32 yc = y + py;
++					for (sint32 px = 0; px < blockSizeX; px++)
++					{
++						sint32 pixelOffset = (x + px + yc * textureLoader->width) * 4; // write to target buffer
++						float red = rgbaBlock[(px + py * 4) * 4 + 0];
++						float green = rgbaBlock[(px + py * 4) * 4 + 1];
++						float blue = rgbaBlock[(px + py * 4) * 4 + 2];
++						float alpha = rgbaBlock[(px + py * 4) * 4 + 3];
++						*(outputData + pixelOffset + 0) = red * 255;
++						*(outputData + pixelOffset + 1) = green * 255;
++						*(outputData + pixelOffset + 2) = blue * 255;
++						*(outputData + pixelOffset + 3) = alpha * 255;
++					}
++				}
++			}
++		}
++	}
++
++	void decodePixelToRGBA(uint8* blockData, uint8* outputPixel, uint8 blockOffsetX, uint8 blockOffsetY) override
++	{
++		return;
++	}
++};
++
+ class TextureDecoder_BC2 : public TextureDecoder, public SingletonClass<TextureDecoder_BC2>
+ {
+ public:
+@@ -1849,6 +1942,53 @@ class TextureDecoder_BC3_uncompress_generic : public TextureDecoder
+ 	}
+ };
+ 
++class TextureDecoder_BC3_To_R8G8B8A8 : public TextureDecoder, public SingletonClass<TextureDecoder_BC3_To_R8G8B8A8>
++{
++public:
++
++	sint32 getBytesPerTexel(LatteTextureLoaderCtx* textureLoader) override
++	{
++		return 4;
++	}
++
++	void decode(LatteTextureLoaderCtx* textureLoader, uint8* outputData) override
++	{
++		for (sint32 y = 0; y < textureLoader->height; y += textureLoader->stepY)
++		{
++			for (sint32 x = 0; x < textureLoader->width; x += textureLoader->stepX)
++			{
++				uint8* blockData = LatteTextureLoader_GetInput(textureLoader, x, y);
++				sint32 blockSizeX = (std::min)(4, textureLoader->width - x);
++				sint32 blockSizeY = (std::min)(4, textureLoader->height - y);
++				// decode 4x4 pixels at once
++				float rgbaBlock[4 * 4 * 4];
++				decodeBC3Block_UNORM(blockData, rgbaBlock);
++				for (sint32 py = 0; py < blockSizeY; py++)
++				{
++					sint32 yc = y + py;
++					for (sint32 px = 0; px < blockSizeX; px++)
++					{
++						sint32 pixelOffset = (x + px + yc * textureLoader->width) * 4; // write to target buffer
++						float red = rgbaBlock[(px + py * 4) * 4 + 0];
++						float green = rgbaBlock[(px + py * 4) * 4 + 1];
++						float blue = rgbaBlock[(px + py * 4) * 4 + 2];
++						float alpha = rgbaBlock[(px + py * 4) * 4 + 3];
++						*(outputData + pixelOffset + 0) = (uint8)(red * 255);
++						*(outputData + pixelOffset + 1) = (uint8)(green * 255);
++						*(outputData + pixelOffset + 2) = (uint8)(blue * 255);
++						*(outputData + pixelOffset + 3) = (uint8)(alpha * 255);
++					}
++				}
++			}
++		}
++	}
++
++	void decodePixelToRGBA(uint8* blockData, uint8* outputPixel, uint8 blockOffsetX, uint8 blockOffsetY) override
++	{
++		return;
++	}
++};
++
+ class TextureDecoder_BC3_UNORM_uncompress : public TextureDecoder_BC3_uncompress_generic, public SingletonClass<TextureDecoder_BC3_UNORM_uncompress>
+ {
+ 	// reuse TextureDecoder_BC3_uncompress_generic
+@@ -1947,6 +2087,55 @@ class TextureDecoder_BC4_UNORM_uncompress : public TextureDecoder, public Single
+ 	}
+ };
+ 
++
++class TextureDecoder_BC4_To_R8 : public TextureDecoder, public SingletonClass<TextureDecoder_BC4_To_R8>
++{
++public:
++
++	sint32 getBytesPerTexel(LatteTextureLoaderCtx* textureLoader) override
++	{
++		return 1;
++	}
++
++	void decode(LatteTextureLoaderCtx* textureLoader, uint8* outputData) override
++	{
++		for (sint32 y = 0; y < textureLoader->height; y += textureLoader->stepY)
++		{
++			for (sint32 x = 0; x < textureLoader->width; x += textureLoader->stepX)
++			{
++				uint8* blockData = LatteTextureLoader_GetInput(textureLoader, x, y);
++				sint32 blockSizeX = (std::min)(4, textureLoader->width - x);
++				sint32 blockSizeY = (std::min)(4, textureLoader->height - y);
++				// decode 4x4 pixels at once
++				float rBlock[4 * 4 * 1];
++				decodeBC4Block_UNORM(blockData, rBlock);
++
++				for (sint32 py = 0; py < blockSizeY; py++)
++				{
++					sint32 yc = y + py;
++					for (sint32 px = 0; px < blockSizeX; px++)
++					{
++						sint32 pixelOffset = (x + px + yc * textureLoader->width); // write to target buffer
++						float red = rBlock[(px + py * 4) * 1 + 0];
++						*(outputData + pixelOffset + 0) = (uint8)(red * 255);
++					}
++				}
++			}
++		}
++	}
++
++	void decodePixelToRGBA(uint8* blockData, uint8* outputPixel, uint8 blockOffsetX, uint8 blockOffsetY) override
++	{
++		float rBlock[4 * 4 * 1];
++		decodeBC4Block_UNORM(blockData, rBlock);
++		float red = rBlock[(blockOffsetX + blockOffsetY * 4) * 1 + 0];
++		*(outputPixel + 0) = (uint8)(red * 255.0f);
++		*(outputPixel + 1) = 0;
++		*(outputPixel + 2) = 0;
++		*(outputPixel + 3) = 255;
++	}
++};
++
+ class TextureDecoder_BC4 : public TextureDecoder, public SingletonClass<TextureDecoder_BC4>
+ {
+ public:
+@@ -1983,6 +2172,57 @@ class TextureDecoder_BC4 : public TextureDecoder, public SingletonClass<TextureD
+ 	}
+ };
+ 
++class TextureDecoder_BC5_To_R8G8 : public TextureDecoder, public SingletonClass<TextureDecoder_BC5_To_R8G8>
++{
++public:
++
++	sint32 getBytesPerTexel(LatteTextureLoaderCtx* textureLoader) override
++	{
++		return 2;
++	}
++
++	void decode(LatteTextureLoaderCtx* textureLoader, uint8* outputData) override
++	{
++		for (sint32 y = 0; y < textureLoader->height; y += textureLoader->stepY)
++		{
++			for (sint32 x = 0; x < textureLoader->width; x += textureLoader->stepX)
++			{
++				uint8* blockData = LatteTextureLoader_GetInput(textureLoader, x, y);
++				sint32 blockSizeX = (std::min)(4, textureLoader->width - x);
++				sint32 blockSizeY = (std::min)(4, textureLoader->height - y);
++				// decode 4x4 pixels at once
++				float rgBlock[4 * 4 * 2];
++				decodeBC5Block_UNORM(blockData, rgBlock);
++
++				for (sint32 py = 0; py < blockSizeY; py++)
++				{
++					sint32 yc = y + py;
++					for (sint32 px = 0; px < blockSizeX; px++)
++					{
++						sint32 pixelOffset = (x + px + yc * textureLoader->width) * 2; // write to target buffer
++						float red = rgBlock[(px + py * 4) * 2 + 0];
++						float green = rgBlock[(px + py * 4) * 2 + 1];
++						*(outputData + pixelOffset + 0) = (uint8)(red * 255);
++						*(outputData + pixelOffset + 1) = (uint8)(green * 255);
++					}
++				}
++			}
++		}
++	}
++
++	void decodePixelToRGBA(uint8* blockData, uint8* outputPixel, uint8 blockOffsetX, uint8 blockOffsetY) override
++	{
++		float rgBlock[4 * 4 * 2];
++		decodeBC5Block_UNORM(blockData, rgBlock);
++		float red = rgBlock[(blockOffsetX + blockOffsetY * 4) * 2 + 0];
++		float green = rgBlock[(blockOffsetX + blockOffsetY * 4) * 2 + 1];
++		*(outputPixel + 0) = (uint8)(red * 255.0f);
++		*(outputPixel + 1) = (uint8)(green * 255.0f);
++		*(outputPixel + 2) = 0;
++		*(outputPixel + 3) = 255;
++	}
++};
++
+ class TextureDecoder_BC5_UNORM_uncompress : public TextureDecoder, public SingletonClass<TextureDecoder_BC5_UNORM_uncompress>
+ {
+ public:
+diff --git a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+index 75c602684..c61c1d04b 100644
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+@@ -1735,6 +1735,16 @@ void VulkanRenderer::QueryMemoryInfo()
+ 
+ void VulkanRenderer::QueryAvailableFormats()
+ {
++	auto isFormatOptimal = [this](VkFormat format) -> bool {
++		VkFormatProperties fmtProp{};
++		vkGetPhysicalDeviceFormatProperties(m_physicalDevice, format, &fmtProp);
++		return fmtProp.optimalTilingFeatures != 0;
++	};
++	m_supportedFormatInfo.fmt_bc1 = isFormatOptimal(VK_FORMAT_BC1_RGBA_SRGB_BLOCK) && isFormatOptimal(VK_FORMAT_BC1_RGBA_UNORM_BLOCK);
++	m_supportedFormatInfo.fmt_bc2 = isFormatOptimal(VK_FORMAT_BC2_UNORM_BLOCK) && isFormatOptimal(VK_FORMAT_BC2_SRGB_BLOCK);
++	m_supportedFormatInfo.fmt_bc3 = isFormatOptimal(VK_FORMAT_BC3_UNORM_BLOCK) && isFormatOptimal(VK_FORMAT_BC3_SRGB_BLOCK);
++	m_supportedFormatInfo.fmt_bc4 = isFormatOptimal(VK_FORMAT_BC4_UNORM_BLOCK) && isFormatOptimal(VK_FORMAT_BC4_SNORM_BLOCK);
++	m_supportedFormatInfo.fmt_bc5 = isFormatOptimal(VK_FORMAT_BC5_UNORM_BLOCK) && isFormatOptimal(VK_FORMAT_BC5_SNORM_BLOCK);
+ 	VkFormatProperties fmtProp{};
+ 	vkGetPhysicalDeviceFormatProperties(m_physicalDevice, VK_FORMAT_D24_UNORM_S8_UINT, &fmtProp);
+ 	// D24S8
+@@ -2465,44 +2475,124 @@ void VulkanRenderer::GetTextureFormatInfoVK(Latte::E_GX2SURFFMT format, bool isD
+ 			break;
+ 			// compressed formats
+ 		case Latte::E_GX2SURFFMT::BC1_SRGB:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC1_RGBA_SRGB_BLOCK; // todo - verify
+-			formatInfoOut->decoder = TextureDecoder_BC1::getInstance();
++			if (m_supportedFormatInfo.fmt_bc1)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC1_RGBA_SRGB_BLOCK; // todo - verify
++				formatInfoOut->decoder = TextureDecoder_BC1::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_SRGB;
++				formatInfoOut->decoder = TextureDecoder_BC1_To_R8G8B8A8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC1_UNORM:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC1_RGBA_UNORM_BLOCK; // todo - verify
+-			formatInfoOut->decoder = TextureDecoder_BC1::getInstance();
++			if (m_supportedFormatInfo.fmt_bc1)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC1_RGBA_UNORM_BLOCK; // todo - verify
++				formatInfoOut->decoder = TextureDecoder_BC1::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_UNORM;
++				formatInfoOut->decoder = TextureDecoder_BC1_To_R8G8B8A8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC2_UNORM:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC2_UNORM_BLOCK; // todo - verify
+-			formatInfoOut->decoder = TextureDecoder_BC2::getInstance();
++			if (m_supportedFormatInfo.fmt_bc2)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC2_UNORM_BLOCK; // todo - verify
++				formatInfoOut->decoder = TextureDecoder_BC2::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_UNORM;
++				formatInfoOut->decoder = TextureDecoder_BC2_To_R8G8B8A8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC2_SRGB:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC2_SRGB_BLOCK; // todo - verify
+-			formatInfoOut->decoder = TextureDecoder_BC2::getInstance();
++			if (m_supportedFormatInfo.fmt_bc2)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC2_SRGB_BLOCK; // todo - verify
++				formatInfoOut->decoder = TextureDecoder_BC2::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_SRGB;
++				formatInfoOut->decoder = TextureDecoder_BC2_To_R8G8B8A8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC3_UNORM:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC3_UNORM_BLOCK;
+-			formatInfoOut->decoder = TextureDecoder_BC3::getInstance();
++			if (m_supportedFormatInfo.fmt_bc3)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC3_UNORM_BLOCK;
++				formatInfoOut->decoder = TextureDecoder_BC3::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_UNORM;
++				formatInfoOut->decoder = TextureDecoder_BC3_To_R8G8B8A8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC3_SRGB:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC3_SRGB_BLOCK;
+-			formatInfoOut->decoder = TextureDecoder_BC3::getInstance();
++			if (m_supportedFormatInfo.fmt_bc3)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC3_SRGB_BLOCK;
++				formatInfoOut->decoder = TextureDecoder_BC3::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_SRGB;
++				formatInfoOut->decoder = TextureDecoder_BC3_To_R8G8B8A8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC4_UNORM:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC4_UNORM_BLOCK;
+-			formatInfoOut->decoder = TextureDecoder_BC4::getInstance();
++			if (m_supportedFormatInfo.fmt_bc4)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC4_UNORM_BLOCK;
++				formatInfoOut->decoder = TextureDecoder_BC4::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8_UNORM;
++				formatInfoOut->decoder = TextureDecoder_BC4_To_R8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC4_SNORM:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC4_SNORM_BLOCK;
+-			formatInfoOut->decoder = TextureDecoder_BC4::getInstance();
++			if (m_supportedFormatInfo.fmt_bc4)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC4_SNORM_BLOCK;
++				formatInfoOut->decoder = TextureDecoder_BC4::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8_SNORM;
++				formatInfoOut->decoder = TextureDecoder_BC4_To_R8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC5_UNORM:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC5_UNORM_BLOCK;
+-			formatInfoOut->decoder = TextureDecoder_BC5::getInstance();
++			if (m_supportedFormatInfo.fmt_bc5)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC5_UNORM_BLOCK;
++				formatInfoOut->decoder = TextureDecoder_BC5::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8_UNORM;
++				formatInfoOut->decoder = TextureDecoder_BC5_To_R8G8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC5_SNORM:
+-			formatInfoOut->vkImageFormat = VK_FORMAT_BC5_SNORM_BLOCK;
+-			formatInfoOut->decoder = TextureDecoder_BC5::getInstance();
++			if (m_supportedFormatInfo.fmt_bc5)
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_BC5_SNORM_BLOCK;
++				formatInfoOut->decoder = TextureDecoder_BC5::getInstance();
++			}
++			else
++			{
++				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8_SNORM;
++				formatInfoOut->decoder = TextureDecoder_BC5_To_R8G8::getInstance();
++			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::R24_X8_UNORM:
+ 			formatInfoOut->vkImageFormat = VK_FORMAT_R32_SFLOAT;
+diff --git a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+index af501b5f5..dccc0079c 100644
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+@@ -21,6 +21,11 @@ struct VkSupportedFormatInfo_t
+ 	bool fmt_r5g6b5_unorm_pack{};
+ 	bool fmt_r4g4b4a4_unorm_pack{};
+ 	bool fmt_a1r5g5b5_unorm_pack{};
++	bool fmt_bc1{};
++	bool fmt_bc2{};
++	bool fmt_bc3{};
++	bool fmt_bc4{};
++	bool fmt_bc5{};
+ };
+ 
+ struct VkDescriptorSetInfo
+From 0c05c3e87f4c0f22bcbf6fd0cedf0e776e63ef72 Mon Sep 17 00:00:00 2001
+From: SSimco <37044560+SSimco@users.noreply.github.com>
+Date: Fri, 27 Sep 2024 01:41:35 +0300
+Subject: [PATCH] Fix bc5 decoding
+
+---
+ src/Cafe/HW/Latte/Core/LatteTextureLoader.h          | 7 ++++---
+ src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp | 4 ++--
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/src/Cafe/HW/Latte/Core/LatteTextureLoader.h b/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
+index 31b049044..8e3ad0985 100644
+--- a/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
++++ b/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
+@@ -46,6 +46,7 @@ void decodeBC3Block_UNORM(uint8* inputData, float* imageRGBA);
+ void decodeBC4Block_UNORM(uint8* blockStorage, float* rOutput);
+ void decodeBC5Block_UNORM(uint8* blockStorage, float* rgOutput);
+ void decodeBC5Block_SNORM(uint8* blockStorage, float* rgOutput);
++using decodingFn = void (uint8 *, float *);
+ 
+ inline void BC1_GetPixel(uint8* inputData, sint32 x, sint32 y, uint8 rgba[4])
+ {
+@@ -2171,8 +2172,8 @@ class TextureDecoder_BC4 : public TextureDecoder, public SingletonClass<TextureD
+ 		*(outputPixel + 3) = 255;
+ 	}
+ };
+-
+-class TextureDecoder_BC5_To_R8G8 : public TextureDecoder, public SingletonClass<TextureDecoder_BC5_To_R8G8>
++template<decodingFn fn>
++class TextureDecoder_BC5_To_R8G8 : public TextureDecoder, public SingletonClass<TextureDecoder_BC5_To_R8G8<fn>>
+ {
+ public:
+ 
+@@ -2192,7 +2193,7 @@ class TextureDecoder_BC5_To_R8G8 : public TextureDecoder, public SingletonClass<
+ 				sint32 blockSizeY = (std::min)(4, textureLoader->height - y);
+ 				// decode 4x4 pixels at once
+ 				float rgBlock[4 * 4 * 2];
+-				decodeBC5Block_UNORM(blockData, rgBlock);
++				fn(blockData, rgBlock);
+ 
+ 				for (sint32 py = 0; py < blockSizeY; py++)
+ 				{
+diff --git a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+index c61c1d04b..521d583c1 100644
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+@@ -2579,7 +2579,7 @@ void VulkanRenderer::GetTextureFormatInfoVK(Latte::E_GX2SURFFMT format, bool isD
+ 			else
+ 			{
+ 				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8_UNORM;
+-				formatInfoOut->decoder = TextureDecoder_BC5_To_R8G8::getInstance();
++				formatInfoOut->decoder = TextureDecoder_BC5_To_R8G8<decodeBC5Block_UNORM>::getInstance();
+ 			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::BC5_SNORM:
+@@ -2591,7 +2591,7 @@ void VulkanRenderer::GetTextureFormatInfoVK(Latte::E_GX2SURFFMT format, bool isD
+ 			else
+ 			{
+ 				formatInfoOut->vkImageFormat = VK_FORMAT_R8G8_SNORM;
+-				formatInfoOut->decoder = TextureDecoder_BC5_To_R8G8::getInstance();
++				formatInfoOut->decoder = TextureDecoder_BC5_To_R8G8<decodeBC5Block_SNORM>::getInstance();
+ 			}
+ 			break;
+ 		case Latte::E_GX2SURFFMT::R24_X8_UNORM:
+From 15183df480dba3e6e36b0ab246da25efda4ab63c Mon Sep 17 00:00:00 2001
+From: SSimco <37044560+SSimco@users.noreply.github.com>
+Date: Sun, 13 Oct 2024 20:33:50 +0300
+Subject: [PATCH] Check for alternative mem types & optional extensions
+
+---
+ .../Latte/Renderer/Vulkan/VulkanRenderer.cpp  | 19 ++++++++++++++++---
+ .../HW/Latte/Renderer/Vulkan/VulkanRenderer.h |  1 +
+ 2 files changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+index 521d583c1..fcc936ad2 100644
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+@@ -585,9 +585,11 @@ VulkanRenderer::VulkanRenderer()
+ 		m_uniformVarBufferMemoryIsCoherent = true; // unified memory
+ 	else if (memoryManager->CreateBuffer2(UNIFORMVAR_RINGBUFFER_SIZE, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, m_uniformVarBuffer, m_uniformVarBufferMemory))
+ 		m_uniformVarBufferMemoryIsCoherent = true;
++	else if (memoryManager->CreateBuffer2(UNIFORMVAR_RINGBUFFER_SIZE, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, m_uniformVarBuffer, m_uniformVarBufferMemory))
++		m_uniformVarBufferMemoryIsCoherent = true;
+ 	else
+ 	{
+-		memoryManager->CreateBuffer2(UNIFORMVAR_RINGBUFFER_SIZE, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, m_uniformVarBuffer, m_uniformVarBufferMemory);
++		memoryManager->CreateBuffer(UNIFORMVAR_RINGBUFFER_SIZE, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, m_uniformVarBuffer, m_uniformVarBufferMemory);
+ 	}
+ 
+ 	if (!m_uniformVarBufferMemoryIsCoherent)
+@@ -597,7 +599,10 @@ VulkanRenderer::VulkanRenderer()
+ 	m_uniformVarBufferPtr = (uint8*)bufferPtr;
+ 
+ 	// texture readback buffer
+-	memoryManager->CreateBuffer(TEXTURE_READBACK_SIZE, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_textureReadbackBuffer, m_textureReadbackBufferMemory);
++	if (!memoryManager->CreateBuffer2(TEXTURE_READBACK_SIZE, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_textureReadbackBuffer, m_textureReadbackBufferMemory))
++	{
++		memoryManager->CreateBuffer(TEXTURE_READBACK_SIZE, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_textureReadbackBuffer, m_textureReadbackBufferMemory);
++	}
+ 	bufferPtr = nullptr;
+ 	vkMapMemory(m_logicalDevice, m_textureReadbackBufferMemory, 0, VK_WHOLE_SIZE, 0, &bufferPtr);
+ 	m_textureReadbackBufferPtr = (uint8*)bufferPtr;
+@@ -606,7 +611,10 @@ VulkanRenderer::VulkanRenderer()
+ 	memoryManager->CreateBuffer(LatteStreamout_GetRingBufferSize(), VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | (m_featureControl.mode.useTFEmulationViaSSBO ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT : 0), 0, m_xfbRingBuffer, m_xfbRingBufferMemory);
+ 
+ 	// occlusion query result buffer
+-	memoryManager->CreateBuffer(OCCLUSION_QUERY_POOL_SIZE * sizeof(uint64), VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_occlusionQueries.bufferQueryResults, m_occlusionQueries.memoryQueryResults);
++	if (!memoryManager->CreateBuffer2(OCCLUSION_QUERY_POOL_SIZE * sizeof(uint64), VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_occlusionQueries.bufferQueryResults, m_occlusionQueries.memoryQueryResults))
++	{
++		memoryManager->CreateBuffer(OCCLUSION_QUERY_POOL_SIZE * sizeof(uint64), VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_occlusionQueries.bufferQueryResults, m_occlusionQueries.memoryQueryResults);
++	}
+ 	bufferPtr = nullptr;
+ 	vkMapMemory(m_logicalDevice, m_occlusionQueries.memoryQueryResults, 0, VK_WHOLE_SIZE, 0, &bufferPtr);
+ 	m_occlusionQueries.ptrQueryResults = (uint64*)bufferPtr;
+@@ -1087,6 +1095,10 @@ VkDeviceCreateInfo VulkanRenderer::CreateDeviceCreateInfo(const std::vector<VkDe
+ 		used_extensions.emplace_back(VK_KHR_PRESENT_ID_EXTENSION_NAME);
+ 	if (m_featureControl.deviceExtensions.present_wait)
+ 		used_extensions.emplace_back(VK_KHR_PRESENT_WAIT_EXTENSION_NAME);
++	if (m_featureControl.deviceExtensions.transform_feedback)
++		used_extensions.emplace_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
++	if (m_featureControl.deviceExtensions.depth_clip_enable)
++		used_extensions.emplace_back(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
+ 
+ 	VkDeviceCreateInfo createInfo{};
+ 	createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+@@ -1174,6 +1186,7 @@ bool VulkanRenderer::CheckDeviceExtensionSupport(const VkPhysicalDevice device,
+ 	info.deviceExtensions.tooling_info = isExtensionAvailable(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
+ 	info.deviceExtensions.transform_feedback = isExtensionAvailable(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+ 	info.deviceExtensions.depth_range_unrestricted = isExtensionAvailable(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
++	info.deviceExtensions.depth_clip_enable = isExtensionAvailable(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
+ 	info.deviceExtensions.nv_fill_rectangle = isExtensionAvailable(VK_NV_FILL_RECTANGLE_EXTENSION_NAME);
+ 	info.deviceExtensions.pipeline_feedback = isExtensionAvailable(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
+ 	info.deviceExtensions.cubic_filter = isExtensionAvailable(VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
+diff --git a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+index dccc0079c..2f2f817ea 100644
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+@@ -449,6 +449,7 @@ class VulkanRenderer : public Renderer
+ 			bool tooling_info = false; // VK_EXT_tooling_info
+ 			bool transform_feedback = false;
+ 			bool depth_range_unrestricted = false;
++			bool depth_clip_enable = false;
+ 			bool nv_fill_rectangle = false; // NV_fill_rectangle
+ 			bool pipeline_feedback = false;
+ 			bool pipeline_creation_cache_control = false; // VK_EXT_pipeline_creation_cache_control
+diff -u -r a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp	2025-01-22 13:44:05.597460220 +0100
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp	2025-01-22 13:56:54.144925519 +0100
+@@ -55,7 +55,6 @@
+ const std::vector<const char*> kRequiredDeviceExtensions =
+ {
+ 	VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+-	VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME
+ }; // Intel doesnt support VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME
+ 
+ VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)
+@@ -271,7 +270,12 @@
+ 	vkGetPhysicalDeviceFeatures2(m_physicalDevice, &physicalDeviceFeatures2);
+ 
+ 	cemuLog_log(LogType::Force, "Vulkan: present_wait extension: {}", (pwf.presentWait && pidf.presentId) ? "supported" : "unsupported");
+-
++	m_featureControl.deviceFeatures.geometry_shader = physicalDeviceFeatures2.features.geometryShader;
++	m_featureControl.deviceFeatures.logic_op = physicalDeviceFeatures2.features.logicOp;
++	m_featureControl.deviceFeatures.sampler_anisotropy = physicalDeviceFeatures2.features.samplerAnisotropy;
++	m_featureControl.deviceFeatures.occlusion_query_precise = physicalDeviceFeatures2.features.occlusionQueryPrecise;
++	m_featureControl.deviceFeatures.depth_clamp = physicalDeviceFeatures2.features.depthClamp;
++	m_featureControl.deviceFeatures.vertex_pipeline_stores_and_atomics = physicalDeviceFeatures2.features.vertexPipelineStoresAndAtomics;
+ 	/* Get Vulkan device properties and limits */
+ 	VkPhysicalDeviceFloatControlsPropertiesKHR pfcp{};
+ 	prevStruct = nullptr;
+@@ -464,14 +468,12 @@
+ 	VkPhysicalDeviceFeatures deviceFeatures = {};
+ 
+ 	deviceFeatures.independentBlend = VK_TRUE;
+-	deviceFeatures.samplerAnisotropy = VK_TRUE;
++	deviceFeatures.samplerAnisotropy = m_featureControl.deviceFeatures.sampler_anisotropy;
+ 	deviceFeatures.imageCubeArray = VK_TRUE;
+-#if !BOOST_OS_MACOS
+-	deviceFeatures.geometryShader = VK_TRUE;
+-	deviceFeatures.logicOp = VK_TRUE;
+-#endif
+-	deviceFeatures.occlusionQueryPrecise = VK_TRUE;
+-	deviceFeatures.depthClamp = VK_TRUE;
++	deviceFeatures.geometryShader = m_featureControl.deviceFeatures.geometry_shader;
++	deviceFeatures.logicOp = m_featureControl.deviceFeatures.logic_op;
++	deviceFeatures.occlusionQueryPrecise = m_featureControl.deviceFeatures.occlusion_query_precise;
++	deviceFeatures.depthClamp = m_featureControl.deviceFeatures.depth_clamp;
+ 	deviceFeatures.depthBiasClamp = VK_TRUE;
+ 	if (m_vendor == GfxVendor::AMD)
+ 	{
+@@ -480,7 +482,7 @@
+ 	}
+ 	if (m_featureControl.mode.useTFEmulationViaSSBO)
+ 	{
+-		deviceFeatures.vertexPipelineStoresAndAtomics = true;
++		m_featureControl.mode.useTFEmulationViaSSBO = deviceFeatures.vertexPipelineStoresAndAtomics = m_featureControl.deviceFeatures.vertex_pipeline_stores_and_atomics;
+ 	}
+ 
+ 	void* deviceExtensionFeatures = nullptr;
+@@ -611,7 +613,7 @@
+ 	// occlusion query result buffer
+ 	if (!memoryManager->CreateBuffer2(OCCLUSION_QUERY_POOL_SIZE * sizeof(uint64), VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_occlusionQueries.bufferQueryResults, m_occlusionQueries.memoryQueryResults))
+ 	{
+-		memoryManager->CreateBuffer(OCCLUSION_QUERY_POOL_SIZE * sizeof(uint64), VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_occlusionQueries.bufferQueryResults, m_occlusionQueries.memoryQueryResults);
++		memoryManager->CreateBuffer(OCCLUSION_QUERY_POOL_SIZE * sizeof(uint64), VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, m_occlusionQueries.bufferQueryResults, m_occlusionQueries.memoryQueryResults);
+ 	}
+ 	bufferPtr = nullptr;
+ 	vkMapMemory(m_logicalDevice, m_occlusionQueries.memoryQueryResults, 0, VK_WHOLE_SIZE, 0, &bufferPtr);
+@@ -2892,7 +2894,7 @@
+ 	{
+ 		throw std::runtime_error(fmt::format("Failed to present image: {}", result));
+ 	}
+-	if(result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
++	if(result == VK_ERROR_OUT_OF_DATE_KHR)
+ 		chainInfo.m_shouldRecreate = true;
+ 
+ 	if(result >= 0)
+diff -u -r a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h	2025-01-22 13:44:05.597460220 +0100
++++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h	2025-01-22 13:53:02.918435661 +0100
+@@ -461,6 +461,16 @@
+ 
+ 		struct
+ 		{
++			bool geometry_shader;
++			bool logic_op;
++			bool sampler_anisotropy;
++			bool occlusion_query_precise;
++			bool depth_clamp;
++			bool vertex_pipeline_stores_and_atomics;
++		} deviceFeatures;
++
++		struct
++		{
+ 			bool shaderRoundingModeRTEFloat32{ false };
+ 		}shaderFloatControls; // from VK_KHR_shader_float_controls
+

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -74,7 +74,7 @@ case "${DEVICE}" in
   ;;
   SM8250)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 daedalus-sa desmume-lr gpsp-lr pcsx_rearmed-lr wine"
-    PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa lime3ds-sa melonds-sa portmaster rpcs3-sa scummvmsa supermodel-sa \
+    PKG_EMUS+=" aethersx2-sa box64 cemu-sa dolphin-sa drastic-sa lime3ds-sa melonds-sa portmaster rpcs3-sa scummvmsa supermodel-sa \
                yabasanshiro-sa xemu-sa"
     LIBRETRO_CORES+=" beetle-psx-lr beetle-saturn-lr bsnes-lr bsnes-hd-lr dolphin-lr flycast-lr geolith-lr panda3ds-lr pcsx_rearmed-lr uae4arm kronos-lr"
     PKG_RETROARCH+=" retropie-shaders"
@@ -548,7 +548,7 @@ makeinstall_target() {
 
   ### Nintendo Wii U
   case ${DEVICE} in
-    AMD64)
+    AMD64|SM8250)
       add_emu_core wiiu cemu cemu-sa true
       add_es_system wiiu
       install_script "Start CEMU.sh"


### PR DESCRIPTION
Over the past month or so Cyril worked on porting the android build over to aarch64 linux and this is the result of that. And also contributions from the following users (and also small contributions from myself):

Thanks to Cyril Delétré of the (PortMaster team) for the creation of a Linux aarch64 version from the Android port. https://github.com/cdeletre
Thanks to rtissera / Romain Tisserand of the REG-Linux team for debugging and fixing crashing issues in the Linux aarch64 version. https://github.com/REG-Linux
Thanks to Exzap for the rework of the recompiler. https://github.com/Exzap
Thanks to SSimco for the Android aarch64 port. https://github.com/SSimco
Thanks to exverge-0 for the work on macOS: Apple Silicon support. https://github.com/exverge-0

This port to aarch64 is very experimental and you will get some crashing. 

Patches in their current form taken from https://github.com/REG-Linux/REG-Linux/tree/master/board/reglinux/patches/aarch64/cemu