### PR TITLE
RK3399: Update u-boot to 2025.01

### DIFF
--- a/projects/Rockchip/devices/RK3399/packages/u-boot/package.mk
+++ b/projects/Rockchip/devices/RK3399/packages/u-boot/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="u-boot"
-PKG_VERSION="2024.10"
+PKG_VERSION="2025.01"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
 PKG_URL="https://ftp.denx.de/pub/u-boot/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
Tested working on the Anbernic RG552. 