### PR TITLE
H700 - RG34XXSP - fix rocknix-dt-id, apply bootloader update workaround

### DIFF
--- a/projects/Allwinner/bootloader/update.sh
+++ b/projects/Allwinner/bootloader/update.sh
@@ -22,6 +22,12 @@ echo "Updating device trees..."
 cp -f $SYSTEM_ROOT/usr/share/bootloader/device_trees/* $BOOT_ROOT/device_trees
 
 DT_ID=$(cat /proc/device-tree/rocknix-dt-id)
+
+# TODO remove - workaround for RG34XXSP incorrect DT bug
+[[ ${DT_ID} = "sun50i-h700-anbernic-rg35xx-plus" ]] &&
+  [[ $(cat /sys/class/graphics/fb0/virtual_size) = "720,480" ]] &&
+    DT_ID="sun50i-h700-anbernic-rg34xx-sp"
+
 UPDATE_DTB_SOURCE="$BOOT_ROOT/device_trees/$DT_ID.dtb"
 if [ -f "$UPDATE_DTB_SOURCE" ]; then
   echo "Updating dtb.img from $(basename $UPDATE_DTB_SOURCE)..."

--- a/projects/Allwinner/patches/linux/H700/0154-rocknix-dt-id.patch
+++ b/projects/Allwinner/patches/linux/H700/0154-rocknix-dt-id.patch
@@ -20,6 +20,17 @@ diff -ur a/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg34xx.dts b/arch/
  };
  
  &panel {
+diff -ur a/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg34xx-sp.dts b/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg34xx-sp.dts
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg34xx-sp.dts	2025-05-26 21:15:31.170386803 +1000
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg34xx-sp.dts	2025-05-26 21:14:05.425219393 +1000
+@@ -9,6 +9,7 @@
+ / {
+ 	model = "Anbernic RG34XX-SP";
+ 	compatible = "anbernic,rg34xx-sp", "allwinner,sun50i-h700";
++	rocknix-dt-id = "sun50i-h700-anbernic-rg34xx-sp";
+ };
+ 
+ &panel {
 diff -ur a/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-2024-rev6-panel.dts b/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-2024-rev6-panel.dts
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-2024-rev6-panel.dts	2024-12-24 12:16:07.534240856 +0000
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-2024-rev6-panel.dts	2024-12-24 12:25:16.464311447 +0000


### PR DESCRIPTION
At the moment RG34XXSP gets assigned the incorrect `rocknix-dt-id` devicetree node:
```
H700:~ # cat /proc/device-tree/rocknix-dt-id
sun50i-h700-anbernic-rg35xx-plus
```

This means when an update is applied, the wrong DTB will be installed as part of the bootloader update and the display is broken.

This PR adds a bootloader update workaround with device detection based on framebuffer size, and sets `rocknix-dt-id` correctly.

Tested and working ok on my RG34XXSP. After updating successfully with a build from this PR (with display working fine):
```
H700:~ # cat /proc/device-tree/rocknix-dt-id
sun50i-h700-anbernic-rg34xx-sp
```