### PR TITLE
azahar-sa - use unified source archive for PKG_VERSION

### DIFF
--- a/packages/emulators/standalone/azahar-sa/package.mk
+++ b/packages/emulators/standalone/azahar-sa/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="azahar-sa"
-PKG_VERSION="fa2c7d0c76b171a0b1ec02b7fedb5735c64a4c8a" # 2121.1
+PKG_VERSION="2121.1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/azahar-emu/azahar"
-PKG_URL="${PKG_SITE}.git"
+PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/azahar-unified-source-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain ffmpeg mesa SDL2 boost zlib libusb boost zstd control-gen spirv-tools qt6"
 PKG_LONGDESC="Azahar - Nintendo 3DS emulator"
 PKG_TOOLCHAIN="cmake"


### PR DESCRIPTION
Possible now that this has been merged: https://github.com/azahar-emu/azahar/issues/221

Built for SM8550 ok, tested ok on my Odin 2.