### PR TITLE
MagicX XU mini M: use generic-dsi driver with many modes

### DIFF
--- a/projects/Rockchip/patches/linux/RK3326/021-magicx-xu-mini-m.patch
+++ b/projects/Rockchip/patches/linux/RK3326/021-magicx-xu-mini-m.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000000..e57803b572b8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3326-magicx-xu-mini-m.dts
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,109 @@
 +/// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024-present ROCKNIX (https://github.com/ROCKNIX)
@@ -23,8 +23,53 @@ index 000000000000..e57803b572b8
 +
 +&dsi {
 +	internal_display: panel@0 {
-+		compatible = "magicx,xu-mini-m-panel", "sitronix,st7701";
-+		reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
++		compatible = "rocknix,generic-dsi";
++		panel_description =
++			"G size=69,139 delays=5,20,20,120,20 format=rgb888 lanes=2 flags=0xe03",
++
++			"M clock=25000 horizontal=480,60,10,54 vertical=640,20,10,20 default=1",
++			"M clock=25200 horizontal=480,60,22,54 vertical=640,20,139,20",
++			"M clock=25000 horizontal=480,60,31,54 vertical=640,20,120,20",
++			"M clock=25660 horizontal=480,60,22,54 vertical=640,20,153,20",
++			"M clock=25300 horizontal=480,60,31,54 vertical=640,20,24,20",
++			"M clock=28590 horizontal=480,60,15,54 vertical=640,20,106,20",
++			"M clock=25380 horizontal=480,60,17,54 vertical=640,20,13,20",
++			"M clock=25410 horizontal=480,60,11,54 vertical=640,20,20,20",
++			"M clock=29490 horizontal=480,60,24,54 vertical=640,20,114,20",
++			"M clock=33520 horizontal=480,60,36,54 vertical=640,20,25,20",
++			"M clock=38430 horizontal=480,60,16,54 vertical=640,20,20,20",
++			"M clock=50820 horizontal=480,60,11,54 vertical=640,20,20,20",
++
++			"I seq=ff7701000013",
++			"I seq=ef08",
++			"I seq=ff7701000010",
++			"I seq=c04f00", "I seq=c11002", "I seq=c22002", "I seq=cc10",
++			"I seq=b006161e0e12060a0809230412102b311f",
++			"I seq=b1060f160d100704090720051210262f1f",
++			"I seq=ff7701000011",
++			"I seq=b065", "I seq=b185", "I seq=b282", "I seq=b380", "I seq=b542", "I seq=b785",
++			"I seq=b820",
++			"I seq=c178", "I seq=c278",
++			"I seq=d088",
++			"I seq=e0000002",
++			"I seq=e104a006a005a007a0004444",
++			"I seq=e2000000000000000000000000",
++			"I seq=e300002222",
++			"I seq=e44444",
++			"I seq=e50c90a0a00e92a0a0088ca0a00a8ea0a0",
++			"I seq=e600002222",
++			"I seq=e74444",
++			"I seq=e80d91a0a00f93a0a0098da0a00b8fa0a0",
++			"I seq=eb0000e4e4440040",
++			"I seq=edfff5476f0ba1abffffba1ab0f6745fff",
++			"I seq=ef080808403f64",
++			"I seq=ff7701000013",
++			"I seq=e6167c", "I seq=e8000e",
++			"I seq=e8000c wait=50",
++			"I seq=e80000",
++			"I seq=ff7701000000",
++			"I seq=11 wait=150",
++			"I seq=29 wait=120";
 +		rotation = <90>;
 +	};
 +};
@@ -66,164 +111,5 @@ index 000000000000..e57803b572b8
 +		};
 +	};
 +};
