### PR TITLE
bdf2psf: bump version 233->234

### DIFF
--- a/packages/textproc/bdf2psf/package.mk
+++ b/packages/textproc/bdf2psf/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="bdf2psf"
-PKG_VERSION="1.233"
+PKG_VERSION="1.234"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://packages.debian.org/unstable/${PKG_NAME}"
 PKG_URL="https://deb.debian.org/debian/pool/main/c/console-setup/${PKG_NAME}_${PKG_VERSION}_all.deb"


### PR DESCRIPTION
```
--2025-02-21 09:00:12--  https://deb.debian.org/debian/pool/main/c/console-setup/bdf2psf_1.233_all.deb
Resolving deb.debian.org (deb.debian.org)... 151.101.42.132, 2a04:4e42:a::644
Connecting to deb.debian.org (deb.debian.org)|151.101.42.132|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-02-21 09:00:12 ERROR 404: Not Found.
```