### PR TITLE
Fixed squished video on flycast-sa for ACE.

### DIFF
--- a/packages/emulators/standalone/flycast-sa/config/RK3588/emu.cfg
+++ b/packages/emulators/standalone/flycast-sa/config/RK3588/emu.cfg
@@ -14,3 +14,8 @@ device1.2 = 1
 device2 = 0
 device2.1 = 1
 device2.2 = 1
+
+[window]
+fullscreen = yes
+height = 1080
+width = 1920


### PR DESCRIPTION
Flycast standalone was displaying squished video on the Gameforce ACE due to the resolution defaulting to 640x480.  Updated the default emu.cfg to use 1920x1080.  This is handled similarly by other platforms (e.g. SM8250).