### PR TITLE
S922X - zram swap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ docs:
 
 world: RK3588 RK3566 RK3326 RK3399 S922X SM8250 SM8550 H700
 
+kconfig-olddefconfig-%:
+	DEVICE=$* ./tools/adjust_kernel_config olddefconfig
+
+kconfig-menuconfig-%:
+	DEVICE=$* ./tools/adjust_kernel_config menuconfig
+
 AMD64:
 	unset DEVICE_ROOT
 	PROJECT=PC DEVICE=AMD64 ARCH=i686 ./scripts/build_distro

--- a/config/show_config
+++ b/config/show_config
@@ -133,7 +133,8 @@ show_config() {
 
   config_message="${config_message}\n - Swap Support:\t\t\t $SWAP_SUPPORT"
   if [ "$SWAP_SUPPORT" = "yes" ]; then
-    config_message="${config_message}\n   - Swapfile default size:\t\t $SWAPFILESIZE"
+    config_message="${config_message}\n   - Swap default size:\t\t $SWAPSIZE"
+    config_message="${config_message}\n   - Swap type :\t\t $SWAP_TYPE"
   fi
   config_message="${config_message}\n - exFAT Support (via Fuse):\t\t $EXFAT"
   config_message="${config_message}\n - NTFS Support (via Fuse):\t\t $NTFS3G"

--- a/distributions/ROCKNIX/options
+++ b/distributions/ROCKNIX/options
@@ -145,8 +145,11 @@
 # swap support enabled per default (yes / no)
   SWAP_ENABLED_DEFAULT="yes"
 
-# swapfile size if SWAP_SUPPORT=yes in MB
-  SWAPFILESIZE="384"
+# swap size if SWAP_SUPPORT=yes in MB
+  SWAPSIZE="384"
+
+# swap type if SWAP_SUPPORT=yes (file / zram)
+  SWAP_TYPE="file"
 
 # Default weston terminal font size
   WESTONFONTSIZE="14"

--- a/packages/kernel/linux/package.mk
+++ b/packages/kernel/linux/package.mk
@@ -128,6 +128,16 @@ pre_make_target() {
     ${PKG_BUILD}/scripts/config --disable CONFIG_SWAP
   fi
 
+  # enable / disable zram support (zstd compression) as required
+  if [ "${SWAP_TYPE}" = zram ]; then
+    ${PKG_BUILD}/scripts/config --module CONFIG_ZRAM
+    ${PKG_BUILD}/scripts/config --enable CONFIG_ZRAM_BACKEND_ZSTD
+    ${PKG_BUILD}/scripts/config --enable CONFIG_ZRAM_DEF_COMP_ZSTD
+    ${PKG_BUILD}/scripts/config --set-val CONFIG_ZRAM_DEF_COMP "zstd"
+  else
+    ${PKG_BUILD}/scripts/config --disable CONFIG_ZRAM
+  fi
+
   # disable nfs support if not enabled
   if [ "${NFS_SUPPORT}" = no ]; then
     ${PKG_BUILD}/scripts/config --disable CONFIG_NFS_FS

--- a/packages/sysutils/util-linux/config/swap.conf
+++ b/packages/sysutils/util-linux/config/swap.conf
@@ -2,5 +2,6 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 
 SWAPFILE="$HOME/.cache/swapfile"
-SWAPFILESIZE="@SWAPFILESIZE@"
+SWAPSIZE="@SWAPSIZE@"
 SWAP_ENABLED="@SWAP_ENABLED_DEFAULT@"
+SWAP_TYPE="@SWAP_TYPE@"

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -62,6 +62,10 @@ if [ "${SWAP_SUPPORT}" = "yes" ]; then
   PKG_CONFIGURE_OPTS_TARGET+=" --enable-swapon"
 fi
 
+if [ "${SWAP_TYPE}" = "zram" ]; then
+  PKG_CONFIGURE_OPTS_TARGET+=" --enable-zramctl"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--enable-shared \
                          --disable-static \
                          ${UTILLINUX_CONFIG_TARGET} \
@@ -87,8 +91,9 @@ post_makeinstall_target() {
 
     mkdir -p ${INSTALL}/etc
       cat ${PKG_DIR}/config/swap.conf | \
-        sed -e "s,@SWAPFILESIZE@,${SWAPFILESIZE},g" \
+        sed -e "s,@SWAPSIZE@,${SWAPSIZE},g" \
             -e "s,@SWAP_ENABLED_DEFAULT@,${SWAP_ENABLED_DEFAULT},g" \
+            -e "s,@SWAP_TYPE@,${SWAP_TYPE},g" \
             > ${INSTALL}/etc/swap.conf
   fi
 }

--- a/packages/sysutils/util-linux/scripts/mount-swap
+++ b/packages/sysutils/util-linux/scripts/mount-swap
@@ -11,8 +11,9 @@ if [ -f /storage/.config/swap.conf ]; then
 fi
 
 if [ -f "$SWAPFILE" ]; then
-  if [ $(ls -l "$SWAPFILE" | awk '{print  $5}') -lt $(($SWAPFILESIZE*1024*1024)) ]; then
-    swapoff "$SWAPFILE"
+  # Clean up existing swap file if it is smaller than desired or swap type is zram
+  if [ $(ls -l "$SWAPFILE" | awk '{print  $5}') -lt $(($SWAPSIZE*1024*1024)) -o "$SWAP_TYPE" = "zram" ]; then
+    [[ $(swapon | grep "$SWAPFILE") ]] && swapoff "$SWAPFILE"
     rm -rf "$SWAPFILE"
   fi
 fi
@@ -31,18 +32,39 @@ SWAP=`blkid -t TYPE="swap" -o device`
 
 case $1 in
   create)
-    if [ -z "$SWAP" -a ! -f "$SWAPFILE" ]; then
-      mkdir -p `dirname $SWAPFILE`
-      dd if=/dev/zero of=$SWAPFILE bs=1M count=$SWAPFILESIZE
-      chmod 0600 $SWAPFILE
-      mkswap $SWAPFILE
+    logger -t Boot "### creating swap type ${SWAP_TYPE} ###"
+
+    if [ "$SWAP_TYPE" = "file" ]; then
+      if [ -z "$SWAP" -a ! -f "$SWAPFILE" ]; then
+        mkdir -p `dirname $SWAPFILE`
+        dd if=/dev/zero of=$SWAPFILE bs=1M count=$SWAPSIZE
+        chmod 0600 $SWAPFILE
+        mkswap $SWAPFILE
+      fi
+    elif [ "$SWAP_TYPE" = "zram" ]; then
+      # Load zram module
+      modprobe zram
+
+      # Set up zram device of desired size
+      zramctl --find --size ${SWAPSIZE}M --algorith zstd
     fi
     ;;
   mount)
