### PR TITLE
preload /etc/profile

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/H700/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/H700/SUPPORTED_EMULATORS_AND_CORES.md
@@ -52,6 +52,7 @@ This document describes all available systems emulators and cores available for 
 |Microsoft|DOS (pc)|1981|`pc`|.com .bat .exe .dosz|**retroarch:** dosbox_pure<br>**retroarch:** dosbox_svn<br>|
 |Microsoft|MSX (msx)|1983|`msx`|.dsk .mx1 .mx2 .rom .zip .7z .m3u|**retroarch:** bluemsx (default)<br>**retroarch:** fmsx<br>|
 |Microsoft|MSX 2 (msx2)|1988|`msx2`|.dsk .mx1 .mx2 .rom .zip .7z .m3u|**retroarch:** bluemsx (default)<br>**retroarch:** fmsx<br>|
+|Microsoft|Windows (windows)|System|`windows`|.sh|**wine:** wine (default)<br>|
 |NEC|PC Engine (pcengine)|1987|`pcengine`|.pce .bin .zip .7z|**retroarch:** beetle_pce_fast (default)<br>**retroarch:** beetle_pce<br>**retroarch:** beetle_supergrafx<br>**mednafen:** pce<br>**mednafen:** pce_fast<br>|
 |NEC|PC Engine CD (pcenginecd)|1988|`pcenginecd`|.cue .ccd .chd .toc .m3u|**retroarch:** beetle_pce_fast (default)<br>**retroarch:** beetle_pce<br>**retroarch:** beetle_supergrafx<br>**mednafen:** pce<br>**mednafen:** pce_fast<br>|
 |NEC|PC-8800 (pc-8800)|1981|`pc88`|.d88 .u88 .m3u|**retroarch:** quasi88 (default)<br>|

--- a/packages/hardware/quirks/autostart/999-export
+++ b/packages/hardware/quirks/autostart/999-export
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/AYANEO AIR Plus/020-fan_control
+++ b/packages/hardware/quirks/devices/AYANEO AIR Plus/020-fan_control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/AYANEO AIR Plus/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYANEO AIR Plus/bin/ledcontrol
@@ -6,7 +6,8 @@
 # in large part to Maya Matuszczyk (https://github.com/Maccraft123)
 # for help with reverse engineering.
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 OUTB="/usr/bin/outb"
 

--- a/packages/hardware/quirks/devices/AYANEO AIR/020-fan_control
+++ b/packages/hardware/quirks/devices/AYANEO AIR/020-fan_control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/AYANEO AIR/bin/fancontrol
+++ b/packages/hardware/quirks/devices/AYANEO AIR/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 ### Enable logging
 case $(get_setting system.loglevel) in

--- a/packages/hardware/quirks/devices/AYANEO AIR/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYANEO AIR/bin/ledcontrol
@@ -37,7 +37,8 @@
 #   0xff - Close channel
 #
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 ECTOOL="/usr/sbin/ectool"
 DEBUG=false

--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/020-fan_control
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/020-fan_control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/bin/fancontrol
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 DEBUG=false
 COOLING_PROFILE=$(get_setting "cooling.profile")

--- a/packages/hardware/quirks/devices/AYANEO AYANEO 2S/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYANEO AYANEO 2S/bin/ledcontrol
@@ -37,7 +37,8 @@
 #   0xff - Close channel
 #
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 ECTOOL="/usr/sbin/ectool"
 DEBUG=false

--- a/packages/hardware/quirks/devices/AYN Odin 2/050-game-configs
+++ b/packages/hardware/quirks/devices/AYN Odin 2/050-game-configs
@@ -1,7 +1,6 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
-
-. /etc/profile
 
 #Set Supermodel resolution
 sed -i '/^XResolution =/c\XResolution = 1920' /storage/.config/supermodel/Config/Supermodel.ini

--- a/packages/hardware/quirks/devices/AYN Odin 2/bin/achievements
+++ b/packages/hardware/quirks/devices/AYN Odin 2/bin/achievements
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
  # Rainbow effect configuration
  STEPS=30            # Fewer steps for faster transitions

