### PR TITLE
usbgadget: check for configured devices only on relevant bus

### DIFF
--- a/packages/rocknix/sources/scripts/usbgadget
+++ b/packages/rocknix/sources/scripts/usbgadget
@@ -301,7 +301,9 @@ cleanup_usb_mtp() {
 usb_start() {
 	if [ "$verbose" -gt "0" ];then echo "STORED=${USB_MODE}, CURRENT=${CURRENT_MODE}, DESIRED=$1"; fi
 
-	grep -q configured /sys/bus/usb/devices/1-0\:1.0/usb1-port1/state && exit 3
+	# Exit with error if this UDC has a downstream device. Applies to RK3326 where we use a single port
+	# Switching to device mode in this case would break USB Wifi and USB gamepad
+	grep -q configured /sys/class/udc/${UDC_NAME}/device/usb1/1-0\:1.0/usb1-port1/state 2>/dev/null && exit 3
 
 	# with no argument setup previous mode
 	[[ -n "$1" ]] && USB_MODE=$1


### PR DESCRIPTION
Small fix for usb gadget prevention with existing downstream devices.  

The problem:
------
The initial protection was implemented for rk3326, and is quite generic.  
On other platforms (s922x, likely rk3566 and others too) device on dedicated Host bus prevented gadget from starting on other, dedicated Device bus.  
This was due to check done on just a bus, not a device-side bus.

Solution:
------
I made the check more strict, now it looks for device only on UDC bus. So, it still works on rk3326 and does not fire on rk3566.