### PR TITLE
blocklist - add minivmac-lr

### DIFF
--- a/config/blocklist
+++ b/config/blocklist
@@ -11,6 +11,7 @@ gzdoom-sa # Stick to release versions.
 idtech-lr # Just a dummy package
 kronos-sa # Using the release version of kronos had better results.
 melonds-sa # Broken OpenGL renderer upstream
+minivmac-lr # Upstream Makefile change breaks build
 mupen64plus-sa-ui-console # Causes segfaults
 nanoboyadvance-sa # SDL version removed after this commit
 np2kai # Last major commit before hiatus is broken.


### PR DESCRIPTION
Upstream Makefile change (https://github.com/libretro/libretro-minivmac/pull/19) breaks build