### PR TITLE
Added option to backup/restore system settings backup with rclone tools

### DIFF
--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -107,8 +107,14 @@ load_config() {
 # Function to backup system backup files
 backup_system_files() {
     if [ "${BACKUPFILE_BACKUP_OPTION}" == "yes" ]; then
-        log_message "Starting backup of system backup files from ${BACKUPFOLDER} to ${REMOTENAME}${SYNCPATH_BACKUP}"
-        log_message "System backup started at $(date)" "false"
+        # Check if backup directory is empty
+        if [ -z "$(ls -A ${BACKUPFOLDER} 2>/dev/null)" ]; then
+            log_message "There is no system backup to transfer" "true" "WARN"
+            return
+        fi
+        
+        log_message "Starting transfer of system backup from ${BACKUPFOLDER} to ${REMOTENAME}${SYNCPATH_BACKUP}"
+        log_message "System transfer started at $(date)" "false"
         
         # Create remote directory if it doesn't exist
         rclone mkdir ${REMOTENAME}${SYNCPATH_BACKUP}/
@@ -119,14 +125,14 @@ backup_system_files() {
         
         BACKUP_SYSTEM_STATUS=$?
         if [ $BACKUP_SYSTEM_STATUS -eq 0 ]; then
-            log_message "System backup files backup completed successfully" "false"
+            log_message "System backup transfer completed successfully" "false"
         else
-            log_message "System backup files backup completed with errors (status $BACKUP_SYSTEM_STATUS)" "false" "WARN"
+            log_message "System backup transfer completed with errors (status $BACKUP_SYSTEM_STATUS)" "false" "WARN"
         fi
         
-        log_message "System backup files backup to ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
+        log_message "System backup transfer to ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
     else
-        log_message "System backup files backup skipped (BACKUPFILE_BACKUP_OPTION is not set to 'yes')" "false"
+        log_message "System backup transfer skipped (BACKUPFILE_BACKUP_OPTION is not set to 'yes')" "false"
     fi
 }
 

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -2,29 +2,45 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
+# Logging function
+log_message() {
+    local message="$1"
+    local echo_to_screen="${2:-true}"  # Default to true
+    local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+    local script_name=$(basename "$0")
+    
+    echo "[${timestamp}] [${script_name}] ${message}" >> /var/log/cloud_sync.log
+    
+    if [[ "${echo_to_screen}" == "true" ]]; then
+        echo -e "${message}"
+    fi
+}
+
 # Check if rclone has been configured
 if [ ! -e "/storage/.config/rclone/rclone.conf" ]
 then
-  echo "You must configure rclone before using this tool.  Run \`rclone config\` to get started."
+  log_message "ERROR: You must configure rclone before using this tool. Run \`rclone config\` to get started."
   sleep 3
-  exit
+  exit 1
 fi
 
 # Check that the internet is reachable
 ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
 if [ "${ONLINESTATUS}" == "offline" ]
 then
-  echo -e "You're not currently connected to the internet.\nPlease verify your settings and then try again."
+  log_message "ERROR: You're not currently connected to the internet.\nPlease verify your settings and then try again."
   sleep 3
-  exit
+  exit 1
 fi
 
 # Loads cloud sync config variables from cloud_sync.conf
+log_message "Loading configuration from cloud_sync.conf" "false"
 source /storage/.config/cloud_sync.conf
 
 # Check if needed default variables from the conf file are present, and add if nececssary
 if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]
 then
+  log_message "Some configuration variables missing, loading defaults" "false"
   source /storage/.config/cloud_sync.conf.defaults
   if [ "${BACKUPPATH}" == "" ]
   then
@@ -70,17 +86,30 @@ then
   REMOTENAME=`rclone listremotes | head -1`
   
   # Run backup
-  echo -e "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
-  echo "Backing up data from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}" 2>&1  
+  log_message "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
+  log_message "Starting backup from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}"
+  
+  # Add start time to log
+  log_message "Backup started at $(date)" "false"
+  
   rclone ${BACKUPMETHOD} \
     ${RCLONEOPTS} \
     ${BACKUPPATH}/ ${REMOTENAME}${SYNCPATH}/
+  
+  BACKUP_STATUS=$?
+  if [ $BACKUP_STATUS -eq 0 ]; then
+    log_message "Backup completed successfully" "false"
+  else
+    log_message "Backup completed with errors (status $BACKUP_STATUS)" "false"
+  fi
+  
   if [ "${RSYNCRMDIR}" == "yes" ] 
   then
+    log_message "Removing empty directories on remote" "false"
     rclone rmdirs ${REMOTENAME}${SYNCPATH}/ --leave-root
   fi
 fi
 
-echo "Backup to ${REMOTENAME}${SYNCPATH} complete!"
+log_message "Backup to ${REMOTENAME}${SYNCPATH} complete!"
 sleep 1.5
 clear

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-# Common functions and constants
+# Script configuration and global variables
 SCRIPT_NAME=$(basename "$0")
 LOG_FILE="/var/log/cloud_sync.log"
 START_TIME=$(date +%s)
 
-# Logging function with severity levels
+# Logging function that supports different severity levels and optional console output
+# Parameters:
+#   $1: Message text
+#   $2: Whether to echo to screen (true/false, defaults to true)
+#   $3: Log level (INFO, WARN, ERROR, defaults to INFO)
 log_message() {
     local message="$1"
     local echo_to_screen="${2:-true}"  # Default to true
@@ -26,7 +30,10 @@ log_message() {
     fi
 }
 
-# Clean exit function
+# Performs cleanup operations and exits with the specified code
+# Records total execution time in the log for performance tracking
+# Parameters:
+#   $1: Exit code to return
 clean_exit() {
     local exit_code=$1
     local duration=$(($(date +%s) - START_TIME))
@@ -35,7 +42,8 @@ clean_exit() {
     exit ${exit_code}
 }
 
-# Check for rclone configuration
+# Verifies rclone is properly configured before attempting operations
+# Exits with error if configuration file is missing
 check_rclone_config() {
     if [ ! -e "/storage/.config/rclone/rclone.conf" ]; then
         log_message "You must configure rclone before using this tool. Run \`rclone config\` to get started." "true" "ERROR"
@@ -44,7 +52,8 @@ check_rclone_config() {
     fi
 }
 
-# Check internet connectivity
+# Validates internet connectivity before attempting cloud operations
+# Uses ping to google.com as a connectivity test
 check_internet() {
     log_message "Checking internet connectivity..." "false"
     ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
@@ -56,7 +65,8 @@ check_internet() {
     log_message "Internet connection detected" "false"
 }
 
-# Load configuration
+# Loads user configuration from cloud_sync.conf
+# Applies default values for any missing configuration parameters
 load_config() {
     log_message "Loading configuration from cloud_sync.conf" "false"
     source /storage/.config/cloud_sync.conf
@@ -104,49 +114,13 @@ load_config() {
     log_message "Configuration loaded successfully" "false"
 }
 
-# Function to backup system backup files
-backup_system_files() {
-    if [ "${BACKUPFILE_BACKUP_OPTION}" == "yes" ]; then
-        # Check if backup directory is empty
-        if [ -z "$(ls -A ${BACKUPFOLDER} 2>/dev/null)" ]; then
-            log_message "There is no system backup to transfer" "true" "WARN"
-            return
-        fi
-        
-        log_message "Starting transfer of system backup from ${BACKUPFOLDER} to ${REMOTENAME}${SYNCPATH_BACKUP}"
-        log_message "System transfer started at $(date)" "false"
-        
-        # Create remote directory if it doesn't exist
-        rclone mkdir ${REMOTENAME}${SYNCPATH_BACKUP}/
-        
-        rclone ${BACKUPMETHOD} \
-          ${RCLONEOPTS} \
-          ${BACKUPFOLDER}/ ${REMOTENAME}${SYNCPATH_BACKUP}/
-        
-        BACKUP_SYSTEM_STATUS=$?
-        if [ $BACKUP_SYSTEM_STATUS -eq 0 ]; then
-            log_message "System backup transfer completed successfully" "false"
-        else
-            log_message "System backup transfer completed with errors (status $BACKUP_SYSTEM_STATUS)" "false" "WARN"
-        fi
-        
-        log_message "System backup transfer to ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
-    else
-        log_message "System backup transfer skipped (BACKUPFILE_BACKUP_OPTION is not set to 'yes')" "false"
-    fi
-}
-
-# Main script execution
-main() {
-    check_rclone_config
-    check_internet
-    load_config
+# PART 1: Game saves backup function
+# Backs up game saves to cloud storage
+backup_game_saves() {
+    log_message "====================================" "true"
+    log_message "STARTING GAME SAVES BACKUP" "true"
+    log_message "====================================" "true"
     
-    # Determine remote to be used
-    REMOTENAME=`rclone listremotes | head -1`
-    
-    # Run backup
-    log_message "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
     log_message "Starting backup from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}"
     log_message "Backup started at $(date)" "false"
     
@@ -156,27 +130,97 @@ main() {
     
     BACKUP_STATUS=$?
     if [ $BACKUP_STATUS -eq 0 ]; then
-        log_message "Backup completed successfully" "false"
+        log_message "Game saves backup completed successfully" "true"
     else
-        log_message "Backup completed with errors (status $BACKUP_STATUS)" "false" "WARN"
+        log_message "Game saves backup completed with errors (status $BACKUP_STATUS)" "true" "WARN"
     fi
     
-    # Backup system backup files
-    backup_system_files
+    log_message "Game saves backup to ${REMOTENAME}${SYNCPATH} complete!"
     
+    # Clean up empty directories if configured to do so
     if [ "${RSYNCRMDIR}" == "yes" ]; then
         log_message "Removing empty directories on remote" "false"
         rclone rmdirs ${REMOTENAME}${SYNCPATH}/ --leave-root
     fi
     
-    log_message "Backup to ${REMOTENAME}${SYNCPATH} complete!"
-    sleep 1.5
-    clear
+    return $BACKUP_STATUS
+}
+
+# PART 2: System backup file transfer function
+# Transfers existing system backup files to cloud storage
+# Only runs when BACKUPFILE_BACKUP_OPTION is set to "yes"
+backup_system_files() {
+    log_message "====================================" "true"
+    log_message "STARTING SYSTEM BACKUP FILE TRANSFER" "true"
+    log_message "====================================" "true"
+    
+    if [ "${BACKUPFILE_BACKUP_OPTION}" == "yes" ]; then
+        # Skip if backup directory is empty to avoid unnecessary transfers
+        if [ -z "$(ls -A ${BACKUPFOLDER} 2>/dev/null)" ]; then
+            log_message "There are no system backup files to transfer" "true" "WARN"
+            return 1
+        fi
+        
+        log_message "Starting transfer of system backup files from ${BACKUPFOLDER} to ${REMOTENAME}${SYNCPATH_BACKUP}"
+        log_message "System backup file transfer started at $(date)" "false"
+        
+        # Ensure target directory exists before attempting transfer
+        rclone mkdir ${REMOTENAME}${SYNCPATH_BACKUP}/
+        
+        rclone ${BACKUPMETHOD} \
+          ${RCLONEOPTS} \
+          ${BACKUPFOLDER}/ ${REMOTENAME}${SYNCPATH_BACKUP}/
+        
+        BACKUP_SYSTEM_STATUS=$?
+        if [ $BACKUP_SYSTEM_STATUS -eq 0 ]; then
+            log_message "System backup file transfer completed successfully" "true"
+        else
+            log_message "System backup file transfer completed with errors (status $BACKUP_SYSTEM_STATUS)" "true" "WARN"
+        fi
+        
+        log_message "System backup file transfer to ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
+    else
+        log_message "System backup file transfer skipped (BACKUPFILE_BACKUP_OPTION is not set to 'yes')" "true"
+        BACKUP_SYSTEM_STATUS=0
+    fi
+    
+    return $BACKUP_SYSTEM_STATUS
+}
+
+# Main script execution
+main() {
+    check_rclone_config
+    check_internet
+    load_config
+    
+    # Use the first configured remote in rclone
+    REMOTENAME=`rclone listremotes | head -1`
+    
+    # Begin main script operations
+    log_message "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
+    
+    # Execute Part 1: Game saves backup
+    backup_game_saves
+    BACKUP_STATUS=$?
+    
+    # Execute Part 2: System backup file transfer
+    backup_system_files
+    BACKUP_SYSTEM_STATUS=$?
+    
+    # Provide final summary of all operations
+    log_message "====================================" "true"
+    log_message "BACKUP SUMMARY:" "true"
+    log_message "Game saves backup: $([ $BACKUP_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
+    [ "${BACKUPFILE_BACKUP_OPTION}" == "yes" ] && log_message "System backup file transfer: $([ $BACKUP_SYSTEM_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
+    log_message "Log file: ${LOG_FILE}" "true"
+    log_message "====================================" "true"
+    
+    # Use the game saves backup status as the overall exit code
     clean_exit ${BACKUP_STATUS}
 }
 
-# Handle script interruption
+# Set up signal trap to handle user interruption gracefully
 trap 'log_message "Script interrupted by user" "false" "WARN"; clean_exit 130' INT TERM
 
-# Execute main function
+# Start script execution
 main

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -2,114 +2,134 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-# Logging function
+# Common functions and constants
+SCRIPT_NAME=$(basename "$0")
+LOG_FILE="/var/log/cloud_sync.log"
+START_TIME=$(date +%s)
+
+# Logging function with severity levels
 log_message() {
     local message="$1"
     local echo_to_screen="${2:-true}"  # Default to true
+    local level="${3:-INFO}"
     local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
-    local script_name=$(basename "$0")
     
-    echo "[${timestamp}] [${script_name}] ${message}" >> /var/log/cloud_sync.log
+    echo "[${timestamp}] [${level}] [${SCRIPT_NAME}] ${message}" >> ${LOG_FILE}
     
     if [[ "${echo_to_screen}" == "true" ]]; then
-        echo -e "${message}"
+        # Color output based on level
+        case "${level}" in
+            ERROR) echo -e "\e[31m${message}\e[0m" ;;
+            WARN)  echo -e "\e[33m${message}\e[0m" ;;
+            *)     echo -e "${message}" ;;
+        esac
     fi
 }
 
-# Check if rclone has been configured
-if [ ! -e "/storage/.config/rclone/rclone.conf" ]
-then
-  log_message "ERROR: You must configure rclone before using this tool. Run \`rclone config\` to get started."
-  sleep 3
-  exit 1
-fi
+# Clean exit function
+clean_exit() {
+    local exit_code=$1
+    local duration=$(($(date +%s) - START_TIME))
+    
+    log_message "Script completed in ${duration} seconds with exit code ${exit_code}" "false"
+    exit ${exit_code}
+}
 
-# Check that the internet is reachable
-ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
-if [ "${ONLINESTATUS}" == "offline" ]
-then
-  log_message "ERROR: You're not currently connected to the internet.\nPlease verify your settings and then try again."
-  sleep 3
-  exit 1
-fi
+# Check for rclone configuration
+check_rclone_config() {
+    if [ ! -e "/storage/.config/rclone/rclone.conf" ]; then
+        log_message "You must configure rclone before using this tool. Run \`rclone config\` to get started." "true" "ERROR"
+        sleep 3
+        clean_exit 1
+    fi
+}
 
-# Loads cloud sync config variables from cloud_sync.conf
-log_message "Loading configuration from cloud_sync.conf" "false"
-source /storage/.config/cloud_sync.conf
+# Check internet connectivity
+check_internet() {
+    log_message "Checking internet connectivity..." "false"
+    ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
+    if [ "${ONLINESTATUS}" == "offline" ]; then
+        log_message "You're not currently connected to the internet.\nPlease verify your settings and then try again." "true" "ERROR"
+        sleep 3
+        clean_exit 1
+    fi
+    log_message "Internet connection detected" "false"
+}
 
-# Check if needed default variables from the conf file are present, and add if nececssary
-if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]
-then
-  log_message "Some configuration variables missing, loading defaults" "false"
-  source /storage/.config/cloud_sync.conf.defaults
-  if [ "${BACKUPPATH}" == "" ]
-  then
-    sed -i -e '$a\\nBACKUPPATH="'"${DEFAULT_BACKUPPATH}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RESTOREPATH}" == "" ]
-  then
-    sed -i -e '$a\\nRESTOREPATH="'"${DEFAULT_RESTOREPATH}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${SYNCPATH}" == "" ]
-  then
-    sed -i -e '$a\\nSYNCPATH="'"${DEFAULT_SYNCPATH}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RCLONEOPTS}" == "" ]
-  then
-    sed -i -e '$a\\nRCLONEOPTS="'"${DEFAULT_RCLONEOPTS}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${BACKUPMETHOD}" == "" ]
-  then
-    sed -i -e '$a\\nBACKUPMETHOD="'"${DEFAULT_BACKUPMETHOD}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RESTOREMETHOD}" == "" ]
-  then
-    sed -i -e '$a\\nRESTOREMETHOD="'"${DEFAULT_RESTOREMETHOD}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RSYNCRMDIR}" == "" ]
-  then
-    sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
-  fi
-  source /storage/.config/cloud_sync.conf
-fi
+# Load configuration
+load_config() {
+    log_message "Loading configuration from cloud_sync.conf" "false"
+    source /storage/.config/cloud_sync.conf
+    
+    # Check if needed variables are present, add if necessary
+    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]; then
+        log_message "Some configuration variables missing, loading defaults" "false" "WARN"
+        source /storage/.config/cloud_sync.conf.defaults
+        if [ "${BACKUPPATH}" == "" ]; then
+            sed -i -e '$a\\nBACKUPPATH="'"${DEFAULT_BACKUPPATH}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RESTOREPATH}" == "" ]; then
+            sed -i -e '$a\\nRESTOREPATH="'"${DEFAULT_RESTOREPATH}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${SYNCPATH}" == "" ]; then
+            sed -i -e '$a\\nSYNCPATH="'"${DEFAULT_SYNCPATH}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RCLONEOPTS}" == "" ]; then
+            sed -i -e '$a\\nRCLONEOPTS="'"${DEFAULT_RCLONEOPTS}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${BACKUPMETHOD}" == "" ]; then
+            sed -i -e '$a\\nBACKUPMETHOD="'"${DEFAULT_BACKUPMETHOD}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RESTOREMETHOD}" == "" ]; then
+            sed -i -e '$a\\nRESTOREMETHOD="'"${DEFAULT_RESTOREMETHOD}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RSYNCRMDIR}" == "" ]; then
+            sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
+        fi
+        source /storage/.config/cloud_sync.conf
+    fi
+    
+    log_message "Configuration loaded successfully" "false"
+}
 
