### PR TITLE
Cleanup tuning flags

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -11,26 +11,31 @@
 # determine architecture's family
   case $TARGET_CPU in
     generic|cortex-a35|cortex-a53|cortex-a57|cortex-a72|exynos-m1|qdf24xx|thunderx|xgene1|cortex-a57.cortex-a53|cortex-a72.cortex-a53|cortex-a73.cortex-a53)
-      TARGET_SUBARCH=aarch64
-      TARGET_VARIANT=armv8-a
+      TARGET_SUBARCH=armv8-a
       TARGET_ABI=eabi
       TARGET_FEATURES+=" neon"
       # This only makes sense for 8.0-a, later revisions have LSE
       TARGET_CFLAGS=" -mno-outline-atomics"
       ;;
-      cortex-a55|cortex-a76.cortex-a55)
-      TARGET_SUBARCH=aarch64
-      TARGET_VARIANT="${TARGET_VARIANT:-armv8.2-a}"
+    cortex-a55|cortex-a76.cortex-a55|cortex-a77)
+      TARGET_SUBARCH="${TARGET_SUBARCH:-armv8.2-a}"
       TARGET_ABI=eabi
       TARGET_FEATURES+=" neon"
       ;;
-
+    cortex-x3)
+      TARGET_SUBARCH=armv9-a
+      TARGET_ABI=eabi
+      TARGET_FEATURES+=" neon"
+      ;;
   esac
 
-  TARGET_GCC_ARCH=${TARGET_SUBARCH/-}
+  TARGET_SUBARCH="$TARGET_SUBARCH$TARGET_ARCH_FLAGS"
+  TARGET_TUNE="$TARGET_CPU"
+
+  TARGET_GCC_ARCH=aarch64
   TARGET_KERNEL_ARCH=arm64
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="${TARGET_CFLAGS} -march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mabi=lp64 -Wno-psabi -mtune=$TARGET_CPU"
-  TARGET_LDFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mtune=$TARGET_CPU"
-  GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_VARIANT"
+  TARGET_CFLAGS="$TARGET_CFLAGS -march=$TARGET_SUBARCH -mtune=$TARGET_TUNE -mabi=lp64 -Wno-psabi"
+  TARGET_LDFLAGS="$TARGET_LDFLAGS -march=$TARGET_SUBARCH -mtune=$TARGET_TUNE"
+  GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_SUBARCH --with-tune=$TARGET_TUNE"

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -27,24 +27,30 @@
     arm1176jzf-s)
       TARGET_SUBARCH=armv6zk
       TARGET_ABI=eabi
-      TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       ;;
     cortex-a7|cortex-a15|cortex-a17|cortex-a15.cortex-a7|cortex-a17.cortex-a7)
       TARGET_SUBARCH=armv7ve
       TARGET_ABI=eabi
-      TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       TARGET_FEATURES+=" neon"
       ;;
     cortex-a5|cortex-a8|cortex-a9)
       TARGET_SUBARCH=armv7-a
       TARGET_ABI=eabi
-      TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       TARGET_FEATURES+=" neon"
       ;;
     cortex-a35|cortex-a53|cortex-a72.cortex-a53|cortex-a55|cortex-a76.cortex-a55|cortex-a73.cortex-a53)
       TARGET_SUBARCH="${TARGET_SUBARCH:-armv8-a}"
       TARGET_ABI=eabi
-      TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
+      TARGET_FEATURES+=" neon"
+      ;;
+    cortex-a77)
+      TARGET_SUBARCH=armv8.2-a
+      TARGET_ABI=eabi
+      TARGET_FEATURES+=" neon"
+      ;;
+    cortex-a710)
+      TARGET_SUBARCH=armv9-a
+      TARGET_ABI=eabi
       TARGET_FEATURES+=" neon"
       ;;
   esac
@@ -53,12 +59,13 @@
 #    TARGET_ABI+="hf"
 #  fi
 
