### PR TITLE
rocknix-fake-suspend - use pactl for mute / unmute

### DIFF
--- a/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -94,12 +94,12 @@ display_on() {
 
 mute_audio() {
   ${DEBUG} && log $0 "Mute audio"
-  wpctl set-mute @DEFAULT_AUDIO_SINK@ 1
+  pactl set-sink-mute @DEFAULT_SINK@ true
 }
 
 unmute_audio() {
   ${DEBUG} && log $0 "Unmute audio"
-  wpctl set-mute @DEFAULT_AUDIO_SINK@ 0
+  pactl set-sink-mute @DEFAULT_SINK@ false
 }
 
 park_cores() {


### PR DESCRIPTION
`wpctl` is not playing nice on the OGU. Figuring that out is a problem for another day, but using `pactl` instead works fine.

Tested on my OGU and RG34XX SP.