### PR TITLE
Build mame2010/2015 & flycast lr single threaded

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/flycast-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/flycast-lr/package.mk
@@ -10,6 +10,7 @@ PKG_DEPENDS_TARGET="toolchain zlib libzip"
 PKG_LONGDESC="Flycast is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator"
 PKG_TOOLCHAIN="cmake"
 PKG_PATCH_DIRS+=" ${DEVICE}"
+PKG_BUILD_FLAGS="-parallel"
 
 if [ "${OPENGL_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL} glu libglvnd"

--- a/projects/ROCKNIX/packages/emulators/libretro/mame2010-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/mame2010-lr/package.mk
@@ -26,7 +26,7 @@ PKG_SITE="https://github.com/libretro/mame2010-libretro"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Late 2010 version of MAME (0.139) for libretro. Compatible with MAME 0.139 romsets."
-
+PKG_BUILD_FLAGS="-parallel"
 PKG_TOOLCHAIN="make"
 
 make_target() {

--- a/projects/ROCKNIX/packages/emulators/libretro/mame2015-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/mame2015-lr/package.mk
@@ -25,7 +25,7 @@ PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Late 2014/Early 2015 version of MAME (0.160-ish) for libretro. Compatible with MAME 0.160 romsets."
 PKG_TOOLCHAIN="make"
-PKG_BUILD_FLAGS="-lto"
+PKG_BUILD_FLAGS="-lto -parallel"
 
 pre_make_target() {
   export REALCC=${CC}


### PR DESCRIPTION
If not they tend to fail when building the whole BR. This resolves those failures, as they always built fine manually.