### PR TITLE
dolphin-sa-gc - 'save type' ES feature

### DIFF
--- a/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/packages/ui/emulationstation/config/common/es_features.cfg
@@ -586,6 +586,10 @@
         <choice name="2x (720P)" value="4"/>
         <choice name="3x (1080P)" value="6"/>
       </feature>
+      <feature name="save type">
+        <choice name="memory card" value="1"/>
+        <choice name="gci folder" value="8"/>
+      </feature>
       <feature name="shader mode">
         <choice name="specialized (fast)" value="0"/>
         <choice name="hybrid (slow)" value="1"/>


### PR DESCRIPTION
Works the same as for `dolphin-qt-gc`. Tested on my Gameforce ACE.