### PR TITLE
Add threshold setting in ES for battery warning

### DIFF
--- a/packages/rocknix/config/system/configs/system.cfg
+++ b/packages/rocknix/config/system/configs/system.cfg
@@ -178,6 +178,7 @@ syncthing.enabled=0
 system.autohotkeys=1
 system.automount=1
 system.battery.warning=0
+system.battery.warning_threshold=25
 system.hostname=@DEVICENAME@
 system.language=en_US
 system.loglevel=none

--- a/packages/sysutils/powerstate/sources/powerstate.sh
+++ b/packages/sysutils/powerstate/sources/powerstate.sh
@@ -75,7 +75,10 @@ do
      [[ "${AC_STATUS}" =~ Disch ]]
   then
     AUDIBLEALERT=$(get_setting system.battery.warning)
-    if (( ${BATLEFT} < "26" ))
+    AUDIBLEALERT_THRESHOLD=$(get_setting system.battery.warning_threshold)
+    [[ -z $AUDIBLEALERT_THRESHOLD ]] && AUDIBLEALERT_THRESHOLD=25
+
+    if [[ ${BATLEFT} -le ${AUDIBLEALERT_THRESHOLD} ]]
     then
       if [ "${DEVICE_LED_CONTROL}" = "true" ]  &&  [ ! "${DEVICE_BATTERY_LED_STATUS}" = "true" ]
       then


### PR DESCRIPTION
This PR adds the possibility to adjust the battery threshold in ES for the warnings.

The slide is displayed even if `ENABLE AUDIBLE BATTERY WARNING` is set to `false` because it the threshold is also used for the LED alert (which I wasn't able to test on RP5).

I've added this lines because I'm not 100% about the default behaviour when the value is not found in `system.cfg` after an upgrade.

```cpp
	if (SystemConf::getInstance()->get("system.battery.warning_threshold").length() == 0) {
		SystemConf::getInstance()->set("system.battery.warning_threshold", "25");
	}
```
