### PR TITLE
Add Rocknix screenshot app

### DIFF
--- a/projects/ROCKNIX/packages/apps/rocknix-screenshot/package.mk
+++ b/projects/ROCKNIX/packages/apps/rocknix-screenshot/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="rocknix-screenshot"
+PKG_VERSION="1.0"
+PKG_LICENSE="GPLv2"
+PKG_SITE=""
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain grim jq sway"
+PKG_LONGDESC="ROCNIX screenshot utility"
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+  :
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp -rf ${PKG_DIR}/sources/rocknix-screenshot ${INSTALL}/usr/bin
+  chmod +x ${INSTALL}/usr/bin/rocknix-screenshot
+}

--- a/projects/ROCKNIX/packages/apps/rocknix-screenshot/sources/rocknix-screenshot
+++ b/projects/ROCKNIX/packages/apps/rocknix-screenshot/sources/rocknix-screenshot
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+# Disable rocknix-screenshot while retroarch is running
+if pgrep -f "retroarch" > /dev/null; then
+    echo "RetroArch is running, skipping screenshot."
+    exit 1
+fi
+
+# Folder to save screenshots
+SAVE_DIR="/storage/roms/screenshots"
+
+# Create the folder if it doesn't exist
+mkdir -p "$SAVE_DIR"
+
+# Generate a timestamped filename
+FILENAME="$(date +'%Y-%m-%d-%H%M%S').png"
+FULL_PATH="${SAVE_DIR}/${FILENAME}"
+
+# Get focused window geometry
+GEOMETRY=$(swaymsg -t get_tree | jq -r '
+  ..
+  | select(.type? == "con" and .focused == true)
+  | "\(.rect.x),\(.rect.y) \(.rect.width)x\(.rect.height)"'
+)
+
+# Take screenshot of the focused window
+grim -g "$GEOMETRY" "$FULL_PATH"
+
+echo "Screenshot saved to $FULL_PATH"
+

--- a/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -67,6 +67,8 @@ FUNCTION_HOTKEY_A_EVENT='*('${BTN_HOTKEY_A_MODIFIER}'), value *'
 FUNCTION_HOTKEY_B_EVENT='*('${BTN_HOTKEY_B_MODIFIER}'), value *'
 FUNCTION_HOTKEY_C_EVENT='*('${BTN_HOTKEY_C_MODIFIER}'), value *'
 
+FUNCTION_HOTKEY_BTN_EAST_EVENT="*(BTN_EAST), value 1*"
+
 FUNCTION_HOTKEY_TOUCH_EVENT="*(BTN_TOUCH), value 1*"
 
 TOUCHSCREEN_EVENTS=$(get_setting key.touchscreen.events)
@@ -365,6 +367,12 @@ set +e
         if [ "${FN_A_PRESSED}" = true ] && [ "${TOUCHSCREEN_EVENTS}" = true ]; then
           ${DEBUG} && log $0 "${FUNCTION_HOTKEY_TOUCH_EVENT}: Toggle Touchscreen Keyboard"
           kill -34 $(pidof wvkbd-mobintl)
+        fi
+      ;;
+      (${FUNCTION_HOTKEY_BTN_EAST_EVENT})
+        if [ "${FN_A_PRESSED}" = true ]; then
+          ${DEBUG} && log $0 "${FUNCTION_HOTKEY_BTN_EAST_EVENT}: Screenshot Taken"
+          /usr/bin/rocknix-screenshot
         fi
       ;;
     esac

--- a/projects/ROCKNIX/packages/virtual/swaywm-env/package.mk
+++ b/projects/ROCKNIX/packages/virtual/swaywm-env/package.mk
@@ -11,5 +11,5 @@ PKG_LONGDESC="swaywm-env: Sway window manager environment"
 
 if [ ! "${BASE_ONLY}" = "true" ]
 then
-  PKG_DEPENDS_TARGET+=" sway wlr-randr swayimg"
+  PKG_DEPENDS_TARGET+=" sway wlr-randr swayimg rocknix-screenshot"
 fi


### PR DESCRIPTION
Hotkey enable + button east, allows users to take screenshots anywhere in the ui or any game.

Disabled while retroarch is running so you can still use RA's screenshot utility. 