### PR TITLE
SM8550 - Odin2 devicetree - retain sdhci-caps-mask property

### DIFF
--- a/projects/Qualcomm/patches/linux/SM8550/0048_arm64--dts--qcom--Add-AYN-Odin2-Common.patch
+++ b/projects/Qualcomm/patches/linux/SM8550/0048_arm64--dts--qcom--Add-AYN-Odin2-Common.patch
@@ -1099,7 +1099,7 @@ index 000000000000..58d9ab342fe9
 +
 +	qcom,use-level-shifter;
 +	qcom,dll-config = <0x0007442c>;
-+	/delete-property/ sdhci-caps-mask;
++//	/delete-property/ sdhci-caps-mask;
 +
 +	status = "okay";
 +};


### PR DESCRIPTION
Fixes rare kernel panic on boot with a 512 GB Samsung Pro Plus card - at least I was unable to make the kernel panic happen with a build from this PR.

No issues with slow game load times, everything I tested on my Odin 2 felt very fast.