### PR TITLE
SM8550 - dolphin-sa - gamecube - fix south controller profile

### DIFF
--- a/packages/emulators/standalone/dolphin-sa/config/SM8550/GamecubeControllerProfiles/GCPadNew.ini.south
+++ b/packages/emulators/standalone/dolphin-sa/config/SM8550/GamecubeControllerProfiles/GCPadNew.ini.south
@@ -1,9 +1,9 @@
 [GCPad1]
 Device = evdev/0/Microsoft X-Box 360 pad
-Buttons/A = Button 1
+Buttons/A = Button 0
 Buttons/B = Button 3
 Buttons/Start = Button 7
-Buttons/X = Button 0
+Buttons/X = Button 1
 Buttons/Y = Button 2
 Buttons/Z = Button 5
 Buttons/Hotkey = Button 6


### PR DESCRIPTION
Tested on my Odin 2 with dolphin-sa gamecube NFS Hot Pursuit 2.