### PR TITLE
SM8550 - EXTRA_CMDLINE - allow_mismatched_32bit_el0

### DIFF
--- a/projects/Qualcomm/devices/SM8550/options
+++ b/projects/Qualcomm/devices/SM8550/options
@@ -63,7 +63,7 @@
     WINDOWMANAGER="swaywm-env"
   
   # kernel serial console
-    EXTRA_CMDLINE="quiet rootwait console=tty0"
+    EXTRA_CMDLINE="quiet rootwait console=tty0 allow_mismatched_32bit_el0"
 
   # build and install rocknix joypad driver (yes / no)
     ROCKNIX_JOYPAD="no"


### PR DESCRIPTION
I remember there were some problems running 32-bit binaries without this.