### PR TITLE
aethersx2-sa - add libpcap dependency

### DIFF
--- a/packages/emulators/standalone/aethersx2-sa/package.mk
+++ b/packages/emulators/standalone/aethersx2-sa/package.mk
@@ -7,7 +7,7 @@ PKG_ARCH="aarch64"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://github.com/ROCKNIX/packages"
 PKG_URL="${PKG_SITE}/raw/refs/heads/main/aethersx2.tar.gz"
-PKG_DEPENDS_TARGET="toolchain qt6 libgpg-error fuse2 xz"
+PKG_DEPENDS_TARGET="toolchain qt6 libgpg-error fuse2 xz libpcap"
 PKG_LONGDESC="Arm PS2 Emulator appimage"
 PKG_TOOLCHAIN="manual"
 


### PR DESCRIPTION
Tested on my OGU, fixes crashes at launch with `libpcap` not found errors in the log.