-  TARGET_VARIANT="${TARGET_SUBARCH}${TARGET_CPU_FLAGS}"
   TARGET_GCC_ARCH=${TARGET_SUBARCH/-}
   TARGET_KERNEL_ARCH=${TARGET_KERNEL_ARCH:-arm}
 
+  TARGET_SUBARCH="$TARGET_SUBARCH$TARGET_ARCH_FLAGS"
+  TARGET_TUNE="$TARGET_CPU$TARGET_TUNE_FLAGS"
+
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated"
-  [ -n "$TARGET_FPU" ] && TARGET_CFLAGS="$TARGET_CFLAGS $TARGET_FPU_FLAGS"
-  TARGET_LDFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU"
-  GCC_OPTS="--with-abi=aapcs-linux --with-arch=$TARGET_SUBARCH --with-float=$TARGET_FLOAT --with-fpu=$TARGET_FPU"
+  TARGET_CFLAGS="$TARGET_CFLAGS -march=$TARGET_SUBARCH -mtune=$TARGET_TUNE -mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated"
+  TARGET_LDFLAGS="$TARGET_LDFLAGS -march=$TARGET_SUBARCH -mtune=$TARGET_TUNE -mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
+  GCC_OPTS="--with-abi=aapcs-linux --with-arch=$TARGET_SUBARCH --with-tune=$TARGET_TUNE --with-float=$TARGET_FLOAT --with-fpu=$TARGET_FPU"

--- a/config/arch.i686
+++ b/config/arch.i686
@@ -12,13 +12,14 @@
 
 # determine architecture's family
   TARGET_SUBARCH=i686
+  TARGET_TUNE=generic
 
-  TARGET_GCC_ARCH="${TARGET_SUBARCH/-/}"
+  TARGET_GCC_ARCH="${TARGET_SUBARCH/-}"
   TARGET_KERNEL_ARCH=x86
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=${TARGET_CPU}"
-  TARGET_LDFLAGS="-march=${TARGET_CPU}"
+  TARGET_CFLAGS="-march=${TARGET_SUBARCH} -mtune=${TARGET_TUNE}"
+  TARGET_LDFLAGS="${TARGET_CFLAGS}"
 
 # build with SIMD support ( yes / no )
   TARGET_FEATURES+=" mmx sse sse2"

--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -11,14 +11,14 @@
   fi
 
 # determine architecture's family
-  TARGET_SUBARCH=x86_64
+  TARGET_SUBARCH=x86_64-v3
+  TARGET_TUNE=generic
 
-  TARGET_GCC_ARCH="${TARGET_SUBARCH/-/}"
+  TARGET_GCC_ARCH="${TARGET_SUBARCH/-}"
   TARGET_KERNEL_ARCH=x86
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=${TARGET_CPU} -mtune=generic"
-  TARGET_CXXFLAGS="${TARGET_CFLAGS}"
+  TARGET_CFLAGS="-march=${TARGET_SUBARCH} -mtune=${TARGET_TUNE}"
   TARGET_LDFLAGS="${TARGET_CFLAGS}"
 
 # build with SIMD support ( yes / no )

--- a/packages/debug/valgrind/patches/valgrind-0001-enable-armv8+.patch
+++ b/packages/debug/valgrind/patches/valgrind-0001-enable-armv8+.patch
@@ -6,7 +6,7 @@ diff -Naur a/configure b/configure
          ;;
  
 -     armv7*)
-+     armv7*|armv8*)
++     armv[789]*)
  	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ok (${host_cpu})" >&5
  printf "%s\n" "ok (${host_cpu})" >&6; }
  	ARCH_MAX="arm"

--- a/packages/emulators/libretro/flycast2021-lr/patches/aarch64/000-platform.patch
+++ b/packages/emulators/libretro/flycast2021-lr/patches/aarch64/000-platform.patch
@@ -2,7 +2,20 @@ diff --git a/Makefile b/Makefile
 index 01d99c3..0b80603 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -403,25 +403,27 @@ else ifeq ($(platform), arm64_cortex_a53_gles2)
