### PR TITLE
dolphin-sa - GC memory cards - handle only exists in .config scenario

### DIFF
--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
@@ -65,14 +65,25 @@ fi
 # Link bios and memory cards to roms
 for REGION in EUR JAP USA
 do
+  # Link bios
   rm -rf "/storage/.config/dolphin-emu/GC/${REGION}"
   ln -sf "/storage/roms/bios/GC/${REGION}" "/storage/.config/dolphin-emu/GC/${REGION}"
 
+  # Link memory cards, copying to roms/bios first as needed
   for SLOT in A B
   do
-    if [ -f "/storage/roms/bios/GC/MemoryCard${SLOT}.${REGION}.raw" ]; then
-      rm -f "/storage/.config/dolphin-emu/GC/MemoryCard${SLOT}.${REGION}.raw"
-      ln -sf "/storage/roms/bios/GC/MemoryCard${SLOT}.${REGION}.raw" "/storage/.config/dolphin-emu/GC/MemoryCard${SLOT}.${REGION}.raw"
+    MEM_CARD_FILE="MemoryCard${SLOT}.${REGION}.raw"
+    CONFIG_MEM_CARD="/storage/.config/dolphin-emu/GC/${MEM_CARD_FILE}"
+    ROMS_BIOS_MEM_CARD="/storage/roms/bios/GC/${MEM_CARD_FILE}"
+
+    if [ -f "${ROMS_BIOS_MEM_CARD}" ]; then
+      # Exists in roms/bios, remove from .config and link
+      rm -f "${CONFIG_MEM_CARD}"
+      ln -sf "${ROMS_BIOS_MEM_CARD}" "${CONFIG_MEM_CARD}"
+    elif [ -f "${CONFIG_MEM_CARD}" ]; then
+      # Only exists in .config, move to roms/bios and link
+      mv -f "${CONFIG_MEM_CARD}" "${ROMS_BIOS_MEM_CARD}"
+      ln -sf "${ROMS_BIOS_MEM_CARD}" "${CONFIG_MEM_CARD}"
     fi
   done
 done

--- a/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
+++ b/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
@@ -72,14 +72,25 @@ fi
 # Link bios and memory cards to roms
 for REGION in EUR JAP USA
 do
+  # Link bios
   rm -rf "/storage/.config/dolphin-emu/GC/${REGION}"
   ln -sf "/storage/roms/bios/GC/${REGION}" "/storage/.config/dolphin-emu/GC/${REGION}"
 
+  # Link memory cards, copying to roms/bios first as needed
   for SLOT in A B
   do
-    if [ -f "/storage/roms/bios/GC/MemoryCard${SLOT}.${REGION}.raw" ]; then
-      rm -f "/storage/.config/dolphin-emu/GC/MemoryCard${SLOT}.${REGION}.raw"
-      ln -sf "/storage/roms/bios/GC/MemoryCard${SLOT}.${REGION}.raw" "/storage/.config/dolphin-emu/GC/MemoryCard${SLOT}.${REGION}.raw"
+    MEM_CARD_FILE="MemoryCard${SLOT}.${REGION}.raw"
+    CONFIG_MEM_CARD="/storage/.config/dolphin-emu/GC/${MEM_CARD_FILE}"
+    ROMS_BIOS_MEM_CARD="/storage/roms/bios/GC/${MEM_CARD_FILE}"
+
+    if [ -f "${ROMS_BIOS_MEM_CARD}" ]; then
+      # Exists in roms/bios, remove from .config and link
+      rm -f "${CONFIG_MEM_CARD}"
+      ln -sf "${ROMS_BIOS_MEM_CARD}" "${CONFIG_MEM_CARD}"
+    elif [ -f "${CONFIG_MEM_CARD}" ]; then
+      # Only exists in .config, move to roms/bios and link
+      mv -f "${CONFIG_MEM_CARD}" "${ROMS_BIOS_MEM_CARD}"
+      ln -sf "${ROMS_BIOS_MEM_CARD}" "${CONFIG_MEM_CARD}"
     fi
   done
 done


### PR DESCRIPTION
End result is GC memory card and bios files in `/storage/roms/bios/GC`, linked to `/storage/.config/dolphin-emu/GC`:
```
.config/dolphin-emu/GC
|-- EUR -> /storage/roms/bios/GC/EUR
|-- JAP -> /storage/roms/bios/GC/JAP
|-- MemoryCardA.EUR.raw -> /storage/roms/bios/GC/MemoryCardA.EUR.raw
|-- MemoryCardA.USA.raw -> /storage/roms/bios/GC/MemoryCardA.USA.raw
|-- USA -> /storage/roms/bios/GC/USA
|-- dsp_coef.bin
|-- dsp_rom.bin
|-- font-licenses.txt
|-- font_japanese.bin
`-- font_western.bin

/roms/bios/GC
|-- EUR
|   `-- IPL.bin
|-- JAP
|   `-- IPL.bin
|-- MemoryCardA.EUR.raw
|-- MemoryCardA.USA.raw
|-- USA
|   `-- IPL.bin
|-- dsp_coef.bin
|-- dsp_rom.bin
|-- font-licenses.txt
|-- font_japanese.bin
`-- font_western.bin
```