### PR TITLE
fs-resize: Add configurable game partition for Windows users

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -19,6 +19,13 @@ if [ -e /storage/.please_resize_me ] ; then
   LOG=/flash/fs-resize.log
   date -Iseconds >>$LOG
 
+  # Check for resize_storage_xG file
+  RESIZE_FILE=$(find /flash -maxdepth 1 -name 'resize_storage_*G')
+  TARGET_SIZE=""
+  if [ -n "$RESIZE_FILE" ]; then
+    TARGET_SIZE=$(basename "$RESIZE_FILE" | sed -E 's/^resize_storage_([0-9]+)G$/\1G/')
+  fi
+
   # this sh** was never intended to be used
   # on already installed and runing system
   if [ -d /storage/.config -o -d /storage/.cache ] ; then
@@ -59,9 +66,22 @@ if [ -e /storage/.please_resize_me ] ; then
     echo "Please do not reboot or turn off your @DISTRONAME@ device!"
     echo ""
 
-    StartProgressLog spinner "Resizing partition...   " "parted -s -f -m $DISK resizepart $PARTNUM 100% >>$LOG 2>&1"
+    if [ -n "$TARGET_SIZE" ]; then
+      StartProgressLog spinner "Resizing storage partition to $TARGET_SIZE...   " "parted -s -f -m $DISK resizepart $PARTNUM ${TARGET_SIZE} >>$LOG 2>&1"
+    else
+      StartProgressLog spinner "Resizing storage partition to maximum size...   " "parted -s -f -m $DISK resizepart $PARTNUM 100% >>$LOG 2>&1"
+    fi
+
     StartProgressLog spinner "Checking file system... " "e2fsck -f -p $PART >>$LOG 2>&1"
     StartProgressLog spinner "Resizing file system... " "resize2fs $PART >>$LOG 2>&1"
+    if [ -n "$TARGET_SIZE" ]; then
+      # Create GAMES partition using relative positioning
+      GAME_PART=$(echo $PART | awk -F'[p]' '{print $1"p"($2+1)}')
+      StartProgress spinner "Creating GAMES partition..." "parted -s -a optimal -m $DISK mkpart primary fat32 ${TARGET_SIZE} 100% >>$LOG 2>&1"
+      StartProgress spinner "Formatting GAMES partition as EXFAT..." "mkfs.exfat -n GAMES ${GAME_PART} >>$LOG 2>&1"
+      echo "Created new GAMES partition on ${DISK}${GAME_PARTNUM}" >>$LOG
+      rm -f /flash/resize_storage_*
+    fi
     StartProgressLog spinner "Syncing to disk...      " "sync >>$LOG 2>&1"
     StartProgress countdown "Rebooting in 5s...     " 5 "NOW"
   else


### PR DESCRIPTION
Previously, all remaining space on the system disk was allocated to the storage partition. This approach may not be ideal for Windows users who wish to add games, as it doesn't provide a dedicated Windows known partition. Although Windows users can utilize Samba and USB methods for transferring game data, these methods tend to be slower compared to direct copying via a card reader, especially for large game files.

This commit introduces the ability to create a configurable "GAMES" partition. Users can now specify the desired size of the storage partition by creating a file named `resize_storage_xG` in the `/flash` partition before the first system startup (after flashing the image to the disk). The `fs-resize` script will then:

1. Resize the storage partition to end at `xG`.
2. Create a new "GAMES" partition using the remaining space on the disk.

If the `resize_storage_xG` file is not present, the `fs-resize` script will default to allocating all available space to the storage partition as before.

Example:
- To reserve storage partition ends with 50G and use the remaining space for the GAMES partition, create a file named `resize_storage_50G` in the `/flash` partition.