### PR TITLE
lime3ds-sa - use L2/R2 for hotkeys

### DIFF
--- a/packages/emulators/standalone/lime3ds-sa/config/common/lime3ds.gptk
+++ b/packages/emulators/standalone/lime3ds-sa/config/common/lime3ds.gptk
@@ -24,7 +24,7 @@ right_analog_left = \\
 right_analog_right = \\
 
 # Map hotkey + left shoulder to swap layout
-l1_hk = f10
+l2_hk = f10
 
 # Map hotkey + right shoulder to swap screen
-r1_hk = f9
+r2_hk = f9


### PR DESCRIPTION
L1 / R1 more often trigger a gameplay action. Tested on my OGU and Odin 2.