### PR TITLE
libfmt: enable version 11 for SM8250 and SM8550 and remove deprecated SD865 device name

### DIFF
--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="libfmt"
 case ${DEVICE} in
-  SD865|AMD64)
+  SM8250|SM8550|AMD64)
     PKG_VERSION="11.1.3"
   ;;
   *)


### PR DESCRIPTION
Can't make my limonade without fmt 11

It might also be the reason why cemu-sa is running like sh*t on the SM8550 build, I have felt that fm11 gave me better results on SM8250