### PR TITLE
fix(cemu): wii_u_pro_controller invert a/b and x/y

### DIFF
--- a/packages/emulators/standalone/cemu-sa/config/controllerProfiles/wii_u_pro_controller.xml
+++ b/packages/emulators/standalone/cemu-sa/config/controllerProfiles/wii_u_pro_controller.xml
@@ -61,11 +61,11 @@
 			</entry>
 			<entry>
 				<mapping>4</mapping>
-				<button>2</button>
+				<button>3</button>
 			</entry>
 			<entry>
 				<mapping>3</mapping>
-				<button>3</button>
+				<button>2</button>
 			</entry>
 			<entry>
 				<mapping>24</mapping>
@@ -109,7 +109,7 @@
 			</entry>
 			<entry>
 				<mapping>2</mapping>
-				<button>0</button>
+				<button>1</button>
 			</entry>
 			<entry>
 				<mapping>14</mapping>
@@ -117,7 +117,7 @@
 			</entry>
 			<entry>
 				<mapping>1</mapping>
-				<button>1</button>
+				<button>0</button>
 			</entry>
 		</mappings>
 	</controller>


### PR DESCRIPTION
The current configuration has the A/B and X/Y buttons inverted in the Retroid 5.
I think it would be nice to have them match the physical layout.

Could anyone please help me making this change only for the Retroid devices? I understand, the change I'm suggesting shouldn't be applied globally.