### PR TITLE
Bump box86 (v0.3.8), box64 (v0.3.4) and wine (10.7), switch box86 and box64 to version tags

### DIFF
--- a/packages/compat/box64/package.mk
+++ b/packages/compat/box64/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="2b300bd199a7a65a3de1eecd24d6dff5593a9b55"
+PKG_VERSION="v0.3.4"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"
-PKG_URL="${PKG_SITE}.git"
+PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain ncurses SDL_sound cabextract libXss libXdmcp libXft gtk2"
 PKG_LONGDESC="Box64 lets you run x86_64 Linux programs (such as games) on non-x86_64 Linux systems, like ARM."
 PKG_TOOLCHAIN="cmake"

--- a/packages/compat/box86/package.mk
+++ b/packages/compat/box86/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box86"
-PKG_VERSION="efe8bb4e6c6a4e7a4f468061875655423603a224"
+PKG_VERSION="v0.3.8"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box86"
-PKG_URL="${PKG_SITE}.git"
+PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain ncurses SDL_sound libXdmcp libXft libXcomposite cups libogg-system"
 PKG_LONGDESC="Box86 lets you run x86 Linux programs (such as games) on non-x86 Linux systems, like ARM."
 PKG_TOOLCHAIN="cmake"

--- a/packages/compat/wine/package.mk
+++ b/packages/compat/wine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="10.3"
+PKG_VERSION="10.7"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 # Use the amd64 release as it supports running both 32-bit and 64-bit windows apps


### PR DESCRIPTION
Just makes it clearer which version of box86 / box64 we're running.

Tested on my Odin 2.