### PR TITLE
cemu-sa: add support for additional ES settings

### DIFF
--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -800,22 +800,6 @@
    <cores>
     <core name="cemu-sa"> 
      <features>
-      <feature name="graphics backend">
-        <choice name="opengl" value="opengl"/>
-        <choice name="vulkan" value="vulkan"/>
-      </feature>
-      <feature name="gdk backend">
-        <choice name="Wayland" value="wayland"/>
-        <choice name="X11" value="x11"/>
-      </feature>
-      <feature name="online enabled">
-        <choice name="no" value="false"/>
-        <choice name="yes" value="true"/>
-      </feature>
-      <feature name="show fps">
-        <choice name="yes" value="1"/>
-        <choice name="no" value="0"/>
-      </feature>
       <feature name="wiiu controller profile">
         <choice name="Wii U GamePad" value="Wii U GamePad"/>
         <choice name="Wii U Pro Controller" value="Wii U Pro Controller"/>
@@ -825,6 +809,153 @@
       <feature name="wiiu controller layout">
         <choice name="nintendo" value="nintendo"/>
         <choice name="xbox" value="xbox"/>
+      </feature>
+      <feature name="online enabled">
+        <choice name="no" value="false"/>
+        <choice name="yes" value="true"/>
+      </feature>
+      <feature name="graphics backend">
+        <choice name="opengl" value="opengl"/>
+        <choice name="vulkan" value="vulkan"/>
+      </feature>
+      <feature name="gdk backend">
+        <choice name="Wayland" value="wayland"/>
+        <choice name="X11" value="x11"/>
+      </feature>
+      <feature name="vsync">
+        <choice name="off" value="0"/>
+        <choice name="double buffering" value="1"/>
+        <choice name="triple buffering" value="2"/>
+      </feature>
+      <feature name="gx2 draw done sync">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="upscale filter">
+        <choice name="bilinear" value="0"/>
+        <choice name="bicubic" value="1"/>
+        <choice name="hermite" value="2"/>
+        <choice name="nearest neighbor" value="3"/>
+      </feature>
+      <feature name="downscale filter">
+        <choice name="bilinear" value="0"/>
+        <choice name="bicubic" value="1"/>
+        <choice name="hermite" value="2"/>
+        <choice name="nearest neighbor" value="3"/>
+      </feature>
+      <feature name="fullscreen scaling">
+        <choice name="keep aspect ratio" value="0"/>
+        <choice name="stretch" value="1"/>
+      </feature>
+      <feature name="async shader compile">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="vk accurate barriers">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="overlay position">
+        <choice name="disabled" value="0"/>
+        <choice name="top left" value="1"/>
+        <choice name="top center" value="2"/>
+        <choice name="top right" value="3"/>
+        <choice name="bottom left" value="4"/>
+        <choice name="bottom center" value="5"/>
+        <choice name="bottom right" value="6"/>
+      </feature>
+      <feature name="overlay text scale">
+        <choice name="100%" value="100"/>
+        <choice name="150%" value="150"/>
+        <choice name="200%" value="200"/>
+        <choice name="250%" value="250"/>
+        <choice name="300%" value="300"/>
+      </feature>
+      <feature name="overlay text color">
+        <choice name="black" value="000000"/>
+        <choice name="white" value="FFFFFF"/>
+        <choice name="red" value="0000FF"/>
+        <choice name="green" value="00FF00"/>
+        <choice name="blue" value="FF0000"/>
+        <choice name="yellow" value="00FFFF"/>
+        <choice name="pink" value="FF00FF"/>
+        <choice name="cyan" value="FFFF00"/>
+      </feature>
+      <feature name="overlay text transparency">
+        <choice name="0" value="FF"/>
+        <choice name="1" value="EF"/>
+        <choice name="2" value="DF"/>
+        <choice name="3" value="CF"/>
+        <choice name="4" value="BF"/>
+        <choice name="5" value="AF"/>
+        <choice name="6" value="9F"/>
+        <choice name="7" value="8F"/>
+        <choice name="8" value="7F"/>
+        <choice name="9" value="6F"/>
+        <choice name="10" value="5F"/>
+      </feature>
+      <feature name="overlay show fps">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="overlay draw calls">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="overlay show cpu usage">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="overlay show cpu per core usage">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="overlay show ram usage">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="overlay show vram usage">
+        <choice name="true" value="true"/>
+        <choice name="false" value="false"/>
+      </feature>
+      <feature name="notification position">
+        <choice name="disabled" value="0"/>
+        <choice name="top left" value="1"/>
+        <choice name="top center" value="2"/>
+        <choice name="top right" value="3"/>
+        <choice name="bottom left" value="4"/>
+        <choice name="bottom center" value="5"/>
+        <choice name="bottom right" value="6"/>
+      </feature>
+      <feature name="notification text scale">
+        <choice name="100%" value="100"/>
+        <choice name="150%" value="150"/>
+        <choice name="200%" value="200"/>
+        <choice name="250%" value="250"/>
+        <choice name="300%" value="300"/>
+      </feature>
+      <feature name="notification text color">
+        <choice name="black" value="000000"/>
+        <choice name="white" value="FFFFFF"/>
+        <choice name="red" value="0000FF"/>
+        <choice name="green" value="00FF00"/>
+        <choice name="blue" value="FF0000"/>
+        <choice name="yellow" value="00FFFF"/>
+        <choice name="pink" value="FF00FF"/>
+        <choice name="cyan" value="FFFF00"/>
+      </feature>
+      <feature name="notification text transparency">
+        <choice name="0" value="FF"/>
+        <choice name="1" value="EF"/>
+        <choice name="2" value="DF"/>
+        <choice name="3" value="CF"/>
+        <choice name="4" value="BF"/>
+        <choice name="5" value="AF"/>
+        <choice name="6" value="9F"/>
+        <choice name="7" value="8F"/>
+        <choice name="8" value="7F"/>
+        <choice name="9" value="6F"/>
+        <choice name="10" value="5F"/>
       </feature>
      </features>
     </core>


### PR DESCRIPTION
new ES settings for cemu-sa

**Graphic**

- vsync
- gx2_draw_done_sync
- upscale_filter
- downscale_filter
- fullscreen_scaling
- async_shader_compile
- vk_accurate_barriers

**Overlay**

- position
- text scale
- text color
- text transparency
- fps
- draw calls
- cpu usage
- cpu per core usage
- ram usage
- vram usage

**Notification**

- position
- text scale
- text color
- text transparency


![IMG_6332](https://github.com/user-attachments/assets/d46cb2a8-8ac1-4857-b70d-8b1178ff6431)
![IMG_6333](https://github.com/user-attachments/assets/65763463-a3a2-44bb-bfa4-a017df05697a)
![IMG_6334](https://github.com/user-attachments/assets/914b8395-bcea-410e-9f88-5f199d43fe88)
![IMG_6335](https://github.com/user-attachments/assets/24de819e-091d-4877-bed8-eedc0d7477a3)

