### PR TITLE
ports / windows / moonlight - controller layout

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/SM8550/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/SM8550/SUPPORTED_EMULATORS_AND_CORES.md
@@ -7,7 +7,7 @@ This document describes all available systems emulators and cores available for 
 |Manufacturer|System|Release Date|Games Path|Supported Extensions|Emulator / Core|
 |----|----|----|----|----|----|
 |&#xf013; System|Media Player (mplayer)|System|`mplayer`|.mp4 .mkv .avi .mov .wmv .m3u .mpg .ytb .twi .sh .mp3 .aac .mka .dts .flac .ogg .m4a .ac3 .opus .wav .wv .eac33 .thd|**mplayer:** mplayer (default)<br>|
-|&#xf013; System|Moonlight Game Streaming (moonlight)|System|`moonlight`|.sh||
+|&#xf013; System|Moonlight Game Streaming (moonlight)|System|`moonlight`|.sh|**moonlight:** moonlight (default)<br>|
 |&#xf013; System|Music Player (music)|System|`playlists`|.m3u .sh|**gmu:** gmu (default)<br>|
 |&#xf013; System|Ports (ports)|System|`ports`|.sh|**portmaster:** portmaster (default)<br>|
 |&#xf013; System|Screenshots (imageviewer)|System|`screenshots`|.jpg .jpeg .png .bmp .psd .tga .gif .hdr .pic .ppm .pgm .mkv .pdf .mp4 .avi||

--- a/packages/apps/portmaster/package.mk
+++ b/packages/apps/portmaster/package.mk
@@ -28,14 +28,4 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/compat
   curl -Lo ${PKG_BUILD}/compat.zip ${COMPAT_URL}
   unzip -qq ${PKG_BUILD}/compat.zip -d ${INSTALL}/usr/lib/compat/
-
-  case ${DEVICE} in
-    SM8250|SM8550|H700)
-      GUIDEBUTTON='"hotkeyenable")     TR_NAME="guide";;'
-      sed -e "s/@GUIDEBUTTON@/${GUIDEBUTTON}/g" -i ${INSTALL}/usr/config/PortMaster/mapper.txt
-    ;;
-    *)
-      sed -i "/@GUIDEBUTTON@/d" ${INSTALL}/usr/config/PortMaster/mapper.txt 
-    ;;
-  esac
 }

--- a/packages/apps/portmaster/sources/control.txt
+++ b/packages/apps/portmaster/sources/control.txt
@@ -90,28 +90,6 @@ get_controls() {
 
     param_device="${profile}"
 
-    # Clean up any former .port_input files
-    rm -rf /tmp/port_input
-    rm -rf /tmp/es_input.cfg
-
-    # Dump connected device GUIDs
-    /usr/bin/list-guid > /tmp/list-guid
-
-    # Loop through connected device and extract ES xml mapping
-    mkdir /tmp/port_input
-    while read DGUID; do
-      if [ ! -z "$(cat /storage/.config/emulationstation/es_input.cfg | grep ${DGUID})" ]; then
-        cp -r /storage/.config/emulationstation/es_input.cfg /tmp/port_input/${DGUID}.xml
-        xmlstarlet ed --inplace -d  "inputList/inputConfig[@deviceGUID!='${DGUID}']" /tmp/port_input/${DGUID}.xml
-      fi
-    done </tmp/list-guid
-
-    # Combine mappings for each device
-    sed -i '/inputList/d' /tmp/port_input/*.xml
-    echo '<inputList>' > /tmp/es_input.cfg
-    grep -vh '</\?inputConfig>>\|<?xml' /tmp/port_input/*.xml >> /tmp/es_input.cfg
-    echo '</inputList>' >> /tmp/es_input.cfg
-
     # Set file
     export SDL_GAMECONTROLLERCONFIG_FILE="/tmp/gamecontrollerdb.txt"
 

--- a/packages/apps/portmaster/sources/mapper.txt
+++ b/packages/apps/portmaster/sources/mapper.txt
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-. /etc/profile
+. /etc/profile.d/001-functions
+. /etc/profile.d/100-gamecontroller-functions
 
 # -- Config & Setup --
 # Destination file
@@ -20,8 +21,10 @@ ES_CONFIG="/tmp/es_input.cfg"
 
 #Set layout via Emulation Station
 ACTIVE_GAME=""
+ACTIVE_PLATFORM=""
 GAME="${ACTIVE_GAME##*/}"
