### PR TITLE
Add support FriendlyElec NanoPi R6C and R6S (RK3588S)

### DIFF
--- a/projects/Rockchip/bootloader/dtb.xml
+++ b/projects/Rockchip/bootloader/dtb.xml
@@ -53,5 +53,7 @@
     <file>rk3588s-retro-lite-cm5</file>
     <file>rk3588s-retroled-cm5</file>
     <file>rk3588s-rock-5a</file>
+    <file>rk3588s-nanopi-r6c</file>
+    <file>rk3588s-nanopi-r6s</file>
   </RK3588>
 </dtb>


### PR DESCRIPTION
Please add support FriendlyElec NanoPi R6C and R6S.
These device have Rockchip RK3588S.

There are these device tree source contained in latest ROCKNIX build tree already.
So just only add these device tree in projects/Rockchip/bootloader/dtb.xml.

I confirmed to build with this modification and to start linux/ES/NESgame on my R6C.
![IMG_5711](https://github.com/user-attachments/assets/34dd2995-0539-4e9c-8cb1-29dca212e09e)


Note.
I can't confirm R6S because I have no R6S sorry.

Thanks
ASAI, Shigeaki