### PR TITLE
gpudriver - remove unnecessary dependencies

### DIFF
--- a/packages/graphics/gpudriver/package.mk
+++ b/packages/graphics/gpudriver/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION=""
 PKG_LICENSE="GPLv2"
 PKG_SITE=""
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain mesa vulkan-tools"
+PKG_DEPENDS_TARGET=""
 PKG_TOOLCHAIN="manual"
 PKG_LONGDESC="GPU driver util for switching between panfrost / panthor and libmali / libmali-vulkan"
 


### PR DESCRIPTION
Build tested S922X and RK3588 ok.

I have no build env for RK3326 / RK3566 at the moment, but to check I did:
```
DEVICE=<RK3326/RK3566/RK3588/S922X> ./tools/viewplan | grep vulkan
```
`vulkan-tools` package was no longer pulled into the build for RK3326 / RK3566, and was pulled into the build for S922X / RK3588.