### PR TITLE
Bump box64 and wine

### DIFF
--- a/packages/compat/box64/package.mk
+++ b/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="v0.3.4"
+PKG_VERSION="v0.3.6"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"

--- a/packages/compat/wine/package.mk
+++ b/packages/compat/wine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="10.7"
+PKG_VERSION="10.8"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 # Use the amd64 release as it supports running both 32-bit and 64-bit windows apps


### PR DESCRIPTION
Tested on my Gameforce ACE - box64 0.3.6 is fine, wine 10.8 is fine.

Wine 10.9 and 10.10 does not work, no display:
```
Failed creating base context during opening of kernel driver.
Failed creating base context during opening of kernel driver.
Kernel module may not have been loaded
Kernel module may not have been loaded
```

I suspect it is the `EGL library support available to all graphics drivers.` change in Wine 10.9 that breaks rendering.