### PR TITLE
busybox/init: copy and mount system image without slashes when SYSTEM_TORAM is yes

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -277,8 +277,8 @@ mount_part() {
 
 mount_sysroot() {
   if [ "${SYSTEM_TORAM}" = "yes" ]; then
-    cp /flash/${IMAGE_SYSTEM} /dev/${IMAGE_SYSTEM}
-    mount_part "/dev/${IMAGE_SYSTEM}" "/sysroot" "ro,loop"
+    cp /flash/${IMAGE_SYSTEM} /dev/${IMAGE_SYSTEM##*/}
+    mount_part "/dev/${IMAGE_SYSTEM##*/}" "/sysroot" "ro,loop"
   else
     mount_part "/flash/${IMAGE_SYSTEM}" "/sysroot" "ro,loop"
   fi


### PR DESCRIPTION
Useful when `SYSTEM_TORAM` is set to yes and `IMAGE_SYSTEM` is at a non-standard location and in a subfolder (path contains a `/`), because otherwise it will fail (the copy will fail because it will try to copy to a non-existent folder, and so does the mount after it)

Example boot parameters:
```SYSTEM_IMAGE=/rocknix_system/IMAGE toram```

Either that, or detect if IMAGE_SYSTEM contains forward slashes, and create recursive directories in `/dev/`