### PR TITLE
S922X - quirks - modifiers - set DEVICE_FUNC_KEYA_MODIFIER to BTN_MODE

### DIFF
--- a/packages/hardware/quirks/platforms/S922X/050-modifiers
+++ b/packages/hardware/quirks/platforms/S922X/050-modifiers
@@ -3,6 +3,6 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 cat <<EOF >/storage/.config/profile.d/050-modifiers
-DEVICE_FUNC_KEYA_MODIFIER="BTN_SELECT"
+DEVICE_FUNC_KEYA_MODIFIER="BTN_MODE"
 DEVICE_FUNC_KEYB_MODIFIER="BTN_START"
 EOF


### PR DESCRIPTION
Tested on my OGU. This better matches other devices with a similar layout (ACE / Retroid / Odin 2).