### PR TITLE
Aethersx2 settings updates

### DIFF
--- a/packages/emulators/standalone/aethersx2-sa/config/RK3399/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/RK3399/aethersx2/inis/PCSX2.ini
@@ -2,6 +2,8 @@
 SettingsVersion = 1
 StartFullscreen = true
 RenderToSeparateWindow = true
+DoubleClickTogglesFullscreen = false
+
 
 [EmuCore]
 CdvdVerboseReads = false

--- a/packages/emulators/standalone/aethersx2-sa/config/RK3588/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/RK3588/aethersx2/inis/PCSX2.ini
@@ -2,6 +2,8 @@
 SettingsVersion = 1
 StartFullscreen = true
 RenderToSeparateWindow = true
+DoubleClickTogglesFullscreen = false
+
 
 [EmuCore]
 CdvdVerboseReads = false

--- a/packages/emulators/standalone/aethersx2-sa/config/S922X/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/S922X/aethersx2/inis/PCSX2.ini
@@ -2,6 +2,8 @@
 SettingsVersion = 1
 StartFullscreen = true
 RenderToSeparateWindow = true
+DoubleClickTogglesFullscreen = false
+
 
 [EmuCore]
 CdvdVerboseReads = false

--- a/packages/emulators/standalone/aethersx2-sa/config/SM8250/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/SM8250/aethersx2/inis/PCSX2.ini
@@ -275,7 +275,7 @@ BIOS =
 
 [Framerate]
 NominalScalar = 1.000000
-TurboScalar = 2.000000
+TurboScalar = 10
 SlomoScalar = 0.500000
 
 

--- a/packages/emulators/standalone/aethersx2-sa/config/SM8250/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/SM8250/aethersx2/inis/PCSX2.ini
@@ -326,6 +326,7 @@ OpenPauseMenu = SDL-0/Guide & SDL-0/X
 ToggleTurbo = SDL-0/Guide & SDL-0/+RightTrigger
 ResetVM = SDL-0/Guide & SDL-0/B
 Screenshot = SDL-0/Guide & SDL-0/A
+HoldTurbo = SDL-0/Misc1 & SDL-0/+RightTrigger
 
 
 [Pad]

--- a/packages/emulators/standalone/aethersx2-sa/config/SM8250/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/SM8250/aethersx2/inis/PCSX2.ini
@@ -2,6 +2,7 @@
 SettingsVersion = 1
 StartFullscreen = true
 RenderToSeparateWindow = true
+DoubleClickTogglesFullscreen = false
 
 
 [EmuCore]

--- a/packages/emulators/standalone/aethersx2-sa/config/SM8550/aethersx2/inis/PCSX2.ini
+++ b/packages/emulators/standalone/aethersx2-sa/config/SM8550/aethersx2/inis/PCSX2.ini
@@ -2,6 +2,7 @@
 SettingsVersion = 1
 StartFullscreen = true
 RenderToSeparateWindow = true
+DoubleClickTogglesFullscreen = false
 
 
 [EmuCore]


### PR DESCRIPTION
Merged in AetherSX2 settings tweaks from my rpmini

Main one is to add `DoubleClickTogglesFullscreen = false` as I was getting this triggered accidentally somehow on my rpmini while mashing buttons where it would drop out of fullscreen, causing sway to tile the main window and the rendering window, splitting the screen in two. Disabling this setting prevents this undesired behavior from occurring. I assume other devices will want this disabled as well or that it at least won't hurt. Or if someone needs this option, it can still be changed back manually.

The other two commits are less important, just my own preferences - added a turbo mode hotkey when holding BACK+Right Trigger which is useful for speeding things up while running around with the left stick (existing hotkey toggles turbo mode, this one is only in effect while holding, allowing more precise control). The final commit increases the turbo speed to x10 which is the highest setting the AertherSX2 offers in its settings menu.