### PR TITLE
wine - bump to 10.3, switch to amd64 (not amd64-wow64) build

### DIFF
--- a/packages/compat/wine/package.mk
+++ b/packages/compat/wine/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="10.0"
+PKG_VERSION="10.3"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 # Use the amd64 release as it supports running both 32-bit and 64-bit windows apps
-PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-amd64-wow64.tar.xz"
+PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-amd64.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libXcomposite libXdmcp cups"
 PKG_LONGDESC="Wine is a compatibility layer capable of running Windows applications"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
Tested on my ACE, no issues running 32-bit games.