### PR TITLE
Add missing zmusic depend

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/gzdoom-sa/zmusic/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/gzdoom-sa/zmusic/package.mk
@@ -8,7 +8,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ZDoom/ZMusic"
 PKG_URL="https://github.com/ZDoom/ZMusic/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain"
-PKG_DEPENDS_TARGET="toolchain zmusic:host"
+PKG_DEPENDS_TARGET="toolchain zmusic:host glib"
 PKG_LONGDESC="GZDoom's music system as a standalone library"
 PKG_TOOLCHAIN="cmake-make"
 


### PR DESCRIPTION
Got a failure that glib was missing for zmusic, this should fix it. 