### PR TITLE
runemu - use start_core scripts in /usr/bin

### DIFF
--- a/packages/rocknix/sources/scripts/runemu.sh
+++ b/packages/rocknix/sources/scripts/runemu.sh
@@ -283,7 +283,7 @@ case ${EMULATOR} in
         RUNTHIS='${RUN_SHELL} "${ROMNAME}"'
       ;;
       *)
-        RUNTHIS='${RUN_SHELL} "start_${CORE%-*}.sh" "${ROMNAME}" "${PLATFORM}"'
+        RUNTHIS='${RUN_SHELL} "/usr/bin/start_${CORE%-*}.sh" "${ROMNAME}" "${PLATFORM}"'
       ;;
     esac
   ;;


### PR DESCRIPTION
Verified all the `start_*` scripts actually do live in `/usr/bin`:
```
RK3588:~ # find / -name "start*.sh"
/usr/bin/start_OpenBOR.sh
/usr/bin/start_aethersx2.sh
/usr/bin/start_amiberry.sh
/usr/bin/start_dolphin_gc.sh
/usr/bin/start_dolphin_wii.sh
/usr/bin/start_drastic.sh
/usr/bin/start_duckstation.sh
/usr/bin/start_es.sh
/usr/bin/start_flycast.sh
/usr/bin/start_gmu.sh
/usr/bin/start_gzdoom.sh
/usr/bin/start_hatari.sh
/usr/bin/start_hypseus.sh
/usr/bin/start_lime3ds.sh
/usr/bin/start_mednafen.sh
/usr/bin/start_melonds.sh
/usr/bin/start_mplayer.sh
/usr/bin/start_mupen64plus.sh
/usr/bin/start_pico8.sh
/usr/bin/start_portmaster.sh
/usr/bin/start_ppsspp.sh
/usr/bin/start_scummvm.sh
/usr/bin/start_supermodel.sh
/usr/bin/start_syncthing.sh
/usr/bin/start_x128.sh
/usr/bin/start_x64sc.sh
/usr/bin/start_xplus4.sh
/usr/bin/start_xvic.sh
/usr/bin/start_yabasanshiro.sh
```
Tested on my ACE.