### PR TITLE
busybox/init: add bootflags and diskflags params

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -679,11 +679,14 @@ wakeonlan() {
 }
 
 mount_flash() {
+  local mount_options="ro,noatime"
+  [ ! -z "$bootflags" ] && mount_options="$mount_options,$bootflags"
+
   progress "Mounting flash"
 
   wakeonlan
 
-  mount_part "$boot" "/flash" "ro,noatime"
+  mount_part "$boot" "/flash" "$mount_options"
 
   if [ -f /flash/post-flash.sh ]; then
     . /flash/post-flash.sh
@@ -705,6 +708,9 @@ cleanup_flash() {
 }
 
 mount_storage() {
+  local mount_options="rw,noatime"
+  [ ! -z "$diskflags" ] && mount_options="$mount_options,$diskflags"
+
   progress "Mounting storage"
 
   if [ "${LIVE}" = "yes" ]; then
@@ -719,7 +725,7 @@ mount_storage() {
     if [ -n "${OVERLAY}" ]; then
       OVERLAY_DIR=$(cat /sys/class/net/eth0/address | tr -d :)
 
-      mount_part "$disk" "/storage" "rw,noatime"
+      mount_part "$disk" "/storage" "$mount_options"
       mkdir -p /storage/${OVERLAY_DIR}
       umount /storage &>/dev/null
 
@@ -736,7 +742,7 @@ mount_storage() {
     if [ -f /flash/mount-storage.sh ]; then
       . /flash/mount-storage.sh
     else
-      mount_part "$disk" "/storage" "rw,noatime"
+      mount_part "$disk" "/storage" "$mount_options"
     fi
   else
     # /storage should always be writable
@@ -1179,6 +1185,12 @@ for arg in $(cat /proc/cmdline); do
           RUN_FSCK_DISKS="${RUN_FSCK_DISKS} ${disk#*=}"
           ;;
       esac
+      ;;
+    bootflags=*)
+      bootflags="${arg#*=}"
+      ;;
+    diskflags=*)
+      diskflags="${arg#*=}"
       ;;
     wol_mac=*)
       wol_mac="${arg#*=}"


### PR DESCRIPTION
Allows specifying additional mount options for `boot` and `disk` mounts, similar to rootflags on Linux systems

This patch allow (advanced) users to specify additional mount options
My specific usecase of this change is to put both `boot` and `disk` on btrfs subvolumes