### PR TITLE
Odin 2 Portal: fix touchscreen orientation

### DIFF
--- a/projects/Qualcomm/patches/linux/SM8550/0050_arm64--dts--qcom--Add-AYN-Odin2Portal.patch
+++ b/projects/Qualcomm/patches/linux/SM8550/0050_arm64--dts--qcom--Add-AYN-Odin2Portal.patch
@@ -153,6 +153,9 @@ index 000000000000..f04c275966e4
 +
 +		touchscreen-size-x = <1080>;
 +		touchscreen-size-y = <1920>;
++
++		touchscreen-inverted-y;
++		touchscreen-swapped-x-y;
 +	};
 +};
 +


### PR DESCRIPTION
The screen is at a 270 degree rotation, this fixes the touch input to match.