### PR TITLE
Remove post-update symlink

### DIFF
--- a/post-update
+++ b/post-update
@@ -1,1 +1,0 @@
-packages/rocknix/sources/post-update


### PR DESCRIPTION
Tidying up - only `packages/rocknix/sources/post-update` is referenced.