### PR TITLE
odin2: update kernel cmdline to allow 32-bit tasks to run

### DIFF
--- a/projects/Qualcomm/devices/SM8550/bootloader/LinuxLoader.cfg
+++ b/projects/Qualcomm/devices/SM8550/bootloader/LinuxLoader.cfg
@@ -11,4 +11,4 @@ DisableDisplayHW = true
 Image = "KERNEL"
 initrd = "KERNEL"
 devicetree = "qcs8550-ayn-odin2.dtb"
-cmdline = "boot=LABEL=ROCKNIX disk=LABEL=STORAGE grub_portable quiet rootwait console=tty0"
+cmdline = "boot=LABEL=ROCKNIX disk=LABEL=STORAGE grub_portable quiet rootwait console=tty0 allow_mismatched_32bit_el0"


### PR DESCRIPTION
SM8550 has ARMv9 which requires to explicitly opt-in to allow 32-bit task to run. See [Asymmetric 32-bit SoCs](https://github.com/strongtz/linux-next/blob/ci/odin2/stable/Documentation/arch/arm64/asymmetric-32bit.rst) for more details.

After updating the cmdline 32 bits ports can run (iconoclast, am2r, santa's surprise were tested). Works on Odin 2 and Odin 2 Portal.