### PR TITLE
update sway to 1.11-rc2 and wlroots to 0.19.0

### DIFF
--- a/packages/wayland/compositor/sway/package.mk
+++ b/packages/wayland/compositor/sway/package.mk
@@ -14,8 +14,8 @@ case ${DEVICE} in
     PKG_URL="https://github.com/swaywm/sway/archive/${PKG_VERSION}.zip"
   ;;
   *)
-    PKG_VERSION="1.10"
-    PKG_SHA256="7472a7f11150212e0bed0bd0af9f591c9caac9f9ea87c35486e475a21f5ce81f"
+    PKG_VERSION="1.11-rc2"
+    PKG_SHA256="78d24a4e0d2eb0e442155ca72afa924dba32a0e873456e8cf1e89155304c2590"
     PKG_URL="https://github.com/swaywm/sway/releases/download/${PKG_VERSION}/sway-${PKG_VERSION}.tar.gz"
   ;;
 esac

--- a/packages/wayland/lib/wlroots/package.mk
+++ b/packages/wayland/lib/wlroots/package.mk
@@ -10,8 +10,9 @@ PKG_TOOLCHAIN="meson"
 
 case ${DEVICE} in
   SM8250|SM8550|AMD64|RK3399|H700)
-  PKG_VERSION="0.18.2"
-  PKG_URL="${PKG_SITE}/-/archive/${PKG_VERSION}/wlroots-${PKG_VERSION}.tar.gz"
+    PKG_VERSION="0.19.0"
+    PKG_SHA256="967f3112c82e8ea18cbdc513e22196b30ccc9fad3fb836f1cff80312c66fab96"
+    PKG_URL="${PKG_SITE}/-/archive/${PKG_VERSION}/wlroots-${PKG_VERSION}.tar.gz"
   ;;
   RK3588)
     PKG_VERSION="0.17.4-rk"
@@ -19,8 +20,8 @@ case ${DEVICE} in
     PKG_URL="https://github.com/stolen/rockchip-wlroots/archive/refs/tags/${PKG_VERSION}.tar.gz"
   ;;
   *)
-    PKG_VERSION="0.18.1-rk"
-    PKG_SHA256="93572a16ba48749e1a8cea4e78a1992008e2713dcb72019abfc6f7efd0947ccf"
+    PKG_VERSION="0.19.0-rk"
+    PKG_SHA256="cf247be7ec6b7be834a2469c6738aa4515e1cb085c6668cdf071bb5a0dc0f524"
     PKG_URL="https://github.com/stolen/rockchip-wlroots/archive/refs/tags/${PKG_VERSION}.tar.gz"
   ;;
 esac


### PR DESCRIPTION
Just updating sway.  

Checked on rk3326, rk3566, s922x, sm8250 - - found no obvious issues.  

The version is not stable but release candidate (rc2). There are two issues left in the milestone: https://github.com/swaywm/sway/milestone/15
  * something about outputs in IPC (IDK if we use anything related)
  * FreeBSD related issue, irrelevant for Rocknix