### PR TITLE
SM8550 - emulationstation - es_input.cfg - fix Odin2 guid

### DIFF
--- a/packages/ui/emulationstation/config/common/es_input.cfg
+++ b/packages/ui/emulationstation/config/common/es_input.cfg
@@ -1623,7 +1623,7 @@
                 <input name="x" type="button" id="2" value="1" />
                 <input name="y" type="button" id="3" value="1" />
         </inputConfig>
-        <inputConfig type="joystick" deviceName="AYN Odin2 Gamepad" deviceGUID="0300f353202000000130000001000000">
+        <inputConfig type="joystick" deviceName="AYN Odin2 Gamepad" deviceGUID="0300b605202000000130000001000000">
                 <input name="a" type="button" id="1" value="1" />
                 <input name="b" type="button" id="0" value="1" />
                 <input name="down" type="button" id="12" value="1" />


### PR DESCRIPTION
guid was a duplicate of the Retroid Pocket gamepad entry. Tested on my Odin 2.