### PR TITLE
box64 - bump to v0.3.4

### DIFF
--- a/packages/compat/box64/package.mk
+++ b/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="5fa65a4b38c1a449af3703a3f760eb09bc9dbca8"
+PKG_VERSION="2b300bd199a7a65a3de1eecd24d6dff5593a9b55"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"


### PR DESCRIPTION
Changelog: https://github.com/ptitSeb/box64/releases/tag/v0.3.4

Tested on my ACE