--- a/packages/hardware/quirks/devices/AYN Odin 2/bin/analog_sticks_ledcontrol
+++ b/packages/hardware/quirks/devices/AYN Odin 2/bin/analog_sticks_ledcontrol
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/devices/AYN Odin 2/bin/battery_led_status
+++ b/packages/hardware/quirks/devices/AYN Odin 2/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
@@ -6,7 +6,8 @@
 # Simple script to watch the battery capacity and
 # turn the power LED orange when it reaches 30%, red at 20%, and blinking red at 10%
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 LED_PATH="/sys/class/leds"
 

--- a/packages/hardware/quirks/devices/AYN Odin 2/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYN Odin 2/bin/ledcontrol
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 LED_PATH="/sys/class/leds"
 

--- a/packages/hardware/quirks/devices/AYN Odin2 Portal/050-game-configs
+++ b/packages/hardware/quirks/devices/AYN Odin2 Portal/050-game-configs
@@ -1,7 +1,6 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
-
-. /etc/profile
 
 #Set Supermodel resolution
 sed -i '/^XResolution =/c\XResolution = 1920' /storage/.config/supermodel/Config/Supermodel.ini

--- a/packages/hardware/quirks/devices/AYN Odin2 Portal/bin/battery_led_status
+++ b/packages/hardware/quirks/devices/AYN Odin2 Portal/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
@@ -6,7 +6,8 @@
 # Simple script to watch the battery capacity and
 # turn the power LED orange when it reaches 30%, red at 20%, and blinking red at 10%
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 function bat_led_off() {
   x=1

--- a/packages/hardware/quirks/devices/AYN Odin2 Portal/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/AYN Odin2 Portal/bin/ledcontrol
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 function led_off() {
   x=1

--- a/packages/hardware/quirks/devices/Anbernic RG ARC-D/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG ARC-D/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/devices/Anbernic RG ARC-D/050-game-configs
+++ b/packages/hardware/quirks/devices/Anbernic RG ARC-D/050-game-configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Set mupen64-plus-sa config for R33S
 if [ ! -d "/storage/.config/mupen64plus" ]; then
     mkdir -p "/storage/.config/mupen64plus/"

--- a/packages/hardware/quirks/devices/Anbernic RG ARC-S/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG ARC-S/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Anbernic RG CubeXX/bin/achievements
+++ b/packages/hardware/quirks/devices/Anbernic RG CubeXX/bin/achievements
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
  # Rainbow effect configuration
  STEPS=30            # Fewer steps for faster transitions

--- a/packages/hardware/quirks/devices/Anbernic RG351M/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG351M/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Anbernic RG351M/050-game_configs
+++ b/packages/hardware/quirks/devices/Anbernic RG351M/050-game_configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Set up gzdoom
 if [ ! -d "/storage/.config/gzdoom/" ]; then
   cp -rf /usr/config/gzdoom /storage/.config/

--- a/packages/hardware/quirks/devices/Anbernic RG351M/075-dpad-volbright
+++ b/packages/hardware/quirks/devices/Anbernic RG351M/075-dpad-volbright
@@ -1,7 +1,10 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-. /etc/profile
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
 DPAD_EVENTS=$(get_setting key.dpad.events)
 if [ -z "${DPAD_EVENTS}" ]
 then

--- a/packages/hardware/quirks/devices/Anbernic RG351V/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG351V/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Anbernic RG351V/004-game-configs
+++ b/packages/hardware/quirks/devices/Anbernic RG351V/004-game-configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Set up gzdoom
 if [ ! -d "/storage/.config/gzdoom/" ]; then
   cp -rf /usr/config/gzdoom /storage/.config/

--- a/packages/hardware/quirks/devices/Anbernic RG351V/075-dpad-volbright
+++ b/packages/hardware/quirks/devices/Anbernic RG351V/075-dpad-volbright
@@ -1,7 +1,10 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-. /etc/profile
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
 DPAD_EVENTS=$(get_setting key.dpad.events)
 if [ -z "${DPAD_EVENTS}" ]
 then

--- a/packages/hardware/quirks/devices/Anbernic RG353P/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG353P/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/devices/Anbernic RG353P/040-display
+++ b/packages/hardware/quirks/devices/Anbernic RG353P/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Anbernic RG353PS/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG353PS/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/devices/Anbernic RG353PS/040-display
+++ b/packages/hardware/quirks/devices/Anbernic RG353PS/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Anbernic RG353V/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG353V/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Anbernic RG353V/040-display
+++ b/packages/hardware/quirks/devices/Anbernic RG353V/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Anbernic RG353VS/001-device_config
+++ b/packages/hardware/quirks/devices/Anbernic RG353VS/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Anbernic RG353VS/040-display
+++ b/packages/hardware/quirks/devices/Anbernic RG353VS/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Anbernic RG40XX V/bin/analog_sticks_ledcontrol
+++ b/packages/hardware/quirks/devices/Anbernic RG40XX V/bin/analog_sticks_ledcontrol
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/devices/Anbernic RG503/040-display
+++ b/packages/hardware/quirks/devices/Anbernic RG503/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Anbernic RG552/050-game-configs
+++ b/packages/hardware/quirks/devices/Anbernic RG552/050-game-configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Remap joypad name to rg552_joypad
 sed -i '/^mapping_name = retrogame_joypad/c\mapping_name = rg552_joypad' /storage/.config/flycast/mappings/SDL_retrogame_joypad.cfg
 sed -i '/retrogame_joypad/c\[rg552_joypad]' /storage/.config/mupen64plus/custominput.ini

--- a/packages/hardware/quirks/devices/Anbernic RG552/bin/fancontrol
+++ b/packages/hardware/quirks/devices/Anbernic RG552/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 DEBUG=false
 COOLING_PROFILE=$(get_setting "cooling.profile")

--- a/packages/hardware/quirks/devices/Game Console R33S/001-device_config
+++ b/packages/hardware/quirks/devices/Game Console R33S/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Game Console R33S/002-disable-led
+++ b/packages/hardware/quirks/devices/Game Console R33S/002-disable-led
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 # Set export GPIO for Power LED
 if [ ! -d "/sys/class/gpio/gpio${DEVICE_PWR_LED_GPIO}" ]; then

--- a/packages/hardware/quirks/devices/Game Console R33S/050-game-configs
+++ b/packages/hardware/quirks/devices/Game Console R33S/050-game-configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Set mupen64-plus-sa config for R33S
 if [ ! -d "/storage/.config/mupen64plus" ]; then
     mkdir -p "/storage/.config/mupen64plus/"

--- a/packages/hardware/quirks/devices/Game Console R33S/075-dpad-volbright
+++ b/packages/hardware/quirks/devices/Game Console R33S/075-dpad-volbright
@@ -1,7 +1,10 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-. /etc/profile
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
 DPAD_EVENTS=$(get_setting key.dpad.events)
 if [ -z "${DPAD_EVENTS}" ]
 then

--- a/packages/hardware/quirks/devices/Game Console R36S/001-device_config
+++ b/packages/hardware/quirks/devices/Game Console R36S/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Game Console R36S/002-disable-led
+++ b/packages/hardware/quirks/devices/Game Console R36S/002-disable-led
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 # Set export GPIO for Power LED
 if [ ! -d "/sys/class/gpio/gpio${DEVICE_PWR_LED_GPIO}" ]; then

--- a/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
+++ b/packages/hardware/quirks/devices/Game Console R36S/050-game-configs
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for R36S, can use same profile as OGS
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/GameForce ACE/bin/fancontrol
+++ b/packages/hardware/quirks/devices/GameForce ACE/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 ### Enable logging
 case $(get_setting system.loglevel) in

--- a/packages/hardware/quirks/devices/Gameforce CHI/001-device_config
+++ b/packages/hardware/quirks/devices/Gameforce CHI/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Gameforce CHI/002-start-input
+++ b/packages/hardware/quirks/devices/Gameforce CHI/002-start-input
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Gameforce CHI/050-game_configs
+++ b/packages/hardware/quirks/devices/Gameforce CHI/050-game_configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Set up gzdoom
 if [ ! -d "/storage/.config/gzdoom/" ]; then
   cp -rf /usr/config/gzdoom /storage/.config/

--- a/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/001-device_config
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/002-turbo-mode_config
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/002-turbo-mode_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/050-game_configs
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/050-game_configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Set up gzdoom
 if [ ! -d "/storage/.config/gzdoom/" ]; then
   cp -rf /usr/config/gzdoom /storage/.config/

--- a/packages/hardware/quirks/devices/Hardkernel ODROID-N2/002-turbo-mode_config
+++ b/packages/hardware/quirks/devices/Hardkernel ODROID-N2/002-turbo-mode_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/MagicX XU Mini M/001-device_config
+++ b/packages/hardware/quirks/devices/MagicX XU Mini M/001-device_config
@@ -1,5 +1,5 @@
 
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/devices/MagicX XU Mini M/004-game-configs
+++ b/packages/hardware/quirks/devices/MagicX XU Mini M/004-game-configs
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for XU Mini M
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/MagicX XU Mini M/bin/battery_led_status
+++ b/packages/hardware/quirks/devices/MagicX XU Mini M/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
@@ -9,8 +9,6 @@
 # 21+% blue
 # charging purple
 # fully charged white
-
-. /etc/profile
 
 function set_led() {
   case $1 in

--- a/packages/hardware/quirks/devices/MagicX XU10/001-device_config
+++ b/packages/hardware/quirks/devices/MagicX XU10/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/MagicX XU10/004-game-configs
+++ b/packages/hardware/quirks/devices/MagicX XU10/004-game-configs
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for XU10
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/MagicX XU10/bin/battery_led_status
+++ b/packages/hardware/quirks/devices/MagicX XU10/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2020-present Fewtarius
@@ -10,8 +10,6 @@
 # 21+% blue
 # charging purple
 # fully charged white
-
-. /etc/profile
 
 function set_led() {
   case $1 in

--- a/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/001-device_config
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance Black Edition/050-game_configs
@@ -1,7 +1,6 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for OGA
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/ODROID-GO Advance/001-device_config
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/ODROID-GO Advance/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Advance/050-game_configs
@@ -1,7 +1,6 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for OGA
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/ODROID-GO Super/001-device_config
+++ b/packages/hardware/quirks/devices/ODROID-GO Super/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/ODROID-GO Super/050-game_configs
+++ b/packages/hardware/quirks/devices/ODROID-GO Super/050-game_configs
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for OGS
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3 Pro/050-game_configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3 Pro/050-game_configs
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
-
 #Set up gzdoom
 if [ ! -d "/storage/.config/gzdoom/" ]; then
   cp -rf /usr/config/gzdoom /storage/.config/

--- a/packages/hardware/quirks/devices/Powkiddy RGB10 Max 3/040-display
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10 Max 3/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Powkiddy RGB10/075-dpad-volbright
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10/075-dpad-volbright
@@ -1,7 +1,10 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-. /etc/profile
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
 DPAD_EVENTS=$(get_setting key.dpad.events)
 if [ -z "${DPAD_EVENTS}" ]
 then

--- a/packages/hardware/quirks/devices/Powkiddy RGB10X/001-device_config
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10X/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/devices/Powkiddy RGB10X/050-game_configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10X/050-game_configs
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for OGA
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/Powkiddy RGB10X/bin/battery_led_status
+++ b/packages/hardware/quirks/devices/Powkiddy RGB10X/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
@@ -9,8 +9,6 @@
 # 21+% green
 # charging red
 # 95+% charging green
-
-. /etc/profile
 
 function set_led() {
   case $1 in

--- a/packages/hardware/quirks/devices/Powkiddy RGB20 Pro/bin/battery_led_status
+++ b/packages/hardware/quirks/devices/Powkiddy RGB20 Pro/bin/battery_led_status
@@ -10,8 +10,6 @@
 # <95% charging green+red
 # 95+% charging green
 
-. /etc/profile
-
 function set_led() {
   case $1 in
     green)

--- a/packages/hardware/quirks/devices/Powkiddy RGB20S/001-device_config
+++ b/packages/hardware/quirks/devices/Powkiddy RGB20S/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Powkiddy RGB20S/002-disable-led
+++ b/packages/hardware/quirks/devices/Powkiddy RGB20S/002-disable-led
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 # Set export GPIO for Power LED
 if [ ! -d "/sys/class/gpio/gpio${DEVICE_PWR_LED_GPIO}" ]; then

--- a/packages/hardware/quirks/devices/Powkiddy RGB20S/050-game-configs
+++ b/packages/hardware/quirks/devices/Powkiddy RGB20S/050-game-configs
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 #Set mupen64-plus-sa config for RGB20S, can use same profile as OGS
 if [ ! -d "/storage/.config/mupen64plus" ]; then

--- a/packages/hardware/quirks/devices/Powkiddy RGB20SX/040-display
+++ b/packages/hardware/quirks/devices/Powkiddy RGB20SX/040-display
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Powkiddy RGB30/040-display
+++ b/packages/hardware/quirks/devices/Powkiddy RGB30/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Powkiddy RK2023/040-display
+++ b/packages/hardware/quirks/devices/Powkiddy RK2023/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Powkiddy x55/001-device_config
+++ b/packages/hardware/quirks/devices/Powkiddy x55/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/Powkiddy x55/040-display
+++ b/packages/hardware/quirks/devices/Powkiddy x55/040-display
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Configure default contrast saturation and hue values
 for PROPERTY in brightness contrast saturation hue

--- a/packages/hardware/quirks/devices/Powkiddy x55/040-hdmi
+++ b/packages/hardware/quirks/devices/Powkiddy x55/040-hdmi
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-
-. /etc/profile
 
 hdmi_con() {
   if [ -f "/sys/class/extcon/hdmi/state" ]

--- a/packages/hardware/quirks/devices/RetrOLED CM5/030-modifiers
+++ b/packages/hardware/quirks/devices/RetrOLED CM5/030-modifiers
@@ -1,3 +1,4 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/devices/Retroid Pocket 5/050-game-configs
+++ b/packages/hardware/quirks/devices/Retroid Pocket 5/050-game-configs
@@ -1,7 +1,6 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
-
-. /etc/profile
 
 #Set Supermodel resolution for the mini
 sed -i '/^XResolution =/c\XResolution = 1920' /storage/.config/supermodel/Config/Supermodel.ini

--- a/packages/hardware/quirks/devices/Retroid Pocket Mini/050-game-configs
+++ b/packages/hardware/quirks/devices/Retroid Pocket Mini/050-game-configs
@@ -1,7 +1,6 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
-
-. /etc/profile
 
 #Set Supermodel resolution for the mini
 sed -i '/^XResolution =/c\XResolution = 1280' /storage/.config/supermodel/Config/Supermodel.ini

--- a/packages/hardware/quirks/devices/ayn Loki Max/020-fan_control
+++ b/packages/hardware/quirks/devices/ayn Loki Max/020-fan_control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/ayn Loki Max/bin/fancontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Max/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 ### Enable logging
 case $(get_setting system.loglevel) in

--- a/packages/hardware/quirks/devices/ayn Loki Max/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Max/bin/ledcontrol
@@ -16,7 +16,8 @@
 # 0xB2 - Blue
 #
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 RGB_RED="0xB0"
 RGB_GREEN="0xB1"

--- a/packages/hardware/quirks/devices/ayn Loki Zero/020-fan_control
+++ b/packages/hardware/quirks/devices/ayn Loki Zero/020-fan_control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/devices/ayn Loki Zero/bin/fancontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Zero/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 DEBUG=false
 COOLING_PROFILE=$(get_setting "cooling.profile")

--- a/packages/hardware/quirks/devices/ayn Loki Zero/bin/ledcontrol
+++ b/packages/hardware/quirks/devices/ayn Loki Zero/bin/ledcontrol
@@ -16,7 +16,8 @@
 # 0xB2 - Blue
 #
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 RGB_RED="0xB0"
 RGB_GREEN="0xB1"

--- a/packages/hardware/quirks/platforms/H700/001-device_config
+++ b/packages/hardware/quirks/platforms/H700/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/platforms/H700/002-turbo-mode_config
+++ b/packages/hardware/quirks/platforms/H700/002-turbo-mode_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/platforms/H700/400-set_gpu_overclock
+++ b/packages/hardware/quirks/platforms/H700/400-set_gpu_overclock
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Get GPU overclock state
 GPU_OC_STATE=$(get_setting "enable.gpu-overclock")

--- a/packages/hardware/quirks/platforms/H700/bin/analog_sticks_ledcontrol
+++ b/packages/hardware/quirks/platforms/H700/bin/analog_sticks_ledcontrol
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/platforms/H700/bin/gpu_overclock
+++ b/packages/hardware/quirks/platforms/H700/bin/gpu_overclock
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Set max gpu freq
 case $1 in

--- a/packages/hardware/quirks/platforms/H700/bin/ledcontrol
+++ b/packages/hardware/quirks/platforms/H700/bin/ledcontrol
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 LED_PATH="/sys/class/leds"
 

--- a/packages/hardware/quirks/platforms/RK3326/002-turbo-mode_config
+++ b/packages/hardware/quirks/platforms/RK3326/002-turbo-mode_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/platforms/RK3326/bin/battery_led_status
+++ b/packages/hardware/quirks/platforms/RK3326/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
@@ -6,7 +6,8 @@
 # Simple script to watch the battery capacity and
 # turn the power LED orange when it reaches 30%, red at 20%, and blinking red & orange at 10%
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 function set_led() {
   case $1 in

--- a/packages/hardware/quirks/platforms/RK3399/002-turbo-mode_config
+++ b/packages/hardware/quirks/platforms/RK3399/002-turbo-mode_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/platforms/RK3399/bin/battery_led_status
+++ b/packages/hardware/quirks/platforms/RK3399/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
@@ -6,7 +6,8 @@
 # Simple script to watch the battery capacity and
 # turn the power LED orange when it reaches 30%, red at 20%, and blinking red at 10%
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 function set_led() {
   case $1 in

--- a/packages/hardware/quirks/platforms/RK3566/001-device_config
+++ b/packages/hardware/quirks/platforms/RK3566/001-device_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2021-present Fewtarius (https://github.com/fewtarius)
 

--- a/packages/hardware/quirks/platforms/RK3566/002-turbo-mode_config
+++ b/packages/hardware/quirks/platforms/RK3566/002-turbo-mode_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/platforms/RK3566/bin/ledcontrol
+++ b/packages/hardware/quirks/platforms/RK3566/bin/ledcontrol
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 LED_PATH="/sys/class/leds"
 LED_STATUS=$(get_setting led.color)

--- a/packages/hardware/quirks/platforms/RK3588/041-panfrost
+++ b/packages/hardware/quirks/platforms/RK3588/041-panfrost
@@ -1,7 +1,6 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
-
-
 
 cat <<EOF >/storage/.config/profile.d/041-panfrost
 export PAN_MESA_DEBUG=gofaster

--- a/packages/hardware/quirks/platforms/RK3588/bin/ledcontrol
+++ b/packages/hardware/quirks/platforms/RK3588/bin/ledcontrol
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 LED_PATH="/sys/class/leds"
 LED_STATUS=$(get_setting led.color)

--- a/packages/hardware/quirks/platforms/S922X/041-panfrost
+++ b/packages/hardware/quirks/platforms/S922X/041-panfrost
@@ -1,3 +1,4 @@
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/hardware/quirks/platforms/S922X/bin/battery_led_status
+++ b/packages/hardware/quirks/platforms/S922X/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
@@ -6,7 +6,8 @@
 # Simple script to watch the battery capacity and
 # turn the power LED orange when it reaches 20% and blinking green & orange at 10%
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 function set_led() {
   case $1 in

--- a/packages/hardware/quirks/platforms/SM8250/003-set_boot_device
+++ b/packages/hardware/quirks/platforms/SM8250/003-set_boot_device
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 

--- a/packages/hardware/quirks/platforms/SM8250/061-yabasanshiro_config
+++ b/packages/hardware/quirks/platforms/SM8250/061-yabasanshiro_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/platforms/SM8250/400-set_gpu_overclock
+++ b/packages/hardware/quirks/platforms/SM8250/400-set_gpu_overclock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/platforms/SM8250/500-enable-led
+++ b/packages/hardware/quirks/platforms/SM8250/500-enable-led
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/platforms/SM8250/bin/analog_sticks_ledcontrol
+++ b/packages/hardware/quirks/platforms/SM8250/bin/analog_sticks_ledcontrol
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/platforms/SM8250/bin/battery_led_status
+++ b/packages/hardware/quirks/platforms/SM8250/bin/battery_led_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
@@ -6,7 +6,8 @@
 # Simple script to watch the battery capacity and
 # turn the power LED orange when it reaches 30%, red at 20%, and blinking red at 10%
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 LED_PATH="/sys/devices/platform/"
 

--- a/packages/hardware/quirks/platforms/SM8250/bin/fancontrol
+++ b/packages/hardware/quirks/platforms/SM8250/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 DEBUG=false
 COOLING_PROFILE=$(get_setting "cooling.profile")

--- a/packages/hardware/quirks/platforms/SM8250/bin/gpu_overclock
+++ b/packages/hardware/quirks/platforms/SM8250/bin/gpu_overclock
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Set max gpu freq
 case $1 in

--- a/packages/hardware/quirks/platforms/SM8250/bin/ledcontrol
+++ b/packages/hardware/quirks/platforms/SM8250/bin/ledcontrol
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 LED_PATH="/sys/devices/platform/"
 

--- a/packages/hardware/quirks/platforms/SM8550/061-yabasanshiro_config
+++ b/packages/hardware/quirks/platforms/SM8550/061-yabasanshiro_config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)

--- a/packages/hardware/quirks/platforms/SM8550/500-enable-led
+++ b/packages/hardware/quirks/platforms/SM8550/500-enable-led
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 # Get Internal LED State
 LED_STATE=$(get_setting "led.color")

--- a/packages/hardware/quirks/platforms/SM8550/bin/fancontrol
+++ b/packages/hardware/quirks/platforms/SM8550/bin/fancontrol
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 DEBUG=false
 COOLING_PROFILE=$(get_setting "cooling.profile")

--- a/packages/hardware/quirks/profile.d/999-export
+++ b/packages/hardware/quirks/profile.d/999-export
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 

--- a/packages/rocknix/autostart/001-setup
+++ b/packages/rocknix/autostart/001-setup
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 if [ -d "/storage/cache/.cores" ]
 then

--- a/packages/rocknix/autostart/050-audio
+++ b/packages/rocknix/autostart/050-audio
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-. /etc/profile
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
 
 tocon "Configuring Audio..."
 

--- a/packages/sysutils/autostart/system.d/rocknix-autostart.service
+++ b/packages/sysutils/autostart/system.d/rocknix-autostart.service
@@ -6,7 +6,8 @@ After=network-base.service graphical.target userconfig.service
 [Service]
 Type=oneshot
 Environment=HOME=/storage
-ExecStart=-/bin/sh -c ". /etc/profile; exec /bin/sh /usr/bin/autostart"
+EnvironmentFile=/etc/profile
+ExecStart=/usr/bin/autostart
 RemainAfterExit=yes
 
 [Install]

--- a/packages/sysutils/system-utils/sources/scripts/analog_sticks_ledcontrol
+++ b/packages/sysutils/system-utils/sources/scripts/analog_sticks_ledcontrol
@@ -7,10 +7,6 @@
 ### so we don't need to have multiple variants in /usr/bin.
 ###
 
-if [ -z "${QUIRK_DEVICE}" ] || [ -z "${HW_DEVICE}" ]; then
-  . /etc/profile
-fi
-
 if [ -f "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/analog_sticks_ledcontrol" ]; then
   exec "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/analog_sticks_ledcontrol" $*
 elif [ -f "/usr/lib/autostart/quirks/platforms/${HW_DEVICE}/bin/analog_sticks_ledcontrol" ]; then

--- a/packages/sysutils/system-utils/sources/scripts/battery_led_status
+++ b/packages/sysutils/system-utils/sources/scripts/battery_led_status
@@ -7,10 +7,6 @@
 ### so we don't need to have multiple variants in /usr/bin.
 ###
 
-if [ -z "${QUIRK_DEVICE}" ] || [ -z "${HW_DEVICE}" ]; then
-  . /etc/profile
-fi
-
 if [ -f "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/battery_led_status" ]; then
   exec "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/battery_led_status" $*
 elif [ -f "/usr/lib/autostart/quirks/platforms/${HW_DEVICE}/bin/battery_led_status" ]; then

--- a/packages/sysutils/system-utils/sources/scripts/fancontrol
+++ b/packages/sysutils/system-utils/sources/scripts/fancontrol
@@ -7,10 +7,6 @@
 ### so we don't need to have multiple variants in /usr/bin.
 ###
 
-if [ -z "${QUIRK_DEVICE}" ] || [ -z "${HW_DEVICE}" ]; then
-  . /etc/profile
-fi
-
 if [ -f "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/fancontrol" ]; then
   exec "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/fancontrol" $*
 elif [ -f "/usr/lib/autostart/quirks/platforms/${HW_DEVICE}/bin/fancontrol" ]; then

--- a/packages/sysutils/system-utils/sources/scripts/hdmi_sense
+++ b/packages/sysutils/system-utils/sources/scripts/hdmi_sense
@@ -3,9 +3,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-# Source predefined functions and variables
-. /etc/profile
-
 for HDMI in /sys/class/drm/card*/card*-HDMI-A-[0-9]/status
 do
   HDMI_STATE=$(<${HDMI})

--- a/packages/sysutils/system-utils/sources/scripts/headphone_sense
+++ b/packages/sysutils/system-utils/sources/scripts/headphone_sense
@@ -4,9 +4,6 @@
 # Copyright (C) 2020-present Shanti Gilbert (https://github.com/shantigilbert)
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
-# Source predefined functions and variables
-. /etc/profile
-
 # Switch to headphones if we have them already connected at boot
 GPIO=$(cat /sys/class/gpio/gpio${DEVICE_JACK}/value)
 [[ "$GPIO" == "0" ]] && set_setting "audio.device" "headphone" || set_setting "audio.device" "speakers"

--- a/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -8,8 +8,6 @@
 # set -e
 set -o pipefail
 
-. /etc/profile
-
 ### Summary
 #   This script listens to input events and takes actions.
 ###

--- a/packages/sysutils/system-utils/sources/scripts/ledcontrol
+++ b/packages/sysutils/system-utils/sources/scripts/ledcontrol
@@ -7,10 +7,6 @@
 ### so we don't need to have multiple variants in /usr/bin.
 ###
 
-if [ -z "${QUIRK_DEVICE}" ] || [ -z "${HW_DEVICE}" ]; then
-  . /etc/profile
-fi
-
 if [ -f "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/ledcontrol" ]; then
   exec "/usr/lib/autostart/quirks/devices/${QUIRK_DEVICE}/bin/ledcontrol" $*
 elif [ -f "/usr/lib/autostart/quirks/platforms/${HW_DEVICE}/bin/ledcontrol" ]; then

--- a/packages/ui/emulationstation/system.d/emustation.service
+++ b/packages/ui/emulationstation/system.d/emustation.service
@@ -7,6 +7,7 @@ After=rocknix-automount.service
 Environment=XDG_RUNTIME_DIR=/var/run/0-runtime-dir
 Environment=HOME=/storage
 Environment=SDL_AUDIODRIVER=pulseaudio
+EnvironmentFile=/etc/profile
 ExecStartPre=/usr/bin/es_settings
 ExecStart=/usr/bin/emulationstation --log-path /var/log --no-splash
 KillMode=process

--- a/packages/ui/emulationstation/system.d/essway.service
+++ b/packages/ui/emulationstation/system.d/essway.service
@@ -6,8 +6,9 @@ Requires=sway.service
 After=sway.service
 
 [Service]
-Environment=HOME=/storage
 Type=simple
+Environment=HOME=/storage
+EnvironmentFile=/etc/profile
 ExecStart=/usr/bin/start_es.sh
 WorkingDirectory=/storage
 Restart=always


### PR DESCRIPTION
- load /etc/profile in emustation.service and rocknix-autostart.service
- remove explicit loading of /etc/profile in autostart scripts