### PR TITLE
emulationstation: update to the commit with the battery_warning update (add threshold setting)

### DIFF
--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="129a5e48538d6e4b9a50df1e8b24dfe0a321c313"
+PKG_VERSION="eebd9eeb522a6244142754663088e852dd7894fa"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
The emulationstation package needs to be updated to get the battery threshold setting.