-    [ -z "$SWAP" -a -f "$SWAPFILE" ] && SWAP=$SWAPFILE
-    for i in $SWAP; do
-      swapon -p 10000 $i
-    done
+    logger -t Boot "### mounting swap type ${SWAP_TYPE} ###"
+
+    if [ "$SWAP_TYPE" = "file" ]; then
+      [ -z "$SWAP" -a -f "$SWAPFILE" ] && SWAP=$SWAPFILE
+      for i in $SWAP; do
+        swapon -p 10000 $i
+      done
+    elif [ "$SWAP_TYPE" = "zram" ]; then
+      ZRAM_DEV=$(zramctl -o NAME | grep zram)
+
+      if [ ! -z "$ZRAM_DEV" ]; then
+        mkswap ${ZRAM_DEV}
+        swapon ${ZRAM_DEV}
+      fi
+    fi
     ;;
   unmount)
     swapoff -a

--- a/projects/Amlogic/devices/S922X/options
+++ b/projects/Amlogic/devices/S922X/options
@@ -76,3 +76,9 @@
  
   # debug tty path
     DEBUG_TTY="/dev/ttyAML0"
+
+  # swap size if SWAP_SUPPORT=yes in MB
+    SWAPSIZE="512"
+
+  # swap type if SWAP_SUPPORT=yes (file / zram)
+    SWAP_TYPE="zram"

--- a/projects/PC/devices/AMD64/options
+++ b/projects/PC/devices/AMD64/options
@@ -74,4 +74,4 @@
     INITRAMFS_PARTED_SUPPORT="yes"
 
   # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="1024"
+    SWAPSIZE="1024"


### PR DESCRIPTION
- Makefile - add kconfig targets for convenience
- Add option for zram swap to all platforms, with auto kconfig enable / disable
- S922X - enable zram and zram zstd compression in kconfig, enable 512M zram (zstd compression) swap

These changes are backwards compatible, other platforms continue to use a swap file. To use zram swap, put the following in the platform options file:
```
# swap type if SWAP_SUPPORT=yes (file / zram)
SWAP_TYPE="zram"
```

**Testing**

- [x] S922X - swapfile
- [x] S922X - zram swap
- [x] H700 - regression testing - no swapfile
- [x] H700 - zram swap - build test
- [x] SM8550 - zram swap - build test
- [x] RK3588 - zram swap - build test