-# Backup to rclone remote
-if [ -e "/storage/.config/rclone/rclone.conf" ]
-then
-  # Determine remote to be used
-  REMOTENAME=`rclone listremotes | head -1`
-  
-  # Run backup
-  log_message "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
-  log_message "Starting backup from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}"
-  
-  # Add start time to log
-  log_message "Backup started at $(date)" "false"
-  
-  rclone ${BACKUPMETHOD} \
-    ${RCLONEOPTS} \
-    ${BACKUPPATH}/ ${REMOTENAME}${SYNCPATH}/
-  
-  BACKUP_STATUS=$?
-  if [ $BACKUP_STATUS -eq 0 ]; then
-    log_message "Backup completed successfully" "false"
-  else
-    log_message "Backup completed with errors (status $BACKUP_STATUS)" "false"
-  fi
-  
-  if [ "${RSYNCRMDIR}" == "yes" ] 
-  then
-    log_message "Removing empty directories on remote" "false"
-    rclone rmdirs ${REMOTENAME}${SYNCPATH}/ --leave-root
-  fi
-fi
+# Main script execution
+main() {
+    check_rclone_config
+    check_internet
+    load_config
+    
+    # Determine remote to be used
+    REMOTENAME=`rclone listremotes | head -1`
+    
+    # Run backup
+    log_message "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
+    log_message "Starting backup from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}"
+    log_message "Backup started at $(date)" "false"
+    
+    rclone ${BACKUPMETHOD} \
+      ${RCLONEOPTS} \
+      ${BACKUPPATH}/ ${REMOTENAME}${SYNCPATH}/
+    
+    BACKUP_STATUS=$?
+    if [ $BACKUP_STATUS -eq 0 ]; then
+        log_message "Backup completed successfully" "false"
+    else
+        log_message "Backup completed with errors (status $BACKUP_STATUS)" "false" "WARN"
+    fi
+    
+    if [ "${RSYNCRMDIR}" == "yes" ]; then
+        log_message "Removing empty directories on remote" "false"
+        rclone rmdirs ${REMOTENAME}${SYNCPATH}/ --leave-root
+    fi
+    
+    log_message "Backup to ${REMOTENAME}${SYNCPATH} complete!"
+    sleep 1.5
+    clear
+    clean_exit ${BACKUP_STATUS}
+}
 
