### PR TITLE
rclone tools: new structure and functions to make upgrades go more smoothly

### DIFF
--- a/packages/network/rclone/package.mk
+++ b/packages/network/rclone/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="rclone"
-PKG_VERSION="1.69.0"
+PKG_VERSION="1.69.1"
 PKG_DEPENDS_TARGET="toolchain fuse rsync"
 PKG_LONGDESC="rsync for cloud storage"
 PKG_TOOLCHAIN="manual"
@@ -21,9 +21,13 @@ PKG_URL="https://downloads.rclone.org/v${PKG_VERSION}/rclone-v${PKG_VERSION}-lin
 PKG_RCLONE="rclone-v${PKG_VERSION}-linux-${RCLONE_ARCH}/rclone"
 
 unpack() {
+  # Create build directory
   mkdir -p ${PKG_BUILD}
+  # Rename the downloaded zip to include architecture for better tracking
   mv ${SOURCES}/rclone/rclone-${PKG_VERSION}.zip ${SOURCES}/rclone/rclone-${PKG_VERSION}-${RCLONE_ARCH}.zip
+  # Extract the binary package to the build directory
   unzip ${SOURCES}/rclone/rclone-${PKG_VERSION}-${RCLONE_ARCH}.zip -d ${PKG_BUILD}/
+  # Remove downloaded zip files to conserve space
   rm -f ${SOURCES}/rclone/rclone-${PKG_VERSION}*
 }
 