+@@ -45,12 +45,9 @@
+ 
+ MFLAGS   := 
+ ASFLAGS  := 
+-LDFLAGS  :=
+ LDFLAGS_END :=
+ INCFLAGS :=
+ LIBS     :=
+-CFLAGS   := 
+-CXXFLAGS :=
+ 
+ GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ ifneq ($(GIT_VERSION)," unknown")
+@@ -403,25 +400,27 @@ else ifeq ($(platform), arm64_cortex_a53_gles2)
  
  #######################################
  
@@ -28,9 +41,9 @@ index 01d99c3..0b80603 100644
 +		-fuse-linker-plugin \
 +		-fno-stack-protector -fno-ident -fomit-frame-pointer \
 +		-fmerge-all-constants -ffast-math -funroll-all-loops \
-+		-mcpu=@TARGET_CPU@ -mtune=@TARGET_CPU@ -mno-outline-atomics
++		-mno-outline-atomics
 +	CXXFLAGS += $(CFLAGS)
-+	LDFLAGS += -mcpu=@TARGET_CPU@ -mtune=@TARGET_CPU@ -Ofast -flto -fuse-linker-plugin
++	LDFLAGS += -Ofast -flto -fuse-linker-plugin
  	PLATFORM_EXT := unix
 + 	CORE_DEFINES += -DLOW_END -DLOW_RES
  	WITH_DYNAREC=arm64

--- a/packages/emulators/libretro/geolith-lr/patches/000-platform.patch
+++ b/packages/emulators/libretro/geolith-lr/patches/000-platform.patch
@@ -1,7 +1,7 @@
 diff -rupN geolith-libretro.orig/libretro/Makefile geolith-libretro/libretro/Makefile
 --- geolith-libretro.orig/libretro/Makefile	2024-04-18 21:11:00.166799951 +0000
 +++ geolith-libretro/libretro/Makefile	2024-04-18 22:08:26.503486311 +0000
-@@ -375,6 +375,16 @@ else ifeq ($(platform), rpi4)
+@@ -375,6 +375,15 @@ else ifeq ($(platform), rpi4)
  	FLAGS += -mcpu=cortex-a72 -mtune=cortex-a72
  	FLAGS += -fomit-frame-pointer -ffast-math
  
@@ -10,9 +10,8 @@ diff -rupN geolith-libretro.orig/libretro/Makefile geolith-libretro/libretro/Mak
 +        TARGET := $(TARGET_NAME)_libretro.so
 +        fpic := -fPIC
 +        SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-+        CFLAGS+=-fsigned-char
++        CFLAGS += -fsigned-char
 +        FLAGS += -DARM
-+        FLAGS += -mcpu=@TARGET_CPU@ -mtune=@TARGET_CPU@
 +        FLAGS += -fomit-frame-pointer -ffast-math
 +
  else ifeq ($(platform), emscripten)

--- a/packages/emulators/libretro/gpsp-lr/patches/000-platform.patch
+++ b/packages/emulators/libretro/gpsp-lr/patches/000-platform.patch
@@ -2,14 +2,21 @@ diff --git a/Makefile b/Makefile
 index c52b50b..5e7f2ec 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -289,6 +289,17 @@ else ifeq ($(platform), rpi1)
+@@ -67,7 +67,6 @@
+ endif
+ LIBM		   := -lm
+ CORE_DIR    := .
+-LDFLAGS     :=
+ 
+ # Unix
+ ifeq ($(platform), unix)
+@@ -289,6 +288,16 @@ else ifeq ($(platform), rpi1)
  	MMAP_JIT_CACHE = 1
  	HAVE_DYNAREC = 1
  
 +# @DEVICE@
 +else ifeq ($(platform), @DEVICE@)