-log_message "Backup to ${REMOTENAME}${SYNCPATH} complete!"
-sleep 1.5
-clear
+# Handle script interruption
+trap 'log_message "Script interrupted by user" "false" "WARN"; clean_exit 130' INT TERM
+
+# Execute main function
+main

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -111,6 +111,9 @@ load_config() {
         source /storage/.config/cloud_sync.conf
     fi
     
+    # Create a version of RCLONEOPTS without the --delete-excluded flag for safer operations
+    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
+    
     log_message "Configuration loaded successfully" "false"
 }
 
@@ -150,6 +153,7 @@ backup_game_saves() {
 # Transfers existing system backup files to cloud storage
 # Only runs when BACKUPFILE_BACKUP_OPTION is set to "yes"
 backup_system_files() {
+    echo
     log_message "====================================" "true"
     log_message "STARTING SYSTEM BACKUP FILE TRANSFER" "true"
     log_message "====================================" "true"
@@ -204,22 +208,26 @@ main() {
     BACKUP_STATUS=$?
     
     # Add a pause for better visual separation
-    sleep 1
+    sleep 2
     
     # Execute Part 2: System backup file transfer
     backup_system_files
     BACKUP_SYSTEM_STATUS=$?
     
     # Add a pause before summary
-    sleep 1
+    sleep 2
     
     # Provide final summary of all operations
+    echo
     log_message "====================================" "true"
     log_message "BACKUP SUMMARY:" "true"
     log_message "Game saves backup: $([ $BACKUP_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
     [ "${BACKUPFILE_BACKUP_OPTION}" == "yes" ] && log_message "System backup file transfer: $([ $BACKUP_SYSTEM_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
     log_message "Log file: ${LOG_FILE}" "true"
     log_message "====================================" "true"
+    
+    # Add a final pause before exiting
+    sleep 3
     
     # Use the game saves backup status as the overall exit code
     clean_exit ${BACKUP_STATUS}

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -62,7 +62,7 @@ load_config() {
     source /storage/.config/cloud_sync.conf
     
     # Check if needed variables are present, add if necessary
-    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]; then
+    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ] || [ "${BACKUPFOLDER}" == "" ] || [ "${SYNCPATH_BACKUP}" == "" ] || [ "${BACKUPFILE_BACKUP_OPTION}" == "" ] || [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
         log_message "Some configuration variables missing, loading defaults" "false" "WARN"
         source /storage/.config/cloud_sync.conf.defaults
         if [ "${BACKUPPATH}" == "" ]; then
@@ -86,10 +86,48 @@ load_config() {
         if [ "${RSYNCRMDIR}" == "" ]; then
             sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
         fi
+        if [ "${BACKUPFOLDER}" == "" ]; then
+            sed -i -e '$a\\nBACKUPFOLDER="'"${DEFAULT_BACKUPFOLDER}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${SYNCPATH_BACKUP}" == "" ]; then
+            sed -i -e '$a\\nSYNCPATH_BACKUP="'"${DEFAULT_SYNCPATH}/backup"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${BACKUPFILE_BACKUP_OPTION}" == "" ]; then
+            sed -i -e '$a\\nBACKUPFILE_BACKUP_OPTION="'"${DEFAULT_BACKUPFILE_BACKUP_OPTION}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
+            sed -i -e '$a\\nBACKUPFILE_RESTORE_OPTION="'"${DEFAULT_BACKUPFILE_RESTORE_OPTION}"'"' /storage/.config/cloud_sync.conf
+        fi
         source /storage/.config/cloud_sync.conf
     fi
     
     log_message "Configuration loaded successfully" "false"
+}
+
+# Function to backup system backup files
+backup_system_files() {
+    if [ "${BACKUPFILE_BACKUP_OPTION}" == "yes" ]; then
+        log_message "Starting backup of system backup files from ${BACKUPFOLDER} to ${REMOTENAME}${SYNCPATH_BACKUP}"
+        log_message "System backup started at $(date)" "false"
+        
+        # Create remote directory if it doesn't exist
+        rclone mkdir ${REMOTENAME}${SYNCPATH_BACKUP}/
+        
+        rclone ${BACKUPMETHOD} \
+          ${RCLONEOPTS} \
+          ${BACKUPFOLDER}/ ${REMOTENAME}${SYNCPATH_BACKUP}/
+        
+        BACKUP_SYSTEM_STATUS=$?
+        if [ $BACKUP_SYSTEM_STATUS -eq 0 ]; then
+            log_message "System backup files backup completed successfully" "false"
+        else
+            log_message "System backup files backup completed with errors (status $BACKUP_SYSTEM_STATUS)" "false" "WARN"
+        fi
+        
+        log_message "System backup files backup to ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
+    else
+        log_message "System backup files backup skipped (BACKUPFILE_BACKUP_OPTION is not set to 'yes')" "false"
+    fi
 }
 
 # Main script execution
@@ -116,6 +154,9 @@ main() {
     else
         log_message "Backup completed with errors (status $BACKUP_STATUS)" "false" "WARN"
     fi
+    
+    # Backup system backup files
+    backup_system_files
     
     if [ "${RSYNCRMDIR}" == "yes" ]; then
         log_message "Removing empty directories on remote" "false"

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -203,9 +203,15 @@ main() {
     backup_game_saves
     BACKUP_STATUS=$?
     
+    # Add a pause for better visual separation
+    sleep 1
+    
     # Execute Part 2: System backup file transfer
     backup_system_files
     BACKUP_SYSTEM_STATUS=$?
+    
+    # Add a pause before summary
+    sleep 1
     
     # Provide final summary of all operations
     log_message "====================================" "true"

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -62,7 +62,7 @@ load_config() {
     source /storage/.config/cloud_sync.conf
     
     # Check if needed variables are present, add if necessary
-    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]; then
+    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ] || [ "${BACKUPFOLDER}" == "" ] || [ "${SYNCPATH_BACKUP}" == "" ] || [ "${BACKUPFILE_BACKUP_OPTION}" == "" ] || [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
         log_message "Some configuration variables missing, loading defaults" "false" "WARN"
         source /storage/.config/cloud_sync.conf.defaults
         if [ "${BACKUPPATH}" == "" ]; then
@@ -86,10 +86,48 @@ load_config() {
         if [ "${RSYNCRMDIR}" == "" ]; then
             sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
         fi
+        if [ "${BACKUPFOLDER}" == "" ]; then
+            sed -i -e '$a\\nBACKUPFOLDER="'"${DEFAULT_BACKUPFOLDER}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${SYNCPATH_BACKUP}" == "" ]; then
+            sed -i -e '$a\\nSYNCPATH_BACKUP="'"${DEFAULT_SYNCPATH}/backup"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${BACKUPFILE_BACKUP_OPTION}" == "" ]; then
+            sed -i -e '$a\\nBACKUPFILE_BACKUP_OPTION="'"${DEFAULT_BACKUPFILE_BACKUP_OPTION}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
+            sed -i -e '$a\\nBACKUPFILE_RESTORE_OPTION="'"${DEFAULT_BACKUPFILE_RESTORE_OPTION}"'"' /storage/.config/cloud_sync.conf
+        fi
         source /storage/.config/cloud_sync.conf
     fi
     
     log_message "Configuration loaded successfully" "false"
+}
+
+# Function to restore system backup files
+restore_system_files() {
+    if [ "${BACKUPFILE_RESTORE_OPTION}" == "yes" ]; then
+        log_message "Starting restoration of system backup files from ${REMOTENAME}${SYNCPATH_BACKUP} to ${BACKUPFOLDER}"
+        log_message "System backup restoration started at $(date)" "false"
+        
+        # Create local directory if it doesn't exist
+        mkdir -p ${BACKUPFOLDER}
+        
+        rclone ${RESTOREMETHOD} \
+          ${RCLONEOPTS} \
+          ${REMOTENAME}${SYNCPATH_BACKUP}/ ${BACKUPFOLDER}/
+        
+        RESTORE_SYSTEM_STATUS=$?
+        if [ $RESTORE_SYSTEM_STATUS -eq 0 ]; then
+            log_message "System backup files restoration completed successfully" "false"
+        else
+            log_message "System backup files restoration completed with errors (status $RESTORE_SYSTEM_STATUS)" "false" "WARN"
+        fi
+        
+        log_message "System backup files restoration from ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
+    else
+        log_message "System backup files restoration skipped (BACKUPFILE_RESTORE_OPTION is not set to 'yes')" "false"
+    fi
 }
 
 # Main script execution
@@ -116,6 +154,9 @@ main() {
     else
         log_message "Restore completed with errors (status $RESTORE_STATUS)" "false" "WARN"
     fi
+    
+    # Restore system backup files
+    restore_system_files
     
     # Create empty missing system directories if removed during restore
     if [ "${RESTOREMETHOD}" == "sync" ]; then

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -111,6 +111,8 @@ load_config() {
         source /storage/.config/cloud_sync.conf
     fi
     
+    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
+    
     log_message "Configuration loaded successfully" "false"
 }
 
@@ -125,7 +127,7 @@ restore_game_saves() {
     log_message "Restore started at $(date)" "false"
     
     rclone ${RESTOREMETHOD} \
-      ${RCLONEOPTS} \
+      ${RESTORE_RCLONEOPTS} \
       ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
     
     RESTORE_STATUS=$?
@@ -162,8 +164,11 @@ restore_system_files() {
         # Ensure local target directory exists before attempting restore
         mkdir -p ${BACKUPFOLDER}
         
+        # Adjust filter rules to handle potential path mismatches
         rclone ${RESTOREMETHOD} \
           ${RCLONEOPTS} \
+          --include "/backup/*.zip" \
+          --include "backup/*.zip" \
           ${REMOTENAME}${SYNCPATH_BACKUP}/ ${BACKUPFOLDER}/
         
         RESTORE_SYSTEM_STATUS=$?
@@ -198,6 +203,9 @@ main() {
     restore_game_saves
     RESTORE_STATUS=$?
     
+    # Add a pause for better visual separation
+    sleep 1
+    
     # Execute Part 2: System restore
     restore_system_files
     RESTORE_SYSTEM_STATUS=$?
@@ -208,6 +216,9 @@ main() {
         log_message "Creating empty missing system directories" "true"
         systemd-tmpfiles --create /usr/config/system-dirs.conf
     fi
+    
+    # Add a pause before summary
+    sleep 1
     
     # Provide final summary of all operations
     log_message "====================================" "true"

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -2,29 +2,45 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
+# Logging function
+log_message() {
+    local message="$1"
+    local echo_to_screen="${2:-true}"  # Default to true
+    local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+    local script_name=$(basename "$0")
+    
+    echo "[${timestamp}] [${script_name}] ${message}" >> /var/log/cloud_sync.log
+    
+    if [[ "${echo_to_screen}" == "true" ]]; then
+        echo -e "${message}"
+    fi
+}
+
 # Check if rclone has been configured
 if [ ! -e "/storage/.config/rclone/rclone.conf" ]
 then
-  echo "You must configure rclone before using this tool.  Run \`rclone config\` to get started."
+  log_message "ERROR: You must configure rclone before using this tool. Run \`rclone config\` to get started."
   sleep 3
-  exit
+  exit 1
 fi
 
 # Check that the internet is reachable
 ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
 if [ "${ONLINESTATUS}" == "offline" ]
 then
-  echo -e "You're not currently connected to the internet.\nPlease verify your settings and then try again."
+  log_message "ERROR: You're not currently connected to the internet.\nPlease verify your settings and then try again."
   sleep 3
-  exit
+  exit 1
 fi
 
 # Loads cloud sync config variables from cloud_sync.conf
+log_message "Loading configuration from cloud_sync.conf" "false"
 source /storage/.config/cloud_sync.conf
 
 # Check if needed default variables from the conf file are present, and add if nececssary
 if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]
 then
+  log_message "Some configuration variables missing, loading defaults" "false"
   source /storage/.config/cloud_sync.conf.defaults
   if [ "${BACKUPPATH}" == "" ]
   then
@@ -70,19 +86,31 @@ then
   REMOTENAME=`rclone listremotes | head -1`
 
   # Run restore
-  echo -e "=> ${OS_NAME} CLOUD RESTORE UTILITY\n"
-  echo "Restoring data from ${REMOTENAME}${SYNCPATH} to ${RESTOREPATH}" 2>&1  
-rclone ${RESTOREMETHOD} \
+  log_message "=> ${OS_NAME} CLOUD RESTORE UTILITY\n"
+  log_message "Starting restore from ${REMOTENAME}${SYNCPATH} to ${RESTOREPATH}"
+  
+  # Add start time to log
+  log_message "Restore started at $(date)" "false"
+  
+  rclone ${RESTOREMETHOD} \
     ${RCLONEOPTS} \
     ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
+  
+  RESTORE_STATUS=$?
+  if [ $RESTORE_STATUS -eq 0 ]; then
+    log_message "Restore completed successfully" "false"
+  else
+    log_message "Restore completed with errors (status $RESTORE_STATUS)" "false"
+  fi
 fi
 
 # Create empty missing system directories if removed during restore
 if [ "${RESTOREMETHOD}" == "sync" ]
 then
+  log_message "Creating empty missing system directories" "false"
   systemd-tmpfiles --create /usr/config/system-dirs.conf
 fi
 
-echo "Restore from ${REMOTENAME}${SYNCPATH} complete!"
+log_message "Restore from ${REMOTENAME}${SYNCPATH} complete!"
 sleep 1.5
 clear

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -107,8 +107,15 @@ load_config() {
 # Function to restore system backup files
 restore_system_files() {
     if [ "${BACKUPFILE_RESTORE_OPTION}" == "yes" ]; then
-        log_message "Starting restoration of system backup files from ${REMOTENAME}${SYNCPATH_BACKUP} to ${BACKUPFOLDER}"
-        log_message "System backup restoration started at $(date)" "false"
+        # Check if remote backup directory exists and is not empty
+        REMOTE_FILES=$(rclone ls ${REMOTENAME}${SYNCPATH_BACKUP}/ 2>/dev/null)
+        if [ -z "${REMOTE_FILES}" ]; then
+            log_message "There is no system backup to restore" "true" "WARN"
+            return
+        fi
+        
+        log_message "Starting restore of system backup from ${REMOTENAME}${SYNCPATH_BACKUP} to ${BACKUPFOLDER}"
+        log_message "System restore started at $(date)" "false"
         
         # Create local directory if it doesn't exist
         mkdir -p ${BACKUPFOLDER}
@@ -119,14 +126,14 @@ restore_system_files() {
         
         RESTORE_SYSTEM_STATUS=$?
         if [ $RESTORE_SYSTEM_STATUS -eq 0 ]; then
-            log_message "System backup files restoration completed successfully" "false"
+            log_message "System backup restored successfully" "false"
         else
-            log_message "System backup files restoration completed with errors (status $RESTORE_SYSTEM_STATUS)" "false" "WARN"
+            log_message "System backup restored with errors (status $RESTORE_SYSTEM_STATUS)" "false" "WARN"
         fi
         
-        log_message "System backup files restoration from ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
+        log_message "System backup from ${REMOTENAME}${SYNCPATH_BACKUP} restored!"
     else
-        log_message "System backup files restoration skipped (BACKUPFILE_RESTORE_OPTION is not set to 'yes')" "false"
+        log_message "System backup restore was skipped (BACKUPFILE_RESTORE_OPTION is not set to 'yes')" "false"
     fi
 }
 

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -146,6 +146,7 @@ restore_game_saves() {
 # Restores system backup files from cloud storage
 # Only runs when BACKUPFILE_RESTORE_OPTION is set to "yes"
 restore_system_files() {
+    echo
     log_message "====================================" "true"
     log_message "STARTING SYSTEM BACKUP FILE RESTORE" "true"
     log_message "====================================" "true"
@@ -204,7 +205,7 @@ main() {
     RESTORE_STATUS=$?
     
     # Add a pause for better visual separation
-    sleep 1
+    sleep 2
     
     # Execute Part 2: System restore
     restore_system_files
@@ -218,15 +219,19 @@ main() {
     fi
     
     # Add a pause before summary
-    sleep 1
+    sleep 2
     
     # Provide final summary of all operations
+    echo
     log_message "====================================" "true"
     log_message "RESTORE SUMMARY:" "true"
     log_message "Game saves restore: $([ $RESTORE_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
     [ "${BACKUPFILE_RESTORE_OPTION}" == "yes" ] && log_message "System backup file restore: $([ $RESTORE_SYSTEM_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
     log_message "Log file: ${LOG_FILE}" "true"
     log_message "====================================" "true"
+    
+    # Add a final pause before exiting
+    sleep 3
     
     # Use the game saves restore status as the overall exit code
     clean_exit ${RESTORE_STATUS}

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-# Common functions and constants
+# Script configuration and global variables
 SCRIPT_NAME=$(basename "$0")
 LOG_FILE="/var/log/cloud_sync.log"
 START_TIME=$(date +%s)
 
-# Logging function with severity levels
+# Logging function that supports different severity levels and optional console output
+# Parameters:
+#   $1: Message text
+#   $2: Whether to echo to screen (true/false, defaults to true)
+#   $3: Log level (INFO, WARN, ERROR, defaults to INFO)
 log_message() {
     local message="$1"
     local echo_to_screen="${2:-true}"  # Default to true
@@ -26,7 +30,10 @@ log_message() {
     fi
 }
 
-# Clean exit function
+# Performs cleanup operations and exits with the specified code
+# Records total execution time in the log for performance tracking
+# Parameters:
+#   $1: Exit code to return
 clean_exit() {
     local exit_code=$1
     local duration=$(($(date +%s) - START_TIME))
@@ -35,7 +42,8 @@ clean_exit() {
     exit ${exit_code}
 }
 
-# Check for rclone configuration
+# Verifies rclone is properly configured before attempting operations
+# Exits with error if configuration file is missing
 check_rclone_config() {
     if [ ! -e "/storage/.config/rclone/rclone.conf" ]; then
         log_message "You must configure rclone before using this tool. Run \`rclone config\` to get started." "true" "ERROR"
@@ -44,7 +52,8 @@ check_rclone_config() {
     fi
 }
 
-# Check internet connectivity
+# Validates internet connectivity before attempting cloud operations
+# Uses ping to google.com as a connectivity test
 check_internet() {
     log_message "Checking internet connectivity..." "false"
     ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
@@ -56,7 +65,8 @@ check_internet() {
     log_message "Internet connection detected" "false"
 }
 
-# Load configuration
+# Loads user configuration from cloud_sync.conf
+# Applies default values for any missing configuration parameters
 load_config() {
     log_message "Loading configuration from cloud_sync.conf" "false"
     source /storage/.config/cloud_sync.conf
@@ -104,20 +114,52 @@ load_config() {
     log_message "Configuration loaded successfully" "false"
 }
 
-# Function to restore system backup files
+# PART 1: Game saves restore function
+# Restores game saves from cloud storage
+restore_game_saves() {
+    log_message "====================================" "true"
+    log_message "STARTING GAME SAVES RESTORE" "true"
+    log_message "====================================" "true"
+    
+    log_message "Starting restore from ${REMOTENAME}${SYNCPATH} to ${RESTOREPATH}"
+    log_message "Restore started at $(date)" "false"
+    
+    rclone ${RESTOREMETHOD} \
+      ${RCLONEOPTS} \
+      ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
+    
+    RESTORE_STATUS=$?
+    if [ $RESTORE_STATUS -eq 0 ]; then
+        log_message "Game saves restore completed successfully" "true"
+    else
+        log_message "Game saves restore completed with errors (status $RESTORE_STATUS)" "true" "WARN"
+    fi
+    
+    log_message "Game saves restore from ${REMOTENAME}${SYNCPATH} complete!"
+    
+    return $RESTORE_STATUS
+}
+
+# PART 2: System backup file restore function
+# Restores system backup files from cloud storage
+# Only runs when BACKUPFILE_RESTORE_OPTION is set to "yes"
 restore_system_files() {
+    log_message "====================================" "true"
+    log_message "STARTING SYSTEM BACKUP FILE RESTORE" "true"
+    log_message "====================================" "true"
+    
     if [ "${BACKUPFILE_RESTORE_OPTION}" == "yes" ]; then
-        # Check if remote backup directory exists and is not empty
+        # Verify remote backup directory has content before attempting restore
         REMOTE_FILES=$(rclone ls ${REMOTENAME}${SYNCPATH_BACKUP}/ 2>/dev/null)
         if [ -z "${REMOTE_FILES}" ]; then
-            log_message "There is no system backup to restore" "true" "WARN"
-            return
+            log_message "There are no system backup files to restore" "true" "WARN"
+            return 1
         fi
         
-        log_message "Starting restore of system backup from ${REMOTENAME}${SYNCPATH_BACKUP} to ${BACKUPFOLDER}"
-        log_message "System restore started at $(date)" "false"
+        log_message "Starting restore of system backup files from ${REMOTENAME}${SYNCPATH_BACKUP} to ${BACKUPFOLDER}"
+        log_message "System backup file restore started at $(date)" "false"
         
-        # Create local directory if it doesn't exist
+        # Ensure local target directory exists before attempting restore
         mkdir -p ${BACKUPFOLDER}
         
         rclone ${RESTOREMETHOD} \
@@ -126,15 +168,18 @@ restore_system_files() {
         
         RESTORE_SYSTEM_STATUS=$?
         if [ $RESTORE_SYSTEM_STATUS -eq 0 ]; then
-            log_message "System backup restored successfully" "false"
+            log_message "System backup file restore completed successfully" "true"
         else
-            log_message "System backup restored with errors (status $RESTORE_SYSTEM_STATUS)" "false" "WARN"
+            log_message "System backup file restore completed with errors (status $RESTORE_SYSTEM_STATUS)" "true" "WARN"
         fi
         
-        log_message "System backup from ${REMOTENAME}${SYNCPATH_BACKUP} restored!"
+        log_message "System backup file restore from ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
     else
-        log_message "System backup restore was skipped (BACKUPFILE_RESTORE_OPTION is not set to 'yes')" "false"
+        log_message "System backup file restore skipped (BACKUPFILE_RESTORE_OPTION is not set to 'yes')" "true"
+        RESTORE_SYSTEM_STATUS=0
     fi
+    
+    return $RESTORE_SYSTEM_STATUS
 }
 
 # Main script execution
@@ -146,39 +191,38 @@ main() {
     # Define locations for source and remote
     REMOTENAME=`rclone listremotes | head -1`
     
-    # Run restore
+    # Begin main script operations
     log_message "=> ${OS_NAME} CLOUD RESTORE UTILITY\n"
-    log_message "Starting restore from ${REMOTENAME}${SYNCPATH} to ${RESTOREPATH}"
-    log_message "Restore started at $(date)" "false"
     
-    rclone ${RESTOREMETHOD} \
-      ${RCLONEOPTS} \
-      ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
-    
+    # Execute Part 1: Game saves restore
+    restore_game_saves
     RESTORE_STATUS=$?
-    if [ $RESTORE_STATUS -eq 0 ]; then
-        log_message "Restore completed successfully" "false"
-    else
-        log_message "Restore completed with errors (status $RESTORE_STATUS)" "false" "WARN"
-    fi
     
-    # Restore system backup files
+    # Execute Part 2: System restore
     restore_system_files
+    RESTORE_SYSTEM_STATUS=$?
     
     # Create empty missing system directories if removed during restore
+    # Only necessary when using sync method which can delete files
     if [ "${RESTOREMETHOD}" == "sync" ]; then
-        log_message "Creating empty missing system directories" "false"
+        log_message "Creating empty missing system directories" "true"
         systemd-tmpfiles --create /usr/config/system-dirs.conf
     fi
     
-    log_message "Restore from ${REMOTENAME}${SYNCPATH} complete!"
-    sleep 1.5
-    clear
+    # Provide final summary of all operations
+    log_message "====================================" "true"
+    log_message "RESTORE SUMMARY:" "true"
+    log_message "Game saves restore: $([ $RESTORE_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
+    [ "${BACKUPFILE_RESTORE_OPTION}" == "yes" ] && log_message "System backup file restore: $([ $RESTORE_SYSTEM_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"
+    log_message "Log file: ${LOG_FILE}" "true"
+    log_message "====================================" "true"
+    
+    # Use the game saves restore status as the overall exit code
     clean_exit ${RESTORE_STATUS}
 }
 
-# Handle script interruption
+# Set up signal trap to handle user interruption gracefully
 trap 'log_message "Script interrupted by user" "false" "WARN"; clean_exit 130' INT TERM
 
-# Execute main function
+# Start script execution
 main

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -2,115 +2,135 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-# Logging function
+# Common functions and constants
+SCRIPT_NAME=$(basename "$0")
+LOG_FILE="/var/log/cloud_sync.log"
+START_TIME=$(date +%s)
+
+# Logging function with severity levels
 log_message() {
     local message="$1"
     local echo_to_screen="${2:-true}"  # Default to true
+    local level="${3:-INFO}"
     local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
-    local script_name=$(basename "$0")
     
-    echo "[${timestamp}] [${script_name}] ${message}" >> /var/log/cloud_sync.log
+    echo "[${timestamp}] [${level}] [${SCRIPT_NAME}] ${message}" >> ${LOG_FILE}
     
     if [[ "${echo_to_screen}" == "true" ]]; then
-        echo -e "${message}"
+        # Color output based on level
+        case "${level}" in
+            ERROR) echo -e "\e[31m${message}\e[0m" ;;
+            WARN)  echo -e "\e[33m${message}\e[0m" ;;
+            *)     echo -e "${message}" ;;
+        esac
     fi
 }
 
-# Check if rclone has been configured
-if [ ! -e "/storage/.config/rclone/rclone.conf" ]
-then
-  log_message "ERROR: You must configure rclone before using this tool. Run \`rclone config\` to get started."
-  sleep 3
-  exit 1
-fi
+# Clean exit function
+clean_exit() {
+    local exit_code=$1
+    local duration=$(($(date +%s) - START_TIME))
+    
+    log_message "Script completed in ${duration} seconds with exit code ${exit_code}" "false"
+    exit ${exit_code}
+}
 
-# Check that the internet is reachable
-ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
-if [ "${ONLINESTATUS}" == "offline" ]
-then
-  log_message "ERROR: You're not currently connected to the internet.\nPlease verify your settings and then try again."
-  sleep 3
-  exit 1
-fi
+# Check for rclone configuration
+check_rclone_config() {
+    if [ ! -e "/storage/.config/rclone/rclone.conf" ]; then
+        log_message "You must configure rclone before using this tool. Run \`rclone config\` to get started." "true" "ERROR"
+        sleep 3
+        clean_exit 1
+    fi
+}
 
-# Loads cloud sync config variables from cloud_sync.conf
-log_message "Loading configuration from cloud_sync.conf" "false"
-source /storage/.config/cloud_sync.conf
+# Check internet connectivity
+check_internet() {
+    log_message "Checking internet connectivity..." "false"
+    ONLINESTATUS=`ping -q -c1 google.com &>/dev/null && echo online || echo offline`
+    if [ "${ONLINESTATUS}" == "offline" ]; then
+        log_message "You're not currently connected to the internet.\nPlease verify your settings and then try again." "true" "ERROR"
+        sleep 3
+        clean_exit 1
+    fi
+    log_message "Internet connection detected" "false"
+}
 
-# Check if needed default variables from the conf file are present, and add if nececssary
-if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]
-then
-  log_message "Some configuration variables missing, loading defaults" "false"
-  source /storage/.config/cloud_sync.conf.defaults
-  if [ "${BACKUPPATH}" == "" ]
-  then
-    sed -i -e '$a\\nBACKUPPATH="'"${DEFAULT_BACKUPPATH}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RESTOREPATH}" == "" ]
-  then
-    sed -i -e '$a\\nRESTOREPATH="'"${DEFAULT_RESTOREPATH}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${SYNCPATH}" == "" ]
-  then
-    sed -i -e '$a\\nSYNCPATH="'"${DEFAULT_SYNCPATH}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RCLONEOPTS}" == "" ]
-  then
-    sed -i -e '$a\\nRCLONEOPTS="'"${DEFAULT_RCLONEOPTS}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${BACKUPMETHOD}" == "" ]
-  then
-    sed -i -e '$a\\nBACKUPMETHOD="'"${DEFAULT_BACKUPMETHOD}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RESTOREMETHOD}" == "" ]
-  then
-    sed -i -e '$a\\nRESTOREMETHOD="'"${DEFAULT_RESTOREMETHOD}"'"' /storage/.config/cloud_sync.conf
-  fi
- 
-  if [ "${RSYNCRMDIR}" == "" ]
-  then
-    sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
-  fi
-  source /storage/.config/cloud_sync.conf
-fi
+# Load configuration
+load_config() {
+    log_message "Loading configuration from cloud_sync.conf" "false"
+    source /storage/.config/cloud_sync.conf
+    
+    # Check if needed variables are present, add if necessary
+    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ]; then
+        log_message "Some configuration variables missing, loading defaults" "false" "WARN"
+        source /storage/.config/cloud_sync.conf.defaults
+        if [ "${BACKUPPATH}" == "" ]; then
+            sed -i -e '$a\\nBACKUPPATH="'"${DEFAULT_BACKUPPATH}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RESTOREPATH}" == "" ]; then
+            sed -i -e '$a\\nRESTOREPATH="'"${DEFAULT_RESTOREPATH}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${SYNCPATH}" == "" ]; then
+            sed -i -e '$a\\nSYNCPATH="'"${DEFAULT_SYNCPATH}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RCLONEOPTS}" == "" ]; then
+            sed -i -e '$a\\nRCLONEOPTS="'"${DEFAULT_RCLONEOPTS}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${BACKUPMETHOD}" == "" ]; then
+            sed -i -e '$a\\nBACKUPMETHOD="'"${DEFAULT_BACKUPMETHOD}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RESTOREMETHOD}" == "" ]; then
+            sed -i -e '$a\\nRESTOREMETHOD="'"${DEFAULT_RESTOREMETHOD}"'"' /storage/.config/cloud_sync.conf
+        fi
+        if [ "${RSYNCRMDIR}" == "" ]; then
+            sed -i -e '$a\\nRSYNCRMDIR="'"${DEFAULT_RSYNCRMDIR}"'"' /storage/.config/cloud_sync.conf
+        fi
+        source /storage/.config/cloud_sync.conf
+    fi
+    
+    log_message "Configuration loaded successfully" "false"
+}
 
-# Restore from rclone remote
-if [ -e "/storage/.config/rclone/rclone.conf" ]
-then
-  # Define locations for source and remote
-  REMOTENAME=`rclone listremotes | head -1`
+# Main script execution
+main() {
+    check_rclone_config
+    check_internet
+    load_config
+    
+    # Define locations for source and remote
+    REMOTENAME=`rclone listremotes | head -1`
+    
+    # Run restore
+    log_message "=> ${OS_NAME} CLOUD RESTORE UTILITY\n"
+    log_message "Starting restore from ${REMOTENAME}${SYNCPATH} to ${RESTOREPATH}"
+    log_message "Restore started at $(date)" "false"
+    
+    rclone ${RESTOREMETHOD} \
+      ${RCLONEOPTS} \
+      ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
+    
+    RESTORE_STATUS=$?
+    if [ $RESTORE_STATUS -eq 0 ]; then
+        log_message "Restore completed successfully" "false"
+    else
+        log_message "Restore completed with errors (status $RESTORE_STATUS)" "false" "WARN"
+    fi
+    
+    # Create empty missing system directories if removed during restore
+    if [ "${RESTOREMETHOD}" == "sync" ]; then
+        log_message "Creating empty missing system directories" "false"
+        systemd-tmpfiles --create /usr/config/system-dirs.conf
+    fi
+    
+    log_message "Restore from ${REMOTENAME}${SYNCPATH} complete!"
+    sleep 1.5
+    clear
+    clean_exit ${RESTORE_STATUS}
+}
 
-  # Run restore
-  log_message "=> ${OS_NAME} CLOUD RESTORE UTILITY\n"
-  log_message "Starting restore from ${REMOTENAME}${SYNCPATH} to ${RESTOREPATH}"
-  
-  # Add start time to log
-  log_message "Restore started at $(date)" "false"
-  
-  rclone ${RESTOREMETHOD} \
-    ${RCLONEOPTS} \
-    ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
-  
-  RESTORE_STATUS=$?
-  if [ $RESTORE_STATUS -eq 0 ]; then
-    log_message "Restore completed successfully" "false"
-  else
-    log_message "Restore completed with errors (status $RESTORE_STATUS)" "false"
-  fi
-fi
+# Handle script interruption
+trap 'log_message "Script interrupted by user" "false" "WARN"; clean_exit 130' INT TERM
 
-# Create empty missing system directories if removed during restore
-if [ "${RESTOREMETHOD}" == "sync" ]
-then
-  log_message "Creating empty missing system directories" "false"
-  systemd-tmpfiles --create /usr/config/system-dirs.conf
-fi
-
-log_message "Restore from ${REMOTENAME}${SYNCPATH} complete!"
-sleep 1.5
-clear
+# Execute main function
+main

--- a/packages/network/rclone/sources/cloud_sync-rules.txt
+++ b/packages/network/rclone/sources/cloud_sync-rules.txt
@@ -1,15 +1,18 @@
 # This is a required rule for subdirectory matching.
 + */
 
-### Do not include BIOS.
+# Do not include BIOS.
 - bios/**
 
-### Retroarch saves
+# Retroarch saves
 + *.sav
 + *.srm
 + *.auto
 + *.state*
 + *.dsv*
 
-### This is a required rule to exclude all other file types.
+# Backup files
++ ROCKNIX_BACKUP.zip
+
+# This is a required rule to exclude all other file types.
 - *

--- a/packages/network/rclone/sources/cloud_sync-rules.txt
+++ b/packages/network/rclone/sources/cloud_sync-rules.txt
@@ -12,7 +12,7 @@
 + *.dsv*
 
 # Backup files
-+ ROCKNIX_BACKUP.zip
++ /backup/*.zip
 
 # This is a required rule to exclude all other file types.
 - *

--- a/packages/network/rclone/sources/cloud_sync.conf
+++ b/packages/network/rclone/sources/cloud_sync.conf
@@ -17,13 +17,13 @@ RCLONEOPTS=" \
 "
 
 # Backup method
-# The default is "sync", which creates a 1:1 match between the local path and remote
-# Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
+## The default is "sync", which creates a 1:1 match between the local path and remote
+## Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
 BACKUPMETHOD="sync"
 
 # Restore method
-# The default is "copy", which will preserve any existing files and folders
-# Switching to "sync" will replace all local files in the restore path with what is on the remote
+## The default is "copy", which will preserve any existing files and folders
+## Switching to "sync" will replace all local files in the restore path with what is on the remote
 RESTOREMETHOD="copy"
 
 # Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.

--- a/packages/network/rclone/sources/cloud_sync.conf
+++ b/packages/network/rclone/sources/cloud_sync.conf
@@ -7,6 +7,12 @@ RESTOREPATH="/storage/roms"
 # Directory on the remote where save data should be stored
 SYNCPATH="/GAMES"
 
+# Local path where backups are stored (defined in backuptool)
+BACKUPFOLDER="/storage/roms/backup"
+
+# Remote path where backups are stored
+SYNCPATH_BACKUP="/GAMES/backup"
+
 # rclone sync rules
 RCLONEOPTS=" \
 --progress \
@@ -16,15 +22,27 @@ RCLONEOPTS=" \
 --verbose \
 "
 
-# Backup method
-## The default is "sync", which creates a 1:1 match between the local path and remote
-## Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
+# Backup options
+## Backup method
+### The default is "sync", which creates a 1:1 match between the local path and remote
+### Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
 BACKUPMETHOD="sync"
 
-# Restore method
-## The default is "copy", which will preserve any existing files and folders
-## Switching to "sync" will replace all local files in the restore path with what is on the remote
+## Enable backing-up the system backup file
+### The default is "yes", which will include the system backup file in the backup
+### Switching to "no" will exclude the system backup file from the backup
+BACKUPFILE_BACKUP_OPTION="yes"
+
+# Restore options
+## Restore method
+### The default is "copy", which will preserve any existing files and folders
+### Switching to "sync" will replace all local files in the restore path with what is on the remote
 RESTOREMETHOD="copy"
+
+## Enable restoring the system backup file
+### The default is "no", which will exclude the system backup file from the restore
+### Switching to "yes" will include the system backup file in the restore
+BACKUPFILE_RESTORE_OPTION="no"
 
 # Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.
 RSYNCRMDIR="yes"

--- a/packages/network/rclone/sources/cloud_sync.conf.defaults
+++ b/packages/network/rclone/sources/cloud_sync.conf.defaults
@@ -17,14 +17,14 @@ DEFAULT_RCLONEOPTS=" \
 "
 
 # Backup method
-# The default is "sync", which creates a 1:1 match between the local path and remote
-# Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
+## The default is "sync", which creates a 1:1 match between the local path and remote
+## Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
 DEFAULT_BACKUPMETHOD="sync"
 
 # Restore method
-# The default is "copy", which will preserve any existing files and folders
-# Switching to "sync" will replace all local files in the restore path with what is on the remote
+## The default is "copy", which will preserve any existing files and folders
+## Switching to "sync" will replace all local files in the restore path with what is on the remote
 DEFAULT_RESTOREMETHOD="copy"
 
-## Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.
+# Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.
 DEFAULT_RSYNCRMDIR="yes"

--- a/packages/network/rclone/sources/cloud_sync.conf.defaults
+++ b/packages/network/rclone/sources/cloud_sync.conf.defaults
@@ -7,6 +7,9 @@ DEFAULT_RESTOREPATH="/storage/roms"
 # Directory on the remote where save data should be stored
 DEFAULT_SYNCPATH="/GAMES"
 
+# Local path where backups are stored (defined in backuptool)
+DEFAULT_BACKUPFOLDER="/storage/roms/backup"
+
 # rclone sync rules
 DEFAULT_RCLONEOPTS=" \
 --progress \
@@ -16,15 +19,27 @@ DEFAULT_RCLONEOPTS=" \
 --verbose \
 "
 
-# Backup method
-## The default is "sync", which creates a 1:1 match between the local path and remote
-## Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
+# Backup options
+## Backup method
+### The default is "sync", which creates a 1:1 match between the local path and remote
+### Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
 DEFAULT_BACKUPMETHOD="sync"
 
-# Restore method
-## The default is "copy", which will preserve any existing files and folders
-## Switching to "sync" will replace all local files in the restore path with what is on the remote
+## Enable backing-up the system backup file
+### The default is "yes", which will include the system backup file in the backup
+### Switching to "no" will exclude the system backup file from the backup
+DEFAULT_BACKUPFILE_BACKUP_OPTION="yes"
+
+# Restore options
+## Restore method
+### The default is "copy", which will preserve any existing files and folders
+### Switching to "sync" will replace all local files in the restore path with what is on the remote
 DEFAULT_RESTOREMETHOD="copy"
+
+## Enable restoring the system backup file
+### The default is "no", which will exclude the system backup file from the restore
+### Switching to "yes" will include the system backup file in the restore
+DEFAULT_BACKUPFILE_RESTORE_OPTION="no"
 
 # Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.
 DEFAULT_RSYNCRMDIR="yes"


### PR DESCRIPTION
I've modified the rclone backup/restore scripts to honor a new variable in the cloud sync conf file to allow a user to choose whether or not to include a system backup when running a script.

Additionally, I've refactored the code to make it generally easier to manage and read for another dev coming in. I've also added logging, error handling, etc. to make it a bit more robust.

Next up, I want to fix some odd behaviors with the process of backing-up and restoring the backup file, but wanted to tackle this first.

I've tested it on my RK3566-based RG353M and have had no issues.