### PR TITLE
RK3399 - duckstation-sa - migrate to appimage

### DIFF
--- a/packages/emulators/standalone/duckstation-sa/config/RK3399/settings.ini
+++ b/packages/emulators/standalone/duckstation-sa/config/RK3399/settings.ini
@@ -103,31 +103,6 @@ LogToWindow = false
 LogToFile = false
 
 
-[Controller1]
-Type = AnalogController
-ButtonUp = Controller0/Button11
-ButtonDown = Controller0/Button12
-ButtonLeft = Controller0/Button13
-ButtonRight = Controller0/Button14
-ButtonSelect = Controller0/Button4
-ButtonStart = Controller0/Button6
-ButtonTriangle = Controller0/Button2
-ButtonCross = Controller0/Button1
-ButtonSquare = Controller0/Button3
-ButtonCircle = Controller0/Button0
-ButtonL1 = Controller0/Button9
-ButtonL2 = Controller0/+Axis4
-ButtonR1 = Controller0/Button10
-ButtonR2 = Controller0/+Axis5
-AxisLeftX = Controller0/Axis0
-AxisLeftY = Controller0/Axis1
-ButtonL3 = Controller0/Button7
-ButtonR3 = Controller0/Button8
-AxisRightX = Controller0/Axis2
-AxisRightY = Controller0/Axis3
-AnalogDPadInDigitalMode = false
-
-
 [GameList]
 RecursivePaths = /storage/roms/psx
 
@@ -180,6 +155,10 @@ DMAMaxSliceTicks = 1000
 DMAHaltTicks = 100
 GPUFIFOSize = 16
 GPUMaxRunAhead = 128
+
+
+[Controller1]
+Type = AnalogController
 
 
 [Controller2]

--- a/packages/virtual/emulators/package.mk
+++ b/packages/virtual/emulators/package.mk
@@ -41,7 +41,7 @@ case "${DEVICE}" in
   RK3399)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 desmume-lr gpsp-lr pcsx_rearmed-lr"
     PKG_EMUS+=" aethersx2-sa box64 dolphin-sa drastic-sa mednafen melonds-sa nanoboyadvance-sa portmaster scummvmsa \
-                yabasanshiro-sa duckstation-legacy-sa"
+                yabasanshiro-sa duckstation-sa"
     LIBRETRO_CORES+=" beetle-psx-lr bsnes-lr bsnes-hd-lr dolphin-lr geolith-lr flycast-lr pcsx_rearmed-lr uae4arm"
     PKG_RETROARCH+=" retropie-shaders"
   ;;


### PR DESCRIPTION
I don't have an RK3399 device or build environment. I have tested a similar change on S922X / RK3326 / RK3588, but need some help building / testing this.