### PR TITLE
RG34XXSP - shutdown on lid close

### DIFF
--- a/packages/rocknix/sources/scripts/rocknix-lid
+++ b/packages/rocknix/sources/scripts/rocknix-lid
@@ -1,0 +1,44 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+### Enable logging
+case $(get_setting system.loglevel) in
+  verbose)
+    DEBUG=true
+  ;;
+  *)
+    DEBUG=false
+  ;;
+esac
+
+SUSPEND_MODE="$(get_setting system.suspendmode)"
+
+# Only do something when suspend mode is off
+if [ "${SUSPEND_MODE}" != "off" ]; then
+    ${DEBUG} && log $0 "Suspend enabled, exiting"
+    exit 0
+fi
+
+# Action = open / close
+ACTION=$1
+
+do_es_shutdown() {
+    # Shutdown only when ES is up and no game is running
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1234/runningGame")
+    test $? != 0                 && return 0
+    test "${HTTP_STATUS}" != 201 && return 0 # 201 when not game
+
+    ${DEBUG} && log $0 "Shutting down"
+
+    curl "http://localhost:1234/shutdown"
+}
+
+# Only need to act on close
+if [ "${ACTION}" = "close" ]; then
+    ${DEBUG} && log $0 "Lid close"
+    # Use ES shutdown so metadata is saved
+    do_es_shutdown
+fi

--- a/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -37,6 +37,9 @@ FUNCTION_VOLUME_DOWN_EVENT='*('${KEY_VOLUME_DOWN}'), value 1'
 FUNCTION_POWER_RELEASED_EVENT='*(KEY_POWER), value 0'
 FUNCTION_POWER_PRESSED_EVENT='*(KEY_POWER), value 1'
 
+FUNCTION_LID_OPEN_EVENT='*(SW_LID), value 0'
+FUNCTION_LID_CLOSE_EVENT='*(SW_LID), value 1'
+
 ### Define matching function hotkeys from controller values, but allow them to be overridden in system.cfg.
 KEYA_MODIFIER=$(get_setting key.function.a)
 [ -z "${KEYA_MODIFIER}" ] && KEYA_MODIFIER="${DEVICE_FUNC_KEYA_MODIFIER}"
@@ -275,6 +278,14 @@ set +e
       ;;
       (${FUNCTION_POWER_PRESSED_EVENT})
         rocknix-shutdown 1 &
+      ;;
+      (${FUNCTION_LID_OPEN_EVENT})
+        ${DEBUG} && log $0 "${FUNCTION_LID_OPEN_EVENT}: Open"
+        /usr/bin/rocknix-lid open &
+      ;;
+      (${FUNCTION_LID_CLOSE_EVENT})
+        ${DEBUG} && log $0 "${FUNCTION_LID_CLOSE_EVENT}: Close"
+        /usr/bin/rocknix-lid close &
       ;;
     esac
 

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="4e58bba0745818c8ba2c19d3d71bec4419836845"
+PKG_VERSION="44be3df69899b14120810dfd8887eebde9ee5746"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"

--- a/projects/Allwinner/patches/linux/H700/0146-Create-sun50i-h700-anbernic-rg34xx-sp.dts.patch
+++ b/projects/Allwinner/patches/linux/H700/0146-Create-sun50i-h700-anbernic-rg34xx-sp.dts.patch
@@ -20,7 +20,7 @@ index 000000000..f2eca80b3
 + * Copyright (C) 2024 Chris Morgan <macroalpha82@gmail.com>.
 + */
 +
-+#include "sun50i-h700-anbernic-rg35xx-plus.dts"
++#include "sun50i-h700-anbernic-rg35xx-sp.dts"
 +
 +/ {
 +	model = "Anbernic RG34XX-SP";


### PR DESCRIPTION
- RG34XXSP - inherit from RG35XXSP devicetree for lid switch
- input-sense - trigger EmulationStation shutdown on lid close (if suspend is disabled and no game running)

Notes:
- uses new ES HTTP endpoint `shutdown` so ES metadata is saved: https://github.com/ROCKNIX/emulationstation-next/pull/19

Tested on my RG34XXSP:
```
H700:~ # journalctl -f -u input
May 29 16:16:34 H700 input_sense[4018]: *(SW_LID), value 1: Close
May 29 16:16:34 H700 rocknix-lid[4043]: Lid close
May 29 16:16:34 H700 rocknix-lid[4046]: Shutting down
May 29 16:16:34 H700 input_sense[4048]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
May 29 16:16:34 H700 input_sense[4048]:                                  Dload  Upload   Total   Spent    Left  Speed
May 29 16:16:34 H700 input_sense[4048]: [158B blob data]

Broadcast message from root@H700 (Thu 2025-05-29 16:16:35 AEST):

The system will power off now!

May 29 16:16:35 H700 systemd[1]: Stopping input.service...
May 29 16:16:35 H700 systemd[1]: input.service: Deactivated successfully.
May 29 16:16:35 H700 systemd[1]: Stopped input.service.
Connection to h700.local closed by remote host.
Connection to h700.local closed.
```