-+     CPUFLAGS := -marm -march=armv8-a+crc+simd -mtune=@TARGET_CPU@ -mfpu=neon-fp-armv8 -mfloat-abi=hard -flto
-+     CFLAGS  := $(CPUFLAGS) -fpic -ffast-math -fno-rtti -fno-exceptions
++     CFLAGS  += -marm -flto -fpic -ffast-math -fno-rtti -fno-exceptions
 +     TARGET := $(TARGET_NAME)_libretro.so
 +     fpic := -fPIC
 +     SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined

--- a/packages/emulators/libretro/handy-lr/patches/aarch64/handy-01-add-emuelec.patch
+++ b/packages/emulators/libretro/handy-lr/patches/aarch64/handy-01-add-emuelec.patch
@@ -9,12 +9,13 @@
  	TARGET := $(TARGET_NAME)_libretro.so
  	fpic := -fPIC
      SHARED := -shared -Wl,-version-script=$(LIBRETRO_DIR)/link.T -Wl,-no-undefined
-@@ -256,9 +256,9 @@
+@@ -256,10 +256,9 @@
+ 	-fno-stack-protector -fno-ident -fomit-frame-pointer \
  	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
  	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
- 	-fmerge-all-constants -fno-math-errno \
+-	-fmerge-all-constants -fno-math-errno \
 -	-marm -mtune=cortex-a35 -mfpu=neon-fp-armv8 -mfloat-abi=hard
-+	-mtune=cortex-a72 #-mfpu=neon-fp-armv8 -mfloat-abi=hard
++	-fmerge-all-constants -fno-math-errno
  	HAVE_NEON = 1
 -	ARCH = arm
 +	ARCH = aarch64

--- a/packages/emulators/libretro/mupen64plus-lr/patches/aarch64/001-optimizations.patch
+++ b/packages/emulators/libretro/mupen64plus-lr/patches/aarch64/001-optimizations.patch
@@ -1,17 +1,15 @@
 diff -rupN mupen64plus.orig/Makefile mupen64plus/Makefile
 --- mupen64plus.orig/Makefile	2022-02-27 09:19:06.080700288 -0500
 +++ mupen64plus/Makefile	2022-02-27 13:27:51.390268523 -0500
