### PR TITLE
S922X - u-boot - disable bootmode hotkey check

### DIFF
--- a/projects/Amlogic/packages/u-boot/patches/001-disable-bootmode-hotkey-check.patch
+++ b/projects/Amlogic/packages/u-boot/patches/001-disable-bootmode-hotkey-check.patch
@@ -1,0 +1,53 @@
+diff -rupN u-boot-6e07c57a22182bcdc9e2b828a68a2e7025a6385c.orig/board/hardkernel/odroidgou/recovery.c u-boot-6e07c57a22182bcdc9e2b828a68a2e7025a6385c/board/hardkernel/odroidgou/recovery.c
+--- u-boot-6e07c57a22182bcdc9e2b828a68a2e7025a6385c.orig/board/hardkernel/odroidgou/recovery.c	2025-04-21 23:55:26.477677404 +1000
++++ u-boot-6e07c57a22182bcdc9e2b828a68a2e7025a6385c/board/hardkernel/odroidgou/recovery.c	2025-04-22 00:07:09.273474266 +1000
+@@ -32,48 +32,7 @@ int boot_device(void)
+ 
+ void check_hotkey(void)
+ {
+-	int left1,left2,right1,right2;
+-	int boot_mode = 0;
+-	
+-	gpio_request(KEY_SHOULDER_LEFT1, "left1");
+-	gpio_request(KEY_SHOULDER_LEFT2, "left2");
+-	gpio_request(KEY_SHOULDER_RIGHT1, "right1");
+-	gpio_request(KEY_SHOULDER_RIGHT2, "right2");
+-
+-	gpio_direction_input(KEY_SHOULDER_LEFT1);
+-	gpio_direction_input(KEY_SHOULDER_LEFT2);
+-	gpio_direction_input(KEY_SHOULDER_RIGHT1);
+-	gpio_direction_input(KEY_SHOULDER_RIGHT2);
+-	
+-	//key active low
+-	left1 = !gpio_get_value(KEY_SHOULDER_LEFT1);
+-	left2 = !gpio_get_value(KEY_SHOULDER_LEFT2);
+-	right1 = !gpio_get_value(KEY_SHOULDER_RIGHT1);
+-	right2 = !gpio_get_value(KEY_SHOULDER_RIGHT2);
+-
+-	if (left1 && right1) {
+-		boot_mode = BOOTMODE_TEST;
+-		printf("bootmode : Auto-test mode. \n");
+-	} else if (left2 && right2) {
+-		boot_mode = BOOTMODE_RECOVERY;
+-		printf("bootmode : Recovery mode. \n");
+-	} else {
+-		boot_mode = BOOTMODE_NORMAL;
+-		printf("bootmode : Nomal boot. \n");
+-	}
+-
+-	switch (boot_mode) {
+-		case BOOTMODE_RECOVERY :
+-			setenv("bootmode", "recovery");
+-		break;
+-		case BOOTMODE_TEST :
+-			setenv("bootmode", "test");
+-		break;
+-		case BOOTMODE_NORMAL :
+-		default :
+-			setenv("bootmode", "normal");
+-		break;
+-	}
++	setenv("bootmode", "normal");
+ }
+ 
+ 


### PR DESCRIPTION
Boot hotkeys (L1 + R1 + power for test mode, L2 + R2 + power for recovery mode) no longer work on the OGU / Max 3 Pro. Attempting to use either of them results in a 'SYSTEM FAILURE' message: https://discord.com/channels/948029830325235753/1035228339952160878/1361797548196499629

This PR adds a patch to disable boot hotkeys.