### PR TITLE
Fix the loading of modules that wireguard depends on

### DIFF
--- a/packages/network/wireguard-tools/modules-load.d/wireguard.conf
+++ b/packages/network/wireguard-tools/modules-load.d/wireguard.conf
@@ -1,0 +1,3 @@
+udp_tunnel
+ip6_udp_tunnel
+wireguard


### PR DESCRIPTION
On my test device, the Powkiddy RGB20SX (RK3566), WireGuard cannot start because the dependent modules are not loaded.