-@@ -238,6 +238,18 @@ else ifneq (,$(findstring osx,$(platform
+@@ -238,6 +238,16 @@ else ifneq (,$(findstring osx,$(platform
  
     COREFLAGS += -DOS_LINUX
     ASFLAGS = -f elf -d ELF_TYPE
 +
-+# Rockchip @DEVICE@
++# @DEVICE@
 +else ifneq (,$(findstring @DEVICE@,$(platform)))
 +   TARGET := $(TARGET_NAME)_libretro.so
 +   LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -ldl
-+
-+   CPUFLAGS += -march=armv8-a -mtune=@TARGET_CPU@
 +   COREFLAGS += -DOS_LINUX
 +   HAVE_NEON = 0
 +   WITH_DYNAREC := aarch64

--- a/packages/emulators/libretro/mupen64plus-nx-lr/patches/000-platform.patch
+++ b/packages/emulators/libretro/mupen64plus-nx-lr/patches/000-platform.patch
@@ -2,7 +2,7 @@ diff --git a/Makefile b/Makefile
 index 481e8b9..2a4e365 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -366,34 +366,14 @@ else ifneq (,$(findstring arm64_cortex_a53_gles3,$(platform)))
+@@ -366,34 +366,13 @@ else ifneq (,$(findstring arm64_cortex_a53_gles3,$(platform)))
     COREFLAGS += -DOS_LINUX
     ASFLAGS = -f elf64 -d ELF_TYPE
  
@@ -36,7 +36,6 @@ index 481e8b9..2a4e365 100644
 -   WITH_DYNAREC=arm
 -   COREFLAGS += -DUSE_GENERIC_GLESV2 -DOS_LINUX
 -   ASFLAGS = -f elf -d ELF_TYPE
-+   CPUFLAGS += -march=armv8-a -mtune=@TARGET_CPU@
 +   WITH_DYNAREC := aarch64
 +   COREFLAGS += -DOS_LINUX
 +   ASFLAGS = -f elf64 -d ELF_TYPE

--- a/packages/emulators/libretro/parallel-n64-lr/patches/002-rk3588-make.patch
+++ b/packages/emulators/libretro/parallel-n64-lr/patches/002-rk3588-make.patch
@@ -18,7 +18,7 @@ index 8a719d55..0872e619 100644
 +  #@DEVICE@
 +  ifneq (,$(findstring @DEVICE@,$(platform)))
 +    TARGET := $(TARGET_NAME)_libretro.so
-+    CPUFLAGS += -march=armv8-a+crc+simd -mtune=@TARGET_CPU@ -DARM_FIX -DCLASSIC -DARM64
++    CPUFLAGS += -DARM_FIX -DCLASSIC -DARM64
 +    WITH_DYNAREC = aarch64
 +  endif
 +

--- a/packages/emulators/libretro/pcsx_rearmed-lr/patches/aarch64/pcsx_rearmed-add_platform.patch
+++ b/packages/emulators/libretro/pcsx_rearmed-lr/patches/aarch64/pcsx_rearmed-add_platform.patch
@@ -12,7 +12,7 @@ diff -rupN pcsx_rearmed.orig/Makefile.libretro pcsx_rearmed/Makefile.libretro
 +       DYNAREC = ari64
 +       BUILTIN_GPU = neon
 +       HAVE_NEON = 1
-+       CFLAGS += -march=armv8-a+crc+simd -mtune=@TARGET_CPU@ -ftree-vectorize
++       CFLAGS += -ftree-vectorize
 +
  # Classic Platforms ####################
  # Platform affix = classic_<ISA>_<µARCH>

--- a/packages/emulators/libretro/pcsx_rearmed-lr/patches/arm/pcsx_rearmed-add_platform.patch
+++ b/packages/emulators/libretro/pcsx_rearmed-lr/patches/arm/pcsx_rearmed-add_platform.patch
@@ -1,15 +1,14 @@
 diff -rupN pcsx_rearmed.orig/Makefile.libretro pcsx_rearmed/Makefile.libretro
 --- pcsx_rearmed.orig/Makefile.libretro 2022-08-16 15:19:42.928678600 +0200
 +++ pcsx_rearmed/Makefile.libretro      2022-08-17 17:51:57.256712172 +0200
-@@ -385,6 +385,17 @@ else ifeq ($(platform), rpi4_64)
+@@ -385,6 +385,16 @@ else ifeq ($(platform), rpi4_64)
          fpic := -fPIC
          CFLAGS += -march=armv8-a+crc+simd -mtune=cortex-a72 -ftree-vectorize
 
 +else ifeq ($(platform), @DEVICE@)
 +       TARGET := $(TARGET_NAME)_libretro.so
 +       fpic := -fPIC
-+       CFLAGS += -marm -mtune=@TARGET_CPU@ -mfpu=neon-fp-armv8 -mfloat-abi=hard
-+       ASFLAGS += -mtune=@TARGET_CPU@ -mfpu=neon-fp-armv8 -mfloat-abi=hard
++       CFLAGS += -marm
 +       HAVE_NEON = 1
 +       HAVE_NEON_ASM = 1
 +       ARCH = arm

--- a/packages/emulators/libretro/snes9x2010-lr/patches/snes9x2010-add-oga.patch
+++ b/packages/emulators/libretro/snes9x2010-lr/patches/snes9x2010-add-oga.patch
@@ -19,7 +19,7 @@
 +	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
 +	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
 +	-fmerge-all-constants -fno-math-errno \
-+	-marm -mcpu=cortex-a35 -mfpu=neon-fp-armv8 -mfloat-abi=hard
++	-marm
 +	CXXFLAGS += $(CFLAGS)
 +	CPPFLAGS += $(CFLAGS)
 +	ASFLAGS += $(CFLAGS)

--- a/packages/emulators/libretro/vitaquake2-lr/patches/aarch64/001-set-platform.patch
+++ b/packages/emulators/libretro/vitaquake2-lr/patches/aarch64/001-set-platform.patch
@@ -9,7 +9,7 @@ diff -rupN vitaquake2.orig/Makefile vitaquake2/Makefile
 +    TARGET := $(TARGET_NAME)_libretro.so
 +    fpic := -fPIC
 +    SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl,--no-undefined
-+    CFLAGS += -mcpu=@TARGET_CPU@ -mtune=@TARGET_CPU@ -ffast-math -DARM
++    CFLAGS += -ffast-math -DARM
 +    CFLAGS += -D_POSIX_C_SOURCE=200809L -D_DEFAULT_SOURCE
 +    GLES := 1
 +    GLES31 := 1

--- a/packages/emulators/libretro/yabasanshiro-lr/patches/aarch64/01-optimization.patch
+++ b/packages/emulators/libretro/yabasanshiro-lr/patches/aarch64/01-optimization.patch
@@ -1,18 +1,17 @@
 diff -rupN yabasanshiro.orig/yabause/src/libretro/Makefile yabasanshiro/yabause/src/libretro/Makefile
 --- yabasanshiro.orig/yabause/src/libretro/Makefile	2022-02-27 14:51:53.958685169 -0500
 +++ yabasanshiro/yabause/src/libretro/Makefile	2022-02-27 14:57:08.993824415 -0500
-@@ -155,11 +155,12 @@ else ifneq (,$(findstring rockpro64,$(pl
+@@ -155,11 +155,11 @@ else ifneq (,$(findstring rockpro64,$(pl
  	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
  	LDFLAGS += -lpthread
  	ARCH_IS_LINUX = 1
-+        FLAGS += -DAARCH64
++	FLAGS += -DAARCH64
  	HAVE_SSE = 0
  	FORCE_GLES = 1
 -	USE_ARM_DRC = 1
-+        USE_AARCH64_DRC = 1
++	USE_AARCH64_DRC = 1
  	DYNAREC_DEVMIYAX = 1
 -	FLAGS += -march=armv8-a+crc -mcpu=cortex-a72 -mtune=cortex-a72.cortex-a53 -mfloat-abi=hard -mfpu=neon-vfpv4 -mvectorize-with-neon-quad
-+	FLAGS += -march=armv8-a+crc -mtune=@TARGET_CPU@
  
  # Rpi4 (64-bit)
  else ifeq ($(platform), rpi4)

--- a/packages/emulators/standalone/amiberry/patches/01-platform.patch
+++ b/packages/emulators/standalone/amiberry/patches/01-platform.patch
@@ -1,9 +1,20 @@
-Binary files amiberry.orig/.git/index and amiberry/.git/index differ
-Binary files amiberry.orig/.git/modules/external/capsimg/index and amiberry/.git/modules/external/capsimg/index differ
-Binary files amiberry.orig/.git/modules/external/libmpeg2/index and amiberry/.git/modules/external/libmpeg2/index differ
 diff -rupN amiberry.orig/Makefile amiberry/Makefile
---- amiberry.orig/Makefile	2022-04-16 16:23:12.481980516 -0400
+--- amiberry/Makefile	2022-04-16 16:23:12.481980516 -0400
 +++ amiberry/Makefile	2022-04-16 23:36:53.638425501 -0400
+@@ -43,10 +43,10 @@
+ export SDL_CFLAGS := $(shell $(SDL_CONFIG) --cflags)
+ export SDL_LDFLAGS := $(shell $(SDL_CONFIG) --libs)
+ 
+-CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
++CPPFLAGS = $(CXXFLAGS) -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
+-CFLAGS=-pipe -Wno-shift-overflow -Wno-narrowing
++CFLAGS += -pipe -Wno-shift-overflow -Wno-narrowing
+ USE_LD ?= gold
+-LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lguisan -Lexternal/libguisan/lib
++LDFLAGS += $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lguisan -Lexternal/libguisan/lib
+ ifneq ($(strip $(USE_LD)),)
+ 	LDFLAGS += -fuse-ld=$(USE_LD)
+ endif
 @@ -228,30 +228,12 @@ else ifeq ($(PLATFORM),a64)
  else ifeq ($(PLATFORM),x86-64)
  	CPPFLAGS += -DUSE_RENDER_THREAD
@@ -14,9 +25,9 @@ diff -rupN amiberry.orig/Makefile amiberry/Makefile
 -# RK3326 e.g. Odroid Go Advance - 32-bit userspace
 -else ifneq (,$(findstring RK,$(PLATFORM)))
 -	CPPFLAGS += $(CPPFLAGS32) $(NEON_FLAGS)
-+# Anbernic DEVICE@
++# @DEVICE@
 +else ifeq ($(PLATFORM),@DEVICE@)
-+	CPPFLAGS += $(CPPFLAGS64) -mtune=@TARGET_CPU@ -O3 -ffast-math -DUSE_RENDER_THREAD
++	CPPFLAGS += $(CPPFLAGS64) -O3 -ffast-math -DUSE_RENDER_THREAD
 +	AARCH64 = 1
  	HAVE_NEON = 1
  

--- a/projects/Allwinner/devices/H700/options
+++ b/projects/Allwinner/devices/H700/options
@@ -8,10 +8,8 @@
       aarch64)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
-        TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+fp+simd"
-        TARGET_FPU="fp-armv8"
+        TARGET_ARCH_FLAGS="+crc+fp+simd"
         TARGET_FEATURES="64bit"
         ;;
       arm)
@@ -19,7 +17,7 @@
         TARGET_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
+        TARGET_ARCH_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
         TARGET_FEATURES="32bit"
         ;;

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -9,18 +9,16 @@
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a73.cortex-a53"
-        TARGET_CPU_FLAGS="+crc+fp+simd"
-        TARGET_FPU="fp-armv8"
-	TARGET_FLOAT="hard"
+        TARGET_ARCH_FLAGS="+crc+fp+simd"
         TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a73.cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
+        TARGET_ARCH_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
-	TARGET_FLOAT="hard"
+        TARGET_FLOAT="hard"
         TARGET_FEATURES="32bit"
         ;;
     esac

--- a/projects/Qualcomm/devices/SM8250/options
+++ b/projects/Qualcomm/devices/SM8250/options
@@ -8,19 +8,15 @@
       aarch64)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
-        # cortex-a77.cortex-a55 not supported
         TARGET_CPU="cortex-a76.cortex-a55"
-        TARGET_CPU_FLAGS="+crypto+crc+fp+simd"
-        TARGET_FPU="fp-armv8"
-        TARGET_FLOAT="hard"
+        TARGET_ARCH_FLAGS="+crypto+crc+fp+simd"
         TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
-	# cortex-a77.cortex-a55 not supported
         TARGET_CPU="cortex-a76.cortex-a55"
-        TARGET_CPU_FLAGS="+crc"
+        TARGET_ARCH_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
         TARGET_FLOAT="hard"
         TARGET_FEATURES="32bit"

--- a/projects/Qualcomm/devices/SM8550/options
+++ b/projects/Qualcomm/devices/SM8550/options
@@ -8,11 +8,9 @@
       aarch64)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
-        TARGET_VARIANT="armv8.6-a"
+        TARGET_SUBARCH="armv8.6-a"
         TARGET_CPU="cortex-a76.cortex-a55"
-        TARGET_CPU_FLAGS="+i8mm+sm4+sha3+rcpc+crypto+nosve+nosve2"
-        TARGET_FPU="fp-armv8"
-        TARGET_FLOAT="hard"
+        TARGET_ARCH_FLAGS="+i8mm+sm4+sha3+rcpc+crypto+nosve+nosve2"
         TARGET_FEATURES="64bit"
         ;;
       arm)
@@ -20,7 +18,7 @@
         TARGET_PATCH_ARCH="aarch64"
         TARGET_SUBARCH="armv8.6-a"
         TARGET_CPU="cortex-a76.cortex-a55"
-        TARGET_CPU_FLAGS="+i8mm+crypto"
+        TARGET_ARCH_FLAGS="+i8mm+crypto"
         TARGET_FPU="crypto-neon-fp-armv8"
         TARGET_FLOAT="hard"
         TARGET_FEATURES="32bit"

--- a/projects/Rockchip/devices/RK3326/options
+++ b/projects/Rockchip/devices/RK3326/options
@@ -8,10 +8,8 @@
       aarch64)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
-        TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a35"
-	TARGET_CPU_FLAGS="+crc+fp+simd"
-        TARGET_FPU="fp-armv8"
+        TARGET_ARCH_FLAGS="+crc+fp+simd"
         TARGET_FEATURES="64bit"
         ;;
       arm)
@@ -19,7 +17,7 @@
         TARGET_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a35"
-        TARGET_CPU_FLAGS="+crc"
+        TARGET_ARCH_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
         TARGET_FEATURES="32bit"
         ;;

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -9,16 +9,14 @@
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a72.cortex-a53"
-        TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FPU="fp-armv8"
-        TARGET_FLOAT="hard"
+        TARGET_ARCH_FLAGS="+crc+crypto"
         TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a72.cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
+        TARGET_ARCH_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
         TARGET_FLOAT="hard"
         TARGET_FEATURES="32bit"

--- a/projects/Rockchip/devices/RK3566/options
+++ b/projects/Rockchip/devices/RK3566/options
@@ -9,18 +9,16 @@
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a55"
-        TARGET_CPU_FLAGS="+crc+crypto+fp+simd+rcpc"
-        TARGET_FPU="fp-armv8"
-	TARGET_FLOAT="hard"
+        TARGET_ARCH_FLAGS="+crc+crypto+fp+simd+rcpc"
         TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a55"
-        TARGET_CPU_FLAGS="+crc"
+        TARGET_ARCH_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
-	TARGET_FLOAT="hard"
+        TARGET_FLOAT="hard"
         TARGET_FEATURES="32bit"
         ;;
     esac

--- a/projects/Rockchip/devices/RK3588/options
+++ b/projects/Rockchip/devices/RK3588/options
@@ -9,18 +9,16 @@
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a76.cortex-a55"
-        TARGET_CPU_FLAGS="+crc+crypto+rcpc+dotprod"
-        TARGET_FPU="fp-armv8"
-	TARGET_FLOAT="hard"
+        TARGET_ARCH_FLAGS="+crc+crypto+rcpc+dotprod"
         TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_PATCH_ARCH="aarch64"
         TARGET_CPU="cortex-a76.cortex-a55"
-        TARGET_CPU_FLAGS="+crc"
+        TARGET_ARCH_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-	TARGET_FLOAT="hard"
+        TARGET_FLOAT="hard"
         TARGET_FEATURES="32bit"
         ;;
     esac


### PR DESCRIPTION
The goal is to cleanup and unify the usage of march, mtune, and mcpu. While mcpu is generally does everything needed for arm platforms, a number of packages are more accustomed to the x86 usage of march and mtune, so I decided to stick with those two.

I split this PR into two commits, the first fixing up the packages to consistently use the tuning flags, and the second dealing with cleaning up the platform configuration.