-diff --git a/drivers/gpu/drm/panel/panel-sitronix-st7701.c b/drivers/gpu/drm/panel/panel-sitronix-st7701.c
-index 421eb4592b61..bb7cec6d08f8 100644
---- a/drivers/gpu/drm/panel/panel-sitronix-st7701.c
-+++ b/drivers/gpu/drm/panel/panel-sitronix-st7701.c
-@@ -332,6 +332,41 @@ static void ts8550b_gip_sequence(struct st7701 *st7701)
- 		   0xFF, 0xFF, 0xFF, 0xF3, 0x27, 0x65, 0x40, 0x1F, 0xFF);
- }
- 
-+static void ho28b23_gip_sequence(struct st7701 *st7701)
-+{
-+	/**
-+	 * ST7701_SPEC_V1.2 is unable to provide enough information above this
-+	 * specific command sequence, so grab the same from vendor BSP driver.
-+	 */
-+	ST7701_WRITE(st7701, 0xE0, 0x00, 0x00, 0x02);
-+	ST7701_WRITE(st7701, 0xE1, 0x04, 0xA0, 0x06, 0xA0, 0x05, 0xA0, 0x07,
-+		   0xA0, 0x00, 0x44, 0x44);
-+	ST7701_WRITE(st7701, 0xE2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-+		   0x00, 0x00, 0x00, 0x00, 0x00);
-+	ST7701_WRITE(st7701, 0xE3, 0x00, 0x00, 0x22, 0x22);
-+	ST7701_WRITE(st7701, 0xE4, 0x44, 0x44);
-+	ST7701_WRITE(st7701, 0xE5, 0x0C, 0x90, 0xA0, 0xA0, 0x0E, 0x92, 0xA0,
-+		   0xA0, 0x08, 0x8c, 0xA0, 0xA0, 0x0A, 0x8E, 0xA0, 0xA0);
-+	ST7701_WRITE(st7701, 0xE6, 0x00, 0x00, 0x22, 0x22);
-+	ST7701_WRITE(st7701, 0xE7, 0x44, 0x44);
-+	ST7701_WRITE(st7701, 0xE8, 0x0D, 0x91, 0xA0, 0xA0, 0x0F, 0x93, 0xA0,
-+		   0xA0, 0x09, 0x8D, 0xA0, 0xA0, 0x0B, 0x8F, 0xA0, 0xA0);
-+	ST7701_WRITE(st7701, 0xEB, 0x00, 0x00, 0xE4, 0xE4, 0x44, 0x00, 0x40);
-+	ST7701_WRITE(st7701, 0xED, 0xFF, 0xF5, 0x47, 0x6F, 0x0B, 0xA1, 0xAB,
-+		   0xFF, 0xFF, 0xBA, 0x1A, 0xB0, 0xF6, 0x74, 0x5F, 0xFF);
-+	ST7701_WRITE(st7701, 0xEF, 0x08, 0x08, 0x08, 0x40, 0x3F, 0x64);
 +
-+	st7701_switch_cmd_bkx(st7701, true, 3);
-+	ST7701_WRITE(st7701, 0xE6, 0x16, 0x7C);
-+	ST7701_WRITE(st7701, 0xE8, 0x00, 0x0E);
 +
-+	ST7701_WRITE(st7701, 0xE8, 0x00, 0x0C);
-+	msleep(50);
-+	ST7701_WRITE(st7701, 0xE8, 0x00, 0x00);
-+
-+	st7701_switch_cmd_bkx(st7701, false, 0);
-+}
-+
- static void dmt028vghmcmi_1a_gip_sequence(struct st7701 *st7701)
- {
- 	ST7701_WRITE(st7701, 0xEE, 0x42);
-@@ -675,6 +710,106 @@ static const struct st7701_panel_desc ts8550b_desc = {
- 	.gip_sequence = ts8550b_gip_sequence,
- };
- 
-+static const struct drm_display_mode ho28b23_mode = {
-+	.clock		= 25000,
-+
-+	.hdisplay	= 480,
-+	.hsync_start	= 480 + 30,
-+	.hsync_end	= 480 + 30 + 8,
-+	.htotal		= 480 + 30 + 8 + 30,
-+
-+	.vdisplay	= 640,
-+	.vsync_start	= 640 + 2,
-+	.vsync_end	= 640 + 2 + 1,
-+	.vtotal		= 640 + 2 + 1 + 16,
-+
-+	.width_mm	= 56,
-+	.height_mm	= 78,
-+
-+	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
-+
-+	.type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
-+};
-+
-+static const struct st7701_panel_desc ho28b23_desc = {
-+	.mode = &ho28b23_mode,
-+	.lanes = 2,
-+	.format = MIPI_DSI_FMT_RGB888,
-+	.panel_sleep_delay = 5, /* panel need extra 5ms for sleep out cmd */
-+	.pv_gamma = {
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC0_MASK, 06),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC4_MASK, 0x16),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC8_MASK, 0x1e),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC16_MASK, 0xe),
-+
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC24_MASK, 0x12),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC52_MASK, 0x6),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC80_MASK, 0xA),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC108_MASK, 0x8),
-+
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC147_MASK, 0x9),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC175_MASK, 0x23),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC203_MASK, 0x4),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC231_MASK, 0x12),
-+
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC239_MASK, 0x10),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC247_MASK, 0x2B),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC251_MASK, 0x31),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC255_MASK, 0x1F)
-+	},
-+	.nv_gamma = {
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC0_MASK, 0x06),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC4_MASK, 0xf),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC8_MASK, 0x16),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC16_MASK, 0xd),
-+
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC24_MASK, 0x10),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC52_MASK, 0x7),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC80_MASK, 0x4),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC108_MASK, 0x9),
-+
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC147_MASK, 0x7),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC175_MASK, 0x20),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC203_MASK, 0x5),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC231_MASK, 0x12),
-+
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC239_MASK, 0x10),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC247_MASK, 0x26),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC251_MASK, 0x2f),
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_AJ_MASK, 0) |
-+		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC255_MASK, 0x1f)
-+	},
-+	.nlinv = 0,
-+	.vop_uv = 4800000,
-+	.vcom_uv = 1762500,
-+	.vgh_mv = 15000,
-+	.vgl_mv = -7910,
-+	.avdd_mv = 6600,
-+	.avcl_mv = -4400,
-+	.gamma_op_bias = OP_BIAS_MIDDLE,
-+	.input_op_bias = OP_BIAS_MIN,
-+	.output_op_bias = OP_BIAS_MIN,
-+	.t2d_ns = 1600,
-+	.t3d_ns = 10400,
-+	.eot_en = true,
-+	.gip_sequence = ho28b23_gip_sequence,
-+};
-+
- static const struct drm_display_mode dmt028vghmcmi_1a_mode = {
- 	.clock		= 22325,
- 
-@@ -1056,6 +1191,7 @@ static const struct of_device_id st7701_of_match[] = {
- 	{ .compatible = "densitron,dmt028vghmcmi-1a", .data = &dmt028vghmcmi_1a_desc },
- 	{ .compatible = "elida,kd50t048a", .data = &kd50t048a_desc },
- 	{ .compatible = "techstar,ts8550b", .data = &ts8550b_desc },
-+	{ .compatible = "magicx,xu-mini-m-panel", .data = &ho28b23_desc },
- 	{ }
- };
- MODULE_DEVICE_TABLE(of, st7701_of_match);


### PR DESCRIPTION
Switched XU Mini M to generic-dsi driver.  
The old option (st7701) had a single broken mode, also reset line was inverted.  
`nikki` in discord confirmed it's working well.