### PR TITLE
rename usb gadget network iface to not interfere with ES

### DIFF
--- a/packages/rocknix/udev.d/80-usbgadget.rules
+++ b/packages/rocknix/udev.d/80-usbgadget.rules
@@ -1,2 +1,4 @@
 # trigger for activating gadget after cable is plugged
 SUBSYSTEMS=="extcon", ACTION=="change", RUN+="/usr/bin/usbgadget trigger"
+# rename gadget interface to avoid ES displaying connected state
+ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="gadget", NAME="gadget"


### PR DESCRIPTION
Default gadget network name 'usb0' matched ES filters, and ES considered real network is connected.
Since gadget may always stay configured, I renamed it so that ES ignores it.
```
RK3326:~ # ip ad
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute 
       valid_lft forever preferred_lft forever
2: gadget: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast qlen 1000
    link/ether 82:ba:1c:92:78:b1 brd ff:ff:ff:ff:ff:ff
    inet 10.1.1.2/30 scope global gadget
       valid_lft forever preferred_lft forever
    inet6 fe80::80ba:1cff:fe92:78b1/64 scope link 
       valid_lft forever preferred_lft forever
```