### PR TITLE
S922X - add devicetree overlay to limit GPU clocks

### DIFF
--- a/packages/kernel/device-tree-overlays/sources/S922X/gpu-underclock.dts
+++ b/packages/kernel/device-tree-overlays/sources/S922X/gpu-underclock.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    fragment@0 {
+        target = <&gpu_opp_table>;
+        __overlay__ {
+            // Disable 800 Mhz frequency
+            opp-799999987 {
+                status = "disabled";
+            };
+        };
+    };
+};

--- a/packages/ui/emulationstation/package.mk
+++ b/packages/ui/emulationstation/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="b8a940b8b4ab312bdb6333425f8e0e8dd180afa5"
+PKG_VERSION="1fcadf978a0cac95052397f2369ba14f1a55e09f"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
Tested on my OGU:

```
S922X:~ # cat /sys/bus/platform/devices/ffe40000.gpu_mali_vulkan/devfreq/ffe40000.gpu_mali_vulkan/available_frequencies 
666666656 499999992 399999994
```