-CONTROLLER_LAYOUT=$(get_setting port_controller_layout ports "${GAME}")
+PLATFORM="${ACTIVE_PLATFORM##*/}"
+CONTROLLER_LAYOUT=$(get_setting controller_layout "${PLATFORM}" "${GAME}")
 
 #Default to nintendo if no value assigned
 if [ ! -n "${CONTROLLER_LAYOUT}" ]; then
@@ -42,112 +45,9 @@ fi
 
 source "${controlfolder}/${scriptdir}/${CONTROLLER_LAYOUT}_layout.txt"
 
-# -- Helper function --
-# Map the actual button/hat/axis
-function map {
-  INPUT_NAME=$1
-  TYPE=$2
-  ID=$3
-  VALUE=$4
-
-  map_x_result=""
-  case "${INPUT_NAME}" in
-    "a")                TR_NAME="${ABUT}";;
-    "b")                TR_NAME="${BBUT}";;
-    "x")                TR_NAME="${XBUT}";;
-    "y")                TR_NAME="${YBUT}";;
-    @GUIDEBUTTON@
-    "up")               TR_NAME="dpup";;
-    "down")             TR_NAME="dpdown";;
-    "left")             TR_NAME="dpleft";;
-    "right")            TR_NAME="dpright";;
-    "leftshoulder")     TR_NAME="leftshoulder";;
-    "leftthumb")        TR_NAME="leftstick";;
-    "lefttrigger")      TR_NAME="lefttrigger";;
-    "rightshoulder")    TR_NAME="rightshoulder";;
-    "rightthumb")       TR_NAME="rightstick";;
-    "righttrigger")     TR_NAME="righttrigger";;
-    "select")           TR_NAME="back";;
-    "start")            TR_NAME="start";;
-    "leftanalogup")     TR_NAME="-lefty";;
-    "leftanalogleft")   TR_NAME="-leftx";;
-    "leftanalogdown")   TR_NAME="+lefty";;
-    "leftanalogright")  TR_NAME="+leftx";;
-    "rightanalogup")    TR_NAME="-righty";;
-    "rightanalogleft")  TR_NAME="-rightx";;
-    "rightanalogdown")  TR_NAME="+righty";;
-    "rightanalogright") TR_NAME="+rightx";;
-    *)
-      return
-      ;;
-  esac
-
-  case "${TYPE}" in
-  "axis")
-    if (( $VALUE < 0 )); then
-      map_x_result="${TR_NAME}:${map_x_result}-a${ID},"
-    else
-      # Most (save for a few misbehaved children...) triggers are [0, 1] instead of [-1, 1]
-      # Shitty workaround for an emulationstation issue
-      if [[ $INPUT_NAME =~ .*"trigger" ]]; then
-        map_x_result="${TR_NAME}:${map_x_result}a${ID},"
-      else
-        map_x_result="${TR_NAME}:${map_x_result}+a${ID},"
-      fi
-    fi
-    ;;
-  "button")
-    map_x_result="${TR_NAME}:${map_x_result}b${ID},"
-    ;;
-  "hat")
-    map_x_result="${TR_NAME}:${map_x_result}h${ID}.${VALUE},"
-    ;;
-  *)
-    echo "Invalid entry ${TYPE}"
-    ;;
-  esac
-}
-
-function get_map_suffix {
-  map_suffix="platform:Linux,"
-}
-
-function get_map_prefix {
-  map_prefix="${GUID},${NAME},"
-}
-
-# query controllers mapped in emulationstation, ignore devices without a GUID
-ES_QUERY="$(xmlstarlet sel -T -t -m "inputList/inputConfig[@deviceGUID!='']" -n -v "concat(@deviceName,';',@deviceGUID)" $ES_CONFIG)"
-printf "# ${CONTROLLER_LAYOUT} layout\n" >> "${CONTROLLER_DB}"
-
-echo "## ES Dev Mapper ##"
-while IFS=";" read -r NAME GUID; do
-  echo "$NAME :: $GUID"
-  # Ignore keyboards
-  if [[ "${GUID}" == -1 ]]; then
-    continue
-  fi
-
-    # Query this specific GUID on the mappings
-    MAPPING_CFG=$(xmlstarlet sel -T -t -m "//inputConfig[@deviceGUID = '${GUID}']/input" -n -v "concat(@name,';',@type,';',@id,';',@value)" $ES_CONFIG)
-
-    MAPPING=""
-    while IFS=";" read -r -e INPUT_NAME TYPE ID VALUE; do
-      # Map the controller
-      map "${INPUT_NAME}" "${TYPE}" "${ID}" "${VALUE}"
-
-      # Only concatenate valid mappings
-      if [[ ! -z ${map_x_result} ]]; then
-        MAPPING="${MAPPING}${map_x_result}"
-      fi
-    done <<< ${MAPPING_CFG:1}
-
-    get_map_prefix
-    get_map_suffix
-    if [[ ! -z "${MAPPING}" ]]; then
-      echo "${map_prefix}${MAPPING}${map_suffix}" >> "${CONTROLLER_DB}"
-    fi
-done <<< ${ES_QUERY:1}
+# Call function to create controller db from ES input config file for only connected devices
+create_controller_db ${CONTROLLER_LAYOUT} ${ES_CONFIG} ${CONTROLLER_DB}
 
 #Reset file for next run
 sed -i '/^ACTIVE_GAME=/c\ACTIVE_GAME=""' /storage/.config/PortMaster/mapper.txt
