### PR TITLE
updated syncthing and rclone to latest versions

### DIFF
--- a/packages/network/rclone/package.mk
+++ b/packages/network/rclone/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="rclone"
-PKG_VERSION="1.67.0"
+PKG_VERSION="1.69.0"
 PKG_DEPENDS_TARGET="toolchain fuse rsync"
 PKG_LONGDESC="rsync for cloud storage"
 PKG_TOOLCHAIN="manual"

--- a/packages/network/syncthing/package.mk
+++ b/packages/network/syncthing/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.27.1"
+PKG_VERSION="1.29.2"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"
 PKG_URL="https://github.com/syncthing/syncthing/releases/download/v${PKG_VERSION}/syncthing-source-v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Bumped rclone and Syncthing to the latest versions. Tested and confirmed on RK3566 (RG353M).
- rclone: 1.67.0 > 1.69.0
- Syncthing: 1.27.1 > 1.29.2