### PR TITLE
SM8550 - dolphin-sa - GC - fix east controller profile

### DIFF
--- a/packages/emulators/standalone/dolphin-sa/config/SM8550/GamecubeControllerProfiles/GCPadNew.ini.east
+++ b/packages/emulators/standalone/dolphin-sa/config/SM8550/GamecubeControllerProfiles/GCPadNew.ini.east
@@ -1,7 +1,7 @@
 [GCPad1]
 Device = evdev/0/Microsoft X-Box 360 pad
-Buttons/A = Button 0
-Buttons/B = Button 1
+Buttons/A = Button 1
+Buttons/B = Button 0
 Buttons/Start = Button 7
 Buttons/X = Button 2
 Buttons/Y = Button 3


### PR DESCRIPTION
Follow-up to https://github.com/ROCKNIX/distribution/pull/1355