+sed -i '/^ACTIVE_PLATFORM=/c\ACTIVE_PLATFORM=""' /storage/.config/PortMaster/mapper.txt

--- a/packages/rocknix/profile.d/100-gamecontroller-functions
+++ b/packages/rocknix/profile.d/100-gamecontroller-functions
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+# -- Helper functions --
+# Map the actual button/hat/axis - defaults to Nintendo layout mapping
+function map_input_control {
+  local INPUT_NAME=$1
+  local TYPE=$2
+  local ID=$3
+  local VALUE=$4
+
+  map_x_result=""
+  case "${INPUT_NAME}" in
+    "a")                TR_NAME="${ABUT:-a}";;
+    "b")                TR_NAME="${BBUT:-b}";;
+    "x")                TR_NAME="${XBUT:-x}";;
+    "y")                TR_NAME="${YBUT:-y}";;
+    "hotkeyenable")     TR_NAME="guide";;
+    "up")               TR_NAME="dpup";;
+    "down")             TR_NAME="dpdown";;
+    "left")             TR_NAME="dpleft";;
+    "right")            TR_NAME="dpright";;
+    "leftshoulder")     TR_NAME="${LEFTSHOULDER:-leftshoulder}";;
+    "leftthumb")        TR_NAME="leftstick";;
+    "lefttrigger")      TR_NAME="${LEFTTRIGGER:-lefttrigger}";;
+    "rightshoulder")    TR_NAME="${RIGHTSHOULDER:-rightshoulder}";;
+    "rightthumb")       TR_NAME="rightstick";;
+    "righttrigger")     TR_NAME="${RIGHTTRIGGER:-righttrigger}";;
+    "select")           TR_NAME="back";;
+    "start")            TR_NAME="start";;
+    "leftanalogup")     TR_NAME="-lefty";;
+    "leftanalogleft")   TR_NAME="-leftx";;
+    "leftanalogdown")   TR_NAME="+lefty";;
+    "leftanalogright")  TR_NAME="+leftx";;
+    "rightanalogup")    TR_NAME="-righty";;
+    "rightanalogleft")  TR_NAME="-rightx";;
+    "rightanalogdown")  TR_NAME="+righty";;
+    "rightanalogright") TR_NAME="+rightx";;
+    *)
+      return
+      ;;
+  esac
+
+  case "${TYPE}" in
+  "axis")
+    if (( $VALUE < 0 )); then
+      map_x_result="${TR_NAME}:${map_x_result}-a${ID},"
+    else
+      # Most (save for a few misbehaved children...) triggers are [0, 1] instead of [-1, 1]
+      # Shitty workaround for an emulationstation issue
+      if [[ $INPUT_NAME =~ .*"trigger" ]]; then
+        map_x_result="${TR_NAME}:${map_x_result}a${ID},"
+      else
+        map_x_result="${TR_NAME}:${map_x_result}+a${ID},"
+      fi
+    fi
+    ;;
+  "button")
+    map_x_result="${TR_NAME}:${map_x_result}b${ID},"
+    ;;
+  "hat")
+    map_x_result="${TR_NAME}:${map_x_result}h${ID}.${VALUE},"
+    ;;
+  *)
+    echo "Invalid entry ${TYPE}"
+    ;;
+  esac
+}
+
+function get_map_suffix {
+  map_suffix="platform:Linux,"
+}
+
+function get_map_prefix {
+  map_prefix="${GUID},${NAME},"
+}
+
+function build_connected_devices_es_input {
+  local ES_CONFIG=${1}
+  # Clean up any old files
+  rm -rf /tmp/es_input
+  rm -rf "${ES_CONFIG}"
+
+  # Dump connected device GUIDs
+  /usr/bin/list-guid > /tmp/list-guid
+
+  # Loop through connected device and extract ES xml mapping
+  mkdir /tmp/es_input
+  while read DGUID; do
+    if [ ! -z "$(cat /storage/.config/emulationstation/es_input.cfg | grep ${DGUID})" ]; then
+      cp -r /storage/.config/emulationstation/es_input.cfg /tmp/es_input/${DGUID}.xml
+      xmlstarlet ed --inplace -d  "inputList/inputConfig[@deviceGUID!='${DGUID}']" /tmp/es_input/${DGUID}.xml
+    fi
+  done </tmp/list-guid
+
+  # Combine mappings for each device
+  sed -i '/inputList/d' /tmp/es_input/*.xml
+  echo '<inputList>' > "${ES_CONFIG}"
+  grep -vh '</\?inputConfig>>\|<?xml' /tmp/es_input/*.xml >> "${ES_CONFIG}"
+  echo '</inputList>' >> "${ES_CONFIG}"
+}
+
+# Create a controller DB file for connected controllers witih mappings for desired layout
+function create_controller_db {
+  local CONTROLLER_LAYOUT="${1}"
+  local ES_CONFIG="${2}"
+  local CONTROLLER_DB="${3}";
+
+  # Create an ES input config file containing only connected controllers
+  build_connected_devices_es_input ${ES_CONFIG}
+
+  # Query controllers mapped in emulationstation, ignore devices without a GUID
+  local ES_QUERY="$(xmlstarlet sel -T -t -m "inputList/inputConfig[@deviceGUID!='']" -n -v "concat(@deviceName,';',@deviceGUID)" $ES_CONFIG)"
+  printf "# ${CONTROLLER_LAYOUT} layout\n" >> "${CONTROLLER_DB}"
+
+  echo "## ES Dev Mapper ##"
+  while IFS=";" read -r NAME GUID; do
+    echo "$NAME :: $GUID"
+    # Ignore keyboards
+    if [[ "${GUID}" == -1 ]]; then
+      continue
+    fi
+
+      # Query this specific GUID on the mappings
+      local MAPPING_CFG=$(xmlstarlet sel -T -t -m "//inputConfig[@deviceGUID = '${GUID}']/input" -n -v "concat(@name,';',@type,';',@id,';',@value)" $ES_CONFIG)
+
+      # Grab the 'hotkeyenable' and 'select' button mappings to use later
+      unset HOTKEYENABLE_BUTTON
+      unset SELECT_BUTTON
+
+      while IFS=";" read -r -e INPUT_NAME TYPE ID VALUE; do
+        [ ${INPUT_NAME} == "hotkeyenable" ] && HOTKEYENABLE_BUTTON="${ID}"
+        [ ${INPUT_NAME} == "select" ] && SELECT_BUTTON="${ID}"
+      done <<< ${MAPPING_CFG:1}
+
+      local MAPPING=""
+      while IFS=";" read -r -e INPUT_NAME TYPE ID VALUE; do
+        # Map the controller - skip 'hotkeyenable' if it is the same as 'select'
+        if [ ${INPUT_NAME} == "hotkeyenable" -a ${HOTKEYENABLE_BUTTON} == ${SELECT_BUTTON} ]; then
+          echo "Skipping 'hotkeyenable', same mapping as 'select'"
+        else
+          map_input_control "${INPUT_NAME}" "${TYPE}" "${ID}" "${VALUE}"
+
+          # Only concatenate valid mappings
+          if [[ ! -z ${map_x_result} ]]; then
+            MAPPING="${MAPPING}${map_x_result}"
+          fi
+        fi
+      done <<< ${MAPPING_CFG:1}
+
+      get_map_prefix
+      get_map_suffix
+      if [[ ! -z "${MAPPING}" ]]; then
+        echo "${map_prefix}${MAPPING}${map_suffix}" >> "${CONTROLLER_DB}"
+      fi
+  done <<< ${ES_QUERY:1}
+}

--- a/packages/rocknix/sources/scripts/controller-layout
+++ b/packages/rocknix/sources/scripts/controller-layout
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile.d/001-functions
+. /etc/profile.d/100-gamecontroller-functions
+
+# -- Config & Setup --
+# Destination file
+if [[ -z "$1" ]] && [[ -z "$2" ]] && [[ -z "$3" ]]; then
+  echo "Usage: controller-layout [platform] [game] [gamecontrollerdb.txt]"
+  exit -1
+fi
+
+PLATFORM="$1"
+GAME="$2"
+CONTROLLER_DB="$3"
+
+# Where the emulationstation configuration file is
+ES_CONFIG="/tmp/es_input.cfg"
+
+# Scrub the CONTROLLER_DB file
+echo "" > ${CONTROLLER_DB}
+
+# Set layout via EmulationStation
+CONTROLLER_LAYOUT=$(get_setting controller_layout "${PLATFORM}" "${GAME}")
+
+if [ "${CONTROLLER_LAYOUT}" = "xbox" ]; then
+  # xbox layout
+  ABUT="b"
+  BBUT="a"
+  XBUT="y"
+  YBUT="x"
+  unset LEFTSHOULDER
+  unset LEFTTRIGGER
+  unset RIGHTSHOULDER
+  unset RIGHTTRIGGER
+elif [ "${CONTROLLER_LAYOUT}" = "xbox_swap_shoulders_triggers" ]; then
+  # xbox layout - with shoulders and triggers swapped
+  ABUT="b"
+  BBUT="a"
+  XBUT="y"
+  YBUT="x"
+  LEFTSHOULDER="lefttrigger"
+  LEFTTRIGGER="leftshoulder"
+  RIGHTSHOULDER="righttrigger"
+  RIGHTTRIGGER="rightshoulder"
+else
+  # nintendo layout
+  unset ABUT
+  unset BBUT
+  unset XBUT
+  unset YBUT
+  unset LEFTSHOULDER
+  unset LEFTTRIGGER
+  unset RIGHTSHOULDER
+  unset RIGHTTRIGGER
+fi
+
+# Call function to create controller db from ES input config file for only connected devices
+create_controller_db ${CONTROLLER_LAYOUT} ${ES_CONFIG} ${CONTROLLER_DB}

--- a/packages/rocknix/sources/scripts/runemu.sh
+++ b/packages/rocknix/sources/scripts/runemu.sh
@@ -277,10 +277,14 @@ case ${EMULATOR} in
       ;;
       "ports")
         RUNTHIS='${EMUPERF} ${RUN_SHELL} "${ROMNAME}"'
-	sed -i "/^ACTIVE_GAME=/c\ACTIVE_GAME=\"${ROMNAME}\"" /storage/.config/PortMaster/mapper.txt
+	      sed -i "/^ACTIVE_GAME=/c\ACTIVE_GAME=\"${ROMNAME}\"" /storage/.config/PortMaster/mapper.txt
+        sed -i "/^ACTIVE_PLATFORM=/c\ACTIVE_PLATFORM=\"${PLATFORM}\"" /storage/.config/PortMaster/mapper.txt
       ;;
       "windows")
         RUNTHIS='${EMUPERF} ${RUN_SHELL} "${ROMNAME}"'
+        # Hook into Portmaster control mapping
+        sed -i "/^ACTIVE_GAME=/c\ACTIVE_GAME=\"${ROMNAME}\"" /storage/.config/PortMaster/mapper.txt
+        sed -i "/^ACTIVE_PLATFORM=/c\ACTIVE_PLATFORM=\"${PLATFORM}\"" /storage/.config/PortMaster/mapper.txt
       ;;
       "shell")
         RUNTHIS='${RUN_SHELL} "${ROMNAME}"'

--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -1286,7 +1286,7 @@
    <cores>
     <core name="portmaster">
      <features>
-      <feature name="port controller layout">
+      <feature name="controller layout">
         <choice name="xbox" value="xbox"/>
         <choice name="nintendo" value="nintendo"/>
         <choice name="custom" value="custom"/>
@@ -1305,6 +1305,19 @@
       </feature>
      </features>
     </core>
+  </emulator>
+  <emulator name="moonlight">
+   <cores>
+    <core name="moonlight">
+     <features>
+      <feature name="controller layout">
+        <choice name="xbox" value="xbox"/>
+        <choice name="xbox - swap shoulders / triggers" value="xbox_swap_shoulders_triggers"/>
+        <choice name="nintendo" value="nintendo"/>
+      </feature>
+     </features>
+    </core>
+   </cores>
   </emulator>
   <emulator name="pico-8" features="pixel_perfect" />
   <emulator name="retroarch" features="decoration, ratio, smooth, shaders, pixel_perfect, latency_reduction, game_translation">

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="fb6ad5707359e6aaecd6a9f33b3f44494dea9e9d"
+PKG_VERSION="3887500d4cca6e6b98aeadbf837909b4fb22285a"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -1319,6 +1319,7 @@ makeinstall_target() {
   add_es_system music
 
   ### Moonlight
+  add_emu_core moonlight moonlight moonlight true
   add_es_system moonlight
 
   ### Tools


### PR DESCRIPTION
This PR allows Nintendo / Xbox etc controller layout mapping to be used for `windows` / `moonlight` systems as is currently available for `ports system.

Changes:
- Refactor the main `ports` system mapping logic into some reusable functions
- Fix the `windows` system 'controller layout' ES feature, let it hook into `ports` system controller mapping logic
- Add the `moonlight` system 'controller layout' ES feature

This PR has a dependency on `rocknix-emulationstation-next` change in PR: https://github.com/ROCKNIX/emulationstation-next/pull/16

'windows' / 'moonlight' / 'ports' systems tested on my Odin 2.