@@ -33,6 +37,7 @@ makeinstall_target() {
   cp rclonectl ${INSTALL}/usr/bin/
   cp cloud_backup ${INSTALL}/usr/bin/
   cp cloud_restore ${INSTALL}/usr/bin/
+  cp cloud_sync_helper ${INSTALL}/usr/bin/
   cp ${PKG_BUILD}/${PKG_RCLONE} ${INSTALL}/usr/bin/
   chmod 0755 ${INSTALL}/usr/bin/*
   cp rsync-rules.conf ${INSTALL}/usr/config/
@@ -40,6 +45,7 @@ makeinstall_target() {
   cp cloud_sync-rules.txt ${INSTALL}/usr/config/
   cp cloud_sync.conf ${INSTALL}/usr/config/
   cp cloud_sync.conf.defaults ${INSTALL}/usr/config/
+  cp cloud_sync-rules.txt.defaults ${INSTALL}/usr/config/
   chmod 755 ${INSTALL}/usr/bin/rclone
   mkdir -p ${INSTALL}/usr/config/modules
   ln -sf /usr/bin/cloud_backup ${INSTALL}/usr/config/modules/cloud_backup.sh

--- a/packages/network/rclone/sources/cloud_backup
+++ b/packages/network/rclone/sources/cloud_backup
@@ -8,14 +8,18 @@ LOG_FILE="/var/log/cloud_sync.log"
 START_TIME=$(date +%s)
 
 # Logging function that supports different severity levels and optional console output
+# 
+# This function formats and records log messages with timestamps and severity levels.
+# It can optionally display messages on screen with appropriate color coding.
+#
 # Parameters:
-#   $1: Message text
+#   $1: Message text to log
 #   $2: Whether to echo to screen (true/false, defaults to true)
-#   $3: Log level (INFO, WARN, ERROR, defaults to INFO)
+#   $3: Log level (INFO, WARN, ERROR, defaults to configured LOG_LEVEL or INFO)
 log_message() {
     local message="$1"
     local echo_to_screen="${2:-true}"  # Default to true
-    local level="${3:-INFO}"
+    local level="${3:-${LOG_LEVEL:-INFO}}"  # Use configured LOG_LEVEL as default
     local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
     
     echo "[${timestamp}] [${level}] [${SCRIPT_NAME}] ${message}" >> ${LOG_FILE}
@@ -72,7 +76,7 @@ load_config() {
     source /storage/.config/cloud_sync.conf
     
     # Check if needed variables are present, add if necessary
-    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ] || [ "${BACKUPFOLDER}" == "" ] || [ "${SYNCPATH_BACKUP}" == "" ] || [ "${BACKUPFILE_BACKUP_OPTION}" == "" ] || [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
+    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ] || [ "${BACKUPFOLDER}" == "" ] || [ "${SYNCPATH_BACKUP}" == "" ] || [ "${BACKUPFILE_BACKUP_OPTION}" == "" ] || [ "${BACKUPFILE_RESTORE_OPTION}" == "" ] || [ "${LOG_LEVEL}" == "" ]; then
         log_message "Some configuration variables missing, loading defaults" "false" "WARN"
         source /storage/.config/cloud_sync.conf.defaults
         if [ "${BACKUPPATH}" == "" ]; then
@@ -85,6 +89,7 @@ load_config() {
             sed -i -e '$a\\nSYNCPATH="'"${DEFAULT_SYNCPATH}"'"' /storage/.config/cloud_sync.conf
         fi
         if [ "${RCLONEOPTS}" == "" ]; then
+            # Ensure the options string has proper spacing when adding to config
             sed -i -e '$a\\nRCLONEOPTS="'"${DEFAULT_RCLONEOPTS}"'"' /storage/.config/cloud_sync.conf
         fi
         if [ "${BACKUPMETHOD}" == "" ]; then
@@ -108,10 +113,39 @@ load_config() {
         if [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
             sed -i -e '$a\\nBACKUPFILE_RESTORE_OPTION="'"${DEFAULT_BACKUPFILE_RESTORE_OPTION}"'"' /storage/.config/cloud_sync.conf
         fi
+        if [ "${LOG_LEVEL}" == "" ]; then
+            sed -i -e '$a\\nLOG_LEVEL="'"${DEFAULT_LOG_LEVEL}"'"' /storage/.config/cloud_sync.conf
+        fi
         source /storage/.config/cloud_sync.conf
     fi
     
-    # Create a version of RCLONEOPTS without the --delete-excluded flag for safer operations
+    # Update cloud sync rules by calling the helper script
+    if [ -f "/usr/bin/cloud_sync_helper" ]; then
+        log_message "Updating cloud sync rules" "false"
+        /usr/bin/cloud_sync_helper ${LOG_FILE}
+    fi
+    
+    # Clean and normalize rclone options to ensure proper spacing
+    # Convert multi-line options to a properly spaced single line
+    # First, save original options for debugging
+    log_message "Original RCLONEOPTS: ${RCLONEOPTS}" "false"
+    
+    # Replace any line continuations and normalize spaces
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | tr '\n\\' '  ' | tr -s ' ')
+    log_message "After newline cleanup: ${RCLONEOPTS}" "false"
+    
+    # Ensure each option starts with a space (except the first one)
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--/ --/g' | sed 's/^ //')
+    log_message "After spacing fix: ${RCLONEOPTS}" "false"
+    
+    # Convert to array to ensure proper word splitting
+    RCLONE_OPTS_ARRAY=()
+    for opt in ${RCLONEOPTS}; do
+        RCLONE_OPTS_ARRAY+=("$opt")
+    done
+    log_message "Options array has ${#RCLONE_OPTS_ARRAY[@]} elements" "false"
+    
+    # Create a version without the --delete-excluded flag
     RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
     
     log_message "Configuration loaded successfully" "false"
@@ -127,23 +161,59 @@ backup_game_saves() {
     log_message "Starting backup from ${BACKUPPATH} to ${REMOTENAME}${SYNCPATH}"
     log_message "Backup started at $(date)" "false"
     
-    rclone ${BACKUPMETHOD} \
-      ${RCLONEOPTS} \
-      ${BACKUPPATH}/ ${REMOTENAME}${SYNCPATH}/
+    # Set log level to DEBUG when INFO is selected for more verbose logging
+    local rclone_debug=""
+    local filtered_opts=("${RCLONE_OPTS_ARRAY[@]}")
+    if [ "${LOG_LEVEL}" == "INFO" ]; then
+        rclone_debug="--log-level DEBUG"
+        # Remove --verbose from options to avoid conflict with --log-level
+        filtered_opts=()
+        for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
+            if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
+                filtered_opts+=("$opt")
+            fi
+        done
+    fi
+    
+    # Log the full rclone command for debugging
+    log_message "Executing rclone command with filtered options to prevent conflicts" "false"
+    
+    # Execute rclone directly without capturing output to allow progress display
+    if [ ${#filtered_opts[@]} -gt 0 ]; then
+        rclone ${BACKUPMETHOD} \
+          "${filtered_opts[@]}" \
+          ${rclone_debug} \
+          --exclude="${BACKUPFOLDER}/**" \
+          --exclude="backups/**" \
+          --exclude="bios/**" \
+          --exclude="*.zip" \
+          ${BACKUPPATH}/ ${REMOTENAME}${SYNCPATH}/
+    else
+        # Fallback if array is empty
+        rclone ${BACKUPMETHOD} \
+          --progress \
+          --log-file /var/log/cloud_sync.log \
+          --filter-from /storage/.config/cloud_sync-rules.txt \
+          --delete-excluded \
+          ${rclone_debug} \
+          --exclude="${BACKUPFOLDER}/**" \
+          --exclude="backups/**" \
+          --exclude="bios/**" \
+          --exclude="*.zip" \
+          ${BACKUPPATH}/ ${REMOTENAME}${SYNCPATH}/
+    fi
     
     BACKUP_STATUS=$?
+    
+    # Always log errors
+    if [ $BACKUP_STATUS -ne 0 ]; then
+        log_message "Backup encountered errors (status $BACKUP_STATUS)" "false" "ERROR"
+    fi
+    
     if [ $BACKUP_STATUS -eq 0 ]; then
         log_message "Game saves backup completed successfully" "true"
     else
         log_message "Game saves backup completed with errors (status $BACKUP_STATUS)" "true" "WARN"
-    fi
-    
-    log_message "Game saves backup to ${REMOTENAME}${SYNCPATH} complete!"
-    
-    # Clean up empty directories if configured to do so
-    if [ "${RSYNCRMDIR}" == "yes" ]; then
-        log_message "Removing empty directories on remote" "false"
-        rclone rmdirs ${REMOTENAME}${SYNCPATH}/ --leave-root
     fi
     
     return $BACKUP_STATUS
@@ -171,18 +241,21 @@ backup_system_files() {
         # Ensure target directory exists before attempting transfer
         rclone mkdir ${REMOTENAME}${SYNCPATH_BACKUP}/
         
+        # Use more specific include pattern to target only backup zip files
         rclone ${BACKUPMETHOD} \
-          ${RCLONEOPTS} \
+          ${RESTORE_RCLONEOPTS} \
+          --include="*.zip" \
+          --stats-one-line \
           ${BACKUPFOLDER}/ ${REMOTENAME}${SYNCPATH_BACKUP}/
         
         BACKUP_SYSTEM_STATUS=$?
+        
         if [ $BACKUP_SYSTEM_STATUS -eq 0 ]; then
             log_message "System backup file transfer completed successfully" "true"
         else
             log_message "System backup file transfer completed with errors (status $BACKUP_SYSTEM_STATUS)" "true" "WARN"
         fi
         
-        log_message "System backup file transfer to ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
     else
         log_message "System backup file transfer skipped (BACKUPFILE_BACKUP_OPTION is not set to 'yes')" "true"
         BACKUP_SYSTEM_STATUS=0
@@ -198,27 +271,32 @@ main() {
     load_config
     
     # Use the first configured remote in rclone
+    # Note: This assumes at least one remote is configured and the first one should be used
     REMOTENAME=`rclone listremotes | head -1`
     
-    # Begin main script operations
+    # Begin main script operations with user-friendly header
     log_message "=> ${OS_NAME} CLOUD BACKUP UTILITY\n"
     
     # Execute Part 1: Game saves backup
+    # This performs the primary save file backup operation using the configured method
     backup_game_saves
     BACKUP_STATUS=$?
     
-    # Add a pause for better visual separation
+    # Add a pause for better visual separation between operations
     sleep 2
     
     # Execute Part 2: System backup file transfer
+    # This backs up system backup files (zip files) if enabled in configuration
     backup_system_files
     BACKUP_SYSTEM_STATUS=$?
     
     # Add a pause before summary
     sleep 2
     
-    # Provide final summary of all operations
+    # Add a line break for better visual separation
     echo
+    
+    # Provide final summary of all operations
     log_message "====================================" "true"
     log_message "BACKUP SUMMARY:" "true"
     log_message "Game saves backup: $([ $BACKUP_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"

--- a/packages/network/rclone/sources/cloud_restore
+++ b/packages/network/rclone/sources/cloud_restore
@@ -11,11 +11,11 @@ START_TIME=$(date +%s)
 # Parameters:
 #   $1: Message text
 #   $2: Whether to echo to screen (true/false, defaults to true)
-#   $3: Log level (INFO, WARN, ERROR, defaults to INFO)
+#   $3: Log level (INFO, WARN, ERROR, defaults to configured LOG_LEVEL or INFO)
 log_message() {
     local message="$1"
     local echo_to_screen="${2:-true}"  # Default to true
-    local level="${3:-INFO}"
+    local level="${3:-${LOG_LEVEL:-INFO}}"  # Use configured LOG_LEVEL as default
     local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
     
     echo "[${timestamp}] [${level}] [${SCRIPT_NAME}] ${message}" >> ${LOG_FILE}
@@ -72,7 +72,7 @@ load_config() {
     source /storage/.config/cloud_sync.conf
     
     # Check if needed variables are present, add if necessary
-    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ] || [ "${BACKUPFOLDER}" == "" ] || [ "${SYNCPATH_BACKUP}" == "" ] || [ "${BACKUPFILE_BACKUP_OPTION}" == "" ] || [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
+    if [ "${BACKUPPATH}" == "" ] || [ "${RESTOREPATH}" == "" ] || [ "${SYNCPATH}" == "" ] || [ "${RCLONEOPTS}" == "" ] || [ "${BACKUPMETHOD}" == "" ] || [ "${RESTOREMETHOD}" == "" ] || [ "${RSYNCRMDIR}" == "" ] || [ "${BACKUPFOLDER}" == "" ] || [ "${SYNCPATH_BACKUP}" == "" ] || [ "${BACKUPFILE_BACKUP_OPTION}" == "" ] || [ "${BACKUPFILE_RESTORE_OPTION}" == "" ] || [ "${LOG_LEVEL}" == "" ]; then
         log_message "Some configuration variables missing, loading defaults" "false" "WARN"
         source /storage/.config/cloud_sync.conf.defaults
         if [ "${BACKUPPATH}" == "" ]; then
@@ -108,9 +108,46 @@ load_config() {
         if [ "${BACKUPFILE_RESTORE_OPTION}" == "" ]; then
             sed -i -e '$a\\nBACKUPFILE_RESTORE_OPTION="'"${DEFAULT_BACKUPFILE_RESTORE_OPTION}"'"' /storage/.config/cloud_sync.conf
         fi
+        if [ "${LOG_LEVEL}" == "" ]; then
+            sed -i -e '$a\\nLOG_LEVEL="'"${DEFAULT_LOG_LEVEL}"'"' /storage/.config/cloud_sync.conf
+        fi
         source /storage/.config/cloud_sync.conf
     fi
     
+    # Update cloud sync rules by calling the helper script
+    if [ -f "/usr/bin/cloud_sync_helper" ]; then
+        log_message "Updating cloud sync rules" "false"
+        /usr/bin/cloud_sync_helper ${LOG_FILE}
+    fi
+    
+    # Clean and normalize rclone options to ensure proper spacing
+    # This is necessary because options can be provided in multiple formats:
+    # - Single line with spaces
+    # - Multi-line with backslash continuations
+    # - With or without proper spacing between options
+    # The processing below standardizes the format for reliable command execution
+    
+    # First, save original options for debugging
+    log_message "Original RCLONEOPTS: ${RCLONEOPTS}" "false"
+    
+    # Replace any line continuations and normalize spaces
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | tr '\n\\' '  ' | tr -s ' ')
+    log_message "After newline cleanup: ${RCLONEOPTS}" "false"
+    
+    # Ensure each option starts with a space (except the first one)
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--/ --/g' | sed 's/^ //')
+    log_message "After spacing fix: ${RCLONEOPTS}" "false"
+    
+    # Convert to array to ensure proper word splitting
+    # This prevents issues with options containing spaces and allows
+    # for proper quoting of each individual parameter
+    RCLONE_OPTS_ARRAY=()
+    for opt in ${RCLONEOPTS}; do
+        RCLONE_OPTS_ARRAY+=("$opt")
+    done
+    log_message "Options array has ${#RCLONE_OPTS_ARRAY[@]} elements" "false"
+    
+    # Create a version without the --delete-excluded flag
     RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
     
     log_message "Configuration loaded successfully" "false"
@@ -126,18 +163,56 @@ restore_game_saves() {
     log_message "Starting restore from ${REMOTENAME}${SYNCPATH} to ${RESTOREPATH}"
     log_message "Restore started at $(date)" "false"
     
-    rclone ${RESTOREMETHOD} \
-      ${RESTORE_RCLONEOPTS} \
-      ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
+    # Set log level to DEBUG when INFO is selected for more verbose logging
+    local rclone_debug=""
+    local filtered_opts=("${RCLONE_OPTS_ARRAY[@]}")
+    if [ "${LOG_LEVEL}" == "INFO" ]; then
+        rclone_debug="--log-level DEBUG"
+        # Remove --verbose from options to avoid conflict with --log-level
+        filtered_opts=()
+        for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
+            if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
+                filtered_opts+=("$opt")
+            fi
+        done
+    fi
+    
+    # Log the full rclone command for debugging
+    log_message "Executing rclone command with filtered options to prevent conflicts" "false"
+    
+    # Execute rclone directly without capturing output to allow progress display
+    if ((${#filtered_opts[@]} > 0)); then
+        rclone ${RESTOREMETHOD} \
+          "${filtered_opts[@]}" \
+          ${rclone_debug} \
+          --exclude="${BACKUPFOLDER}/**" \
+          --exclude="backups/**" \
+          --exclude="bios/**" \
+          ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
+    else
+        rclone ${RESTOREMETHOD} \
+          --progress \
+          --log-file /var/log/cloud_sync.log \
+          --filter-from /storage/.config/cloud_sync-rules.txt \
+          ${rclone_debug} \
+          --exclude="${BACKUPFOLDER}/**" \
+          --exclude="backups/**" \
+          --exclude="bios/**" \
+          ${REMOTENAME}${SYNCPATH}/ ${RESTOREPATH}/
+    fi
     
     RESTORE_STATUS=$?
+    
+    # Always log errors
+    if [ $RESTORE_STATUS -ne 0 ]; then
+        log_message "Restore encountered errors (status $RESTORE_STATUS)" "false" "ERROR"
+    fi
+    
     if [ $RESTORE_STATUS -eq 0 ]; then
         log_message "Game saves restore completed successfully" "true"
     else
         log_message "Game saves restore completed with errors (status $RESTORE_STATUS)" "true" "WARN"
     fi
-    
-    log_message "Game saves restore from ${REMOTENAME}${SYNCPATH} complete!"
     
     return $RESTORE_STATUS
 }
@@ -165,11 +240,24 @@ restore_system_files() {
         # Ensure local target directory exists before attempting restore
         mkdir -p ${BACKUPFOLDER}
         
-        # Adjust filter rules to handle potential path mismatches
+        # Check if the rclone version supports the terminal width flag
+        if rclone help | grep -q progress-terminal-width; then
+            TERMINAL_WIDTH="--progress-terminal-width=80"
+        else
+            TERMINAL_WIDTH=""
+        fi
+        
+        # Use individual options instead of the variable
+        # Add progress formatting options to improve display
         rclone ${RESTOREMETHOD} \
-          ${RCLONEOPTS} \
+          --progress \
+          --log-file /var/log/cloud_sync.log \
+          --filter-from /storage/.config/cloud_sync-rules.txt \
+          --verbose \
           --include "/backup/*.zip" \
           --include "backup/*.zip" \
+          --stats-one-line \
+          ${TERMINAL_WIDTH} \
           ${REMOTENAME}${SYNCPATH_BACKUP}/ ${BACKUPFOLDER}/
         
         RESTORE_SYSTEM_STATUS=$?
@@ -179,7 +267,7 @@ restore_system_files() {
             log_message "System backup file restore completed with errors (status $RESTORE_SYSTEM_STATUS)" "true" "WARN"
         fi
         
-        log_message "System backup file restore from ${REMOTENAME}${SYNCPATH_BACKUP} complete!"
+        return $RESTORE_SYSTEM_STATUS
     else
         log_message "System backup file restore skipped (BACKUPFILE_RESTORE_OPTION is not set to 'yes')" "true"
         RESTORE_SYSTEM_STATUS=0
@@ -195,19 +283,22 @@ main() {
     load_config
     
     # Define locations for source and remote
+    # Note: This assumes at least one remote is configured and the first one should be used
     REMOTENAME=`rclone listremotes | head -1`
     
-    # Begin main script operations
+    # Begin main script operations with user-friendly header
     log_message "=> ${OS_NAME} CLOUD RESTORE UTILITY\n"
     
     # Execute Part 1: Game saves restore
+    # This performs the primary save file restoration operation using the configured method
     restore_game_saves
     RESTORE_STATUS=$?
     
-    # Add a pause for better visual separation
+    # Add a pause for better visual separation between operations
     sleep 2
     
     # Execute Part 2: System restore
+    # This restores system backup files (zip files) if enabled in configuration
     restore_system_files
     RESTORE_SYSTEM_STATUS=$?
     
@@ -221,8 +312,10 @@ main() {
     # Add a pause before summary
     sleep 2
     
-    # Provide final summary of all operations
+    # Add a line break for better visual separation
     echo
+    
+    # Provide final summary of all operations
     log_message "====================================" "true"
     log_message "RESTORE SUMMARY:" "true"
     log_message "Game saves restore: $([ $RESTORE_STATUS -eq 0 ] && echo 'SUCCESS' || echo 'COMPLETED WITH ERRORS')" "true"

--- a/packages/network/rclone/sources/cloud_sync-rules.txt.defaults
+++ b/packages/network/rclone/sources/cloud_sync-rules.txt.defaults
@@ -1,5 +1,12 @@
 # Cloud Sync Rules - Default Configuration
-# Rules use the same syntax as .gitignore
+#
+# These rules determine which files are included/excluded during cloud sync operations.
+# The syntax follows the same pattern as .gitignore, where:
+#   + pattern = explicitly include matching files/directories
+#   - pattern = explicitly exclude matching files/directories
+#
+# Rules are processed in order, with later rules overriding earlier ones.
+# Using /** matches files recursively through all subdirectories.
 
 # Start by explicitly including directories we want to fully backup
 + /savefiles/**

--- a/packages/network/rclone/sources/cloud_sync.conf
+++ b/packages/network/rclone/sources/cloud_sync.conf
@@ -1,28 +1,42 @@
+# Cloud Sync Configuration
+# This file defines paths and settings for cloud sync operations
+
+# Base Directory Paths
+# -------------------
 # Directory where Retroarch saves, savestates, and screenshots are located
 BACKUPPATH="/storage/roms"
 
 # Changing the below to be different from BACKUPPATH will prevent data from being replaced on restore
 RESTOREPATH="/storage/roms"
 
-# Directory on the remote where save data should be stored
-SYNCPATH="/GAMES"
-
 # Local path where backups are stored (defined in backuptool)
 BACKUPFOLDER="/storage/roms/backup"
+
+# Cloud Storage Paths
+# ------------------
+# Directory on the remote where save data should be stored
+SYNCPATH="/GAMES"
 
 # Remote path where backups are stored
 SYNCPATH_BACKUP="/GAMES/backup"
 
-# rclone sync rules
-RCLONEOPTS=" \
---progress \
+# Logging Options
+# --------------
+# Set the minimum level of messages to log (INFO, WARN, ERROR)
+LOG_LEVEL="INFO"
+
+# Transfer Settings
+# ---------------
+# rclone sync rules - modify these options to change transfer behavior
+# IMPORTANT: Each option must be preceded by a backslash (\) except the first one
+RCLONEOPTS="--progress \
 --log-file /var/log/cloud_sync.log \
 --filter-from /storage/.config/cloud_sync-rules.txt \
 --delete-excluded \
---verbose \
-"
+--verbose"
 
-# Backup options
+# Backup Options
+# -------------
 ## Backup method
 ### The default is "sync", which creates a 1:1 match between the local path and remote
 ### Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
@@ -33,7 +47,8 @@ BACKUPMETHOD="sync"
 ### Switching to "no" will exclude the system backup file from the backup
 BACKUPFILE_BACKUP_OPTION="yes"
 
-# Restore options
+# Restore Options
+# --------------
 ## Restore method
 ### The default is "copy", which will preserve any existing files and folders
 ### Switching to "sync" will replace all local files in the restore path with what is on the remote
@@ -44,5 +59,7 @@ RESTOREMETHOD="copy"
 ### Switching to "yes" will include the system backup file in the restore
 BACKUPFILE_RESTORE_OPTION="no"
 
+# Maintenance Options
+# -----------------
 # Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.
 RSYNCRMDIR="yes"

--- a/packages/network/rclone/sources/cloud_sync.conf.defaults
+++ b/packages/network/rclone/sources/cloud_sync.conf.defaults
@@ -1,25 +1,42 @@
+# Cloud Sync Default Configuration
+# This file defines the default values used when creating a new configuration
+
+# Base Directory Paths
+# -------------------
 # Directory where Retroarch saves, savestates, and screenshots are located
 DEFAULT_BACKUPPATH="/storage/roms"
 
 # Changing the below to be different from BACKUPPATH will prevent data from being replaced on restore
 DEFAULT_RESTOREPATH="/storage/roms"
 
-# Directory on the remote where save data should be stored
-DEFAULT_SYNCPATH="/GAMES"
-
 # Local path where backups are stored (defined in backuptool)
 DEFAULT_BACKUPFOLDER="/storage/roms/backup"
 
-# rclone sync rules
-DEFAULT_RCLONEOPTS=" \
---progress \
+# Cloud Storage Paths
+# ------------------
+# Directory on the remote where save data should be stored
+DEFAULT_SYNCPATH="/GAMES"
+
+# Remote path where backups are stored
+DEFAULT_SYNCPATH_BACKUP="/GAMES/backup"
+
+# Logging Options
+# --------------
+# Set the minimum level of messages to log (INFO, WARN, ERROR)
+DEFAULT_LOG_LEVEL="INFO"
+
+# Transfer Settings
+# ---------------
+# rclone sync rules - modify these options to change transfer behavior
+# IMPORTANT: Each option must be preceded by a backslash (\) except the first one
+DEFAULT_RCLONEOPTS="--progress \
 --log-file /var/log/cloud_sync.log \
 --filter-from /storage/.config/cloud_sync-rules.txt \
 --delete-excluded \
---verbose \
-"
+--verbose"
 
-# Backup options
+# Backup Options
+# -------------
 ## Backup method
 ### The default is "sync", which creates a 1:1 match between the local path and remote
 ### Switching to "copy" will overwrite newer files at the remote with the local version, but leave other files and folders in place
@@ -30,7 +47,8 @@ DEFAULT_BACKUPMETHOD="sync"
 ### Switching to "no" will exclude the system backup file from the backup
 DEFAULT_BACKUPFILE_BACKUP_OPTION="yes"
 
-# Restore options
+# Restore Options
+# --------------
 ## Restore method
 ### The default is "copy", which will preserve any existing files and folders
 ### Switching to "sync" will replace all local files in the restore path with what is on the remote
@@ -41,5 +59,7 @@ DEFAULT_RESTOREMETHOD="copy"
 ### Switching to "yes" will include the system backup file in the restore
 DEFAULT_BACKUPFILE_RESTORE_OPTION="no"
 
+# Maintenance Options
+# -----------------
 # Option to enable/disable removing orphaned empty directories on the remote that are also empty locally. Enabled by default. Comment out to disable.
 DEFAULT_RSYNCRMDIR="yes"

--- a/packages/network/rclone/sources/cloud_sync_helper
+++ b/packages/network/rclone/sources/cloud_sync_helper
@@ -1,0 +1,163 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
+#
+# Helper script to manage cloud sync rules and configuration
+# Called by both cloud_backup and cloud_restore scripts
+#
+# This script handles:
+# 1. Merging default rules with user customizations
+# 2. Updating configuration files while preserving user settings
+# 3. Ensuring all required parameters exist with sensible defaults
+#
+# Version: 1.0
+# Last updated: 2024
+
+# Logs messages to the specified log file
+log_to_file() {
+  local log_file="${1}"
+  local message="${2}"
+  local level="${3:-INFO}"
+  local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+  local script_name="cloud_sync_helper"
+  
+  echo "[${timestamp}] [${level}] [${script_name}] ${message}" >> ${log_file}
+}
+
+# Merges default rules with user-customized rules
+# 
+# This function preserves user customizations while adding new default rules.
+# It creates a backup of the user's current rules before modifying them,
+# then adds any default rules that are not present in the user's file.
+# 
+# Parameters:
+#   $1: Path to log file for operation messages
+# Returns:
+#   0 on success, 1 if default rules file not found
+update_cloud_sync_rules() {
+  local log_file="${1:-/var/log/cloud_sync.log}"
+  
+  log_to_file "${log_file}" "Checking cloud sync rules file..."
+  
+  # Check if user has a custom cloud_sync-rules.txt
+  if [ -f "/storage/.config/cloud_sync-rules.txt" ]; then
+    # Create a backup of the user's custom rules
+    cp -f /storage/.config/cloud_sync-rules.txt /storage/.config/cloud_sync-rules.txt.bak
+    
+    # Check if defaults file exists
+    if [ ! -f "/usr/config/cloud_sync-rules.txt.defaults" ]; then
+      log_to_file "${log_file}" "Default rules file not found" "WARN"
+      return 1
+    fi
+    
+    # Copy default rules to a temporary file
+    cp -f /usr/config/cloud_sync-rules.txt.defaults /tmp/cloud_sync-rules.new
+    
+    log_to_file "${log_file}" "Merging custom rules with defaults"
+    
+    # Check each user rule and preserve it
+    while IFS= read -r line; do
+      # Skip comment lines and empty lines for comparison
+      if [[ "$line" != \#* ]] && [[ -n "$line" ]]; then
+        # Check if the rule is already in the defaults
+        # The -e flag ensures grep treats the entire line as a fixed pattern,
+        # preventing misinterpretation of spaces and special characters in rules
+        if ! grep -Fxq -e "$line" /tmp/cloud_sync-rules.new; then
+          # If not in defaults, append it to preserve user customization
+          echo "$line" >> /tmp/cloud_sync-rules.new
+        fi
+      fi
+    done < /storage/.config/cloud_sync-rules.txt
+    
+    # Replace the user's file with the merged version
+    mv /tmp/cloud_sync-rules.new /storage/.config/cloud_sync-rules.txt
+    
+    log_to_file "${log_file}" "Updated cloud_sync-rules.txt with new defaults while preserving custom rules"
+  else
+    # No existing rules file, just copy the defaults
+    log_to_file "${log_file}" "No existing rules file, copying defaults"
+    cp -f /usr/config/cloud_sync-rules.txt.defaults /storage/.config/cloud_sync-rules.txt
+  fi
+  
+  return 0
+}
+
+# Updates user configuration file with new defaults while preserving customizations
+#
+# This function ensures user configs have all required parameters while 
+# preserving any customized values. It adds any missing parameters from
+# the defaults file but doesn't overwrite existing user settings.
+#
+# Parameters:
+#   $1: Path to log file for operation messages
+# Returns:
+#   0 on success, 1 if default config file not found
+update_cloud_sync_config() {
+  local log_file="${1:-/var/log/cloud_sync.log}"
+  
+  log_to_file "${log_file}" "Checking cloud sync configuration..."
+  
+  # Check if user has a config file
+  if [ -f "/storage/.config/cloud_sync.conf" ]; then
+    # Create a backup of the user's config
+    cp -f /storage/.config/cloud_sync.conf /storage/.config/cloud_sync.conf.bak
+    
+    # Check if defaults file exists
+    if [ ! -f "/usr/config/cloud_sync.conf.defaults" ]; then
+      log_to_file "${log_file}" "Default config file not found" "WARN"
+      return 1
+    fi
+    
+    log_to_file "${log_file}" "Updating configuration with new defaults"
+    
+    # Extract all configuration variables from defaults - FIXED VERSION
+    while IFS='=' read -r key value; do
+      # Only process DEFAULT_ variables
+      if [[ "$key" == DEFAULT_* ]]; then
+        # Strip the DEFAULT_ prefix
+        var_name="${key#DEFAULT_}"
+        
+        # Check if this variable exists in the user config - FIX the grep pattern to avoid space issues
+        if ! grep -qF "${var_name}=" /storage/.config/cloud_sync.conf; then
+          # Variable doesn't exist, add it with proper quoting
+          echo "${var_name}=${value}" >> /storage/.config/cloud_sync.conf
+          log_to_file "${log_file}" "Added new configuration option: ${var_name}"
+        fi
+      fi
+    done < /usr/config/cloud_sync.conf.defaults
+    
+    log_to_file "${log_file}" "Configuration file updated while preserving customizations"
+  else
+    # No existing config file, create one with defaults
+    log_to_file "${log_file}" "No existing config file, creating from template"
+    
+    # Create a basic user config from defaults
+    touch /storage/.config/cloud_sync.conf
+    
+    # Process each default variable
+    while IFS='=' read -r key value; do
+      if [[ "$key" == DEFAULT_* ]]; then
+        var_name="${key#DEFAULT_}"
+        echo "${var_name}=${value}" >> /storage/.config/cloud_sync.conf
+      fi
+    done < /usr/config/cloud_sync.conf.defaults
+  fi
+  
+  return 0
+}
+
+# Main function that handles all updates
+main() {
+  local log_file="${1:-/var/log/cloud_sync.log}"
+  
+  # Update both rules and config
+  update_cloud_sync_rules "${log_file}"
+  update_cloud_sync_config "${log_file}"
+  
+  return 0
+}
+
+# If script is called directly, run the main function
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/packages/network/rclone/sources/post-update
+++ b/packages/network/rclone/sources/post-update
@@ -1,0 +1,24 @@
+### Add cloud sync-related files if missing
+echo "Update cloud sync files..." >>${LOG}
+if [ -x "/usr/bin/cloud_sync_helper" ]; then
+  # Use the helper script to properly merge configurations
+  # This ensures user customizations are preserved while adding any new options
+  tocon "Updating cloud sync configuration..."
+  /usr/bin/cloud_sync_helper ${LOG}
+else
+  # Fall back to the simple copy method if the helper script is unavailable
+  # This is less sophisticated but ensures basic functionality
+  tocon "Updating cloud sync files..."
+  # Copy default cloud sync files only if they don't exist locally
+  for config_file in cloud_sync-rules.txt.defaults cloud_sync.conf.defaults; do
+    if [ -f "/usr/config/${config_file}" ]; then
+      rsync --ignore-existing /usr/config/${config_file} /storage/.config/
+    fi
+  done
+  # Always make sure the user has a configuration file
+  if [ -f "/usr/config/cloud_sync.conf" ]; then
+    rsync --ignore-existing /usr/config/cloud_sync.conf /storage/.config/
+    # Always update defaults file to ensure latest version is available for reference
+    rsync /usr/config/cloud_sync.conf.defaults /storage/.config/
+  fi
+fi

--- a/packages/network/rclone/sources/rclonectl
+++ b/packages/network/rclone/sources/rclonectl
@@ -1,15 +1,21 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
+#
+# rclonectl - Command line utility for managing rclone cloud mounts
+# This script provides a simple interface to mount/unmount cloud storage
 
+# Configuration path
 CONFIGPATH="/storage/.config"
 
+# Determine mount path: either from command line, config file, or default
 if [ -z "$2" ]
 then
   if [ -e "${CONFIGPATH}/rsync.conf" ]
   then
     source ${CONFIGPATH}/rsync.conf
   else
+    # Default values if no config found
     MOUNTPATH="/storage/cloud"
     SYNCPATH="GAMES"
   fi
@@ -17,6 +23,7 @@ else
   MOUNTPATH=${2}
 fi
 
+# Copy default configuration files if they don't exist
 for CONFIG in rsync.conf rsync-rules.conf 
 do
   if [ ! -e "${CONFIGPATH}/${CONFIG}" ]
@@ -25,6 +32,13 @@ do
   fi
 done
 
+# Verify rclone is configured and mount point exists
+# 
+# This function checks if:
+# 1. rclone has a valid configuration file
+# 2. The specified mount point directory exists (creates it if not)
+#
+# Exits with error code 1 if rclone is not configured
 function checkconfig() {
   if [ ! -e "${CONFIGPATH}/rclone/rclone.conf" ]
   then
@@ -37,23 +51,27 @@ function checkconfig() {
   fi
 }
 
+# Mount a cloud storage remote using rclone
+# Parameters: $1 - Mount point path
 function mount() {
   TARGET=$(rclone listremotes | awk '{printf $1; exit}')
   rclone mount ${TARGET} ${1} \
     --vfs-cache-mode writes \
     --vfs-cache-max-size 100M \
     --vfs-read-chunk-size-limit 128M \
-    --vfs-read-chunk-size-limit off \
     --allow-non-empty \
     --dir-cache-time 48h \
     --log-file /var/log/rclone.log \
     --daemon
 }
 
+# Unmount a previously mounted cloud storage
+# Parameters: $1 - Mount point path
 function unmount() {
   fusermount -u ${1}
 }
 
+# Command processing
 case "${1}" in
   "mount")
     checkconfig
@@ -63,6 +81,7 @@ case "${1}" in
     checkconfig
     unmount ${MOUNTPATH}
   ;;
+  # Show help message if command is unknown or no arguments were provided
   "$*")
     cat <<EOF
 rclonectl is a simple rclone wrapper for mounting and unmounting cloud volumes using fuse.

--- a/packages/network/rclone/sources/rsync-rules.conf
+++ b/packages/network/rclone/sources/rsync-rules.conf
@@ -1,15 +1,22 @@
-# This is a required rule for subdirectory matching.
+# RSYNC Rules Configuration
+# This file defines include/exclude patterns for rsync-based backup
+# Format: + pattern (include), - pattern (exclude)
+
+# Root directory matching rule (required for rsync)
+# Allows subdirectory traversal to match patterns in deeper directories
 + */
 
-### Do not include BIOS.
+### Do not include BIOS files (typically large and don't need backup)
 - bios/**
 
-### Retroarch saves
-+ *.sav
-+ *.srm
-+ *.auto
-+ *.state*
-+ *.dsv*
+### Include save files with these common extensions
+# Retroarch and emulator save formats
++ *.sav    # Common save format for many emulators
++ *.srm    # SNES/Genesis save format
++ *.auto   # Auto-save files
++ *.state* # Save state files (includes state1, state2, etc.)
++ *.dsv*   # Nintendo DS save format
 
-### This is a required rule to exclude all other file types.
+### Exclude everything else
+# This is required to exclude ROMs and other large files
 - *

--- a/packages/network/rclone/sources/rsync.conf
+++ b/packages/network/rclone/sources/rsync.conf
@@ -1,14 +1,23 @@
+# RSYNC Configuration
+# This file configures the legacy rsync-based backup system
+# Note: The newer rclone-based system is configured in cloud_sync.conf
+
 ### This is the path where your cloud volume is mounted.
+# Used by cloud backup/restore scripts to locate mounted cloud storage
 MOUNTPATH="/storage/cloud"
 
 ### This is the path to your game folder on your cloud drive.
+# Directory where games/saves will be synced on the cloud storage
 SYNCPATH="GAMES"
 
 ### This is the path we are backing up from.
+# Local source directory containing save files to back up
 BACKUPPATH="/storage/roms"
 
 ### This allows changes to the rsync options for cloud_backup
+# Options: -r (recursive), -a (archive), -i (itemize changes), -v (verbose)
 RSYNCOPTSBACKUP="-raiv --prune-empty-dirs"
 
 ### This allows changes to the rsync options for cloud_restore
+# Same core options but can be customized differently for restore operations
 RSYNCOPTSRESTORE="-raiv"

--- a/packages/rocknix/sources/post-update
+++ b/packages/rocknix/sources/post-update
@@ -62,9 +62,26 @@ rsync --ignore-existing /usr/config/rsync.conf /storage/.config/
 
 ### Add cloud sync-related files if missing
 echo "Update cloud sync files..." >>${LOG}
-rsync --ignore-existing /usr/config/cloud_sync-rules.txt /storage/.config/
-rsync --ignore-existing /usr/config/cloud_sync.conf /storage/.config/
-rsync --ignore-existing /usr/config/cloud_sync.conf.defaults /storage/.config/
+if [ -x "/usr/bin/cloud_sync_helper" ]; then
+  # Use the helper script to properly merge configurations
+  tocon "Updating cloud sync configuration..."
+  /usr/bin/cloud_sync_helper ${LOG}
+else
+  # Fall back to the simple copy if helper is not available
+  tocon "Updating cloud sync files..."
+  # Copy default cloud sync files if they don't exist
+  for config_file in cloud_sync-rules.txt.defaults cloud_sync.conf.defaults; do
+    if [ -f "/usr/config/${config_file}" ]; then
+      rsync --ignore-existing /usr/config/${config_file} /storage/.config/
+    fi
+  done
+  # Also copy the main config file if it doesn't exist
+  if [ -f "/usr/config/cloud_sync.conf" ]; then
+    rsync --ignore-existing /usr/config/cloud_sync.conf /storage/.config/
+    # Always update defaults file to ensure latest version
+    rsync /usr/config/cloud_sync.conf.defaults /storage/.config/
+  fi
+fi
 
 ### Sync locale data
 tocon "Re-sync locale data..."


### PR DESCRIPTION
I redid the rclone backup and restore scripts to make it work much better when a user is upgrading from a prior version of ROCKNIX. It will honor existing settings while ensuring the conf files have new variables and that the scripts are adjusted accordingly.

I also added a bunch of logging to help me troubleshoot.