### PR TITLE
Fixed rclone parameter conflicts and added file-level logging

### DIFF
--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_backup
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_backup
@@ -277,8 +277,8 @@ load_config() {
     done
     log_message "Options array has ${#RCLONE_OPTS_ARRAY[@]} elements" "false"
     
-    # Create a version without the --delete-excluded flag
-    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
+    # Create a version without the --delete-excluded flag and without verbose flags
+    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//' | sed 's/--verbose//' | sed 's/-v//')
     
     log_message "Configuration loaded successfully" "false"
 }
@@ -377,16 +377,17 @@ backup_game_saves() {
     
     # Set log level to DEBUG when INFO is selected for more verbose logging
     local rclone_debug=""
-    local filtered_opts=("${RCLONE_OPTS_ARRAY[@]}")
+    # Always filter out --verbose and -v to avoid conflicts with --log-level
+    local filtered_opts=()
+    for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
+        if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
+            filtered_opts+=("$opt")
+        fi
+    done
+    
+    # Add debug logging if LOG_LEVEL is INFO
     if [ "${LOG_LEVEL}" == "INFO" ]; then
-        rclone_debug="--log-level DEBUG"
-        # Remove --verbose from options to avoid conflict with --log-level
-        filtered_opts=()
-        for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
-            if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
-                filtered_opts+=("$opt")
-            fi
-        done
+        rclone_debug="--log-level INFO"
     fi
     
     # Build the complete options array

--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_restore
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_restore
@@ -344,7 +344,7 @@ load_config() {
         RCLONE_OPTS_ARRAY+=("$opt")
     done
     log_message "Options array has ${#RCLONE_OPTS_ARRAY[@]} elements" "false"
-    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
+    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//' | sed 's/--verbose//' | sed 's/-v//')
     log_message "Configuration loaded successfully" "false"
 }
 
@@ -431,16 +431,17 @@ restore_game_saves() {
     
     # Set log level to DEBUG when INFO is selected for more verbose logging
     local rclone_debug=""
-    local filtered_opts=("${RCLONE_OPTS_ARRAY[@]}")
+    # Always filter out --verbose and -v to avoid conflicts with --log-level
+    local filtered_opts=()
+    for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
+        if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
+            filtered_opts+=("$opt")
+        fi
+    done
+    
+    # Add debug logging if LOG_LEVEL is INFO
     if [ "${LOG_LEVEL}" == "INFO" ]; then
-        rclone_debug="--log-level DEBUG"
-        # Remove --verbose from options to avoid conflict with --log-level
-        filtered_opts=()
-        for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
-            if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
-                filtered_opts+=("$opt")
-            fi
-        done
+        rclone_debug="--log-level INFO"
     fi
     
     # Build the complete options array
@@ -519,7 +520,7 @@ restore_system_files() {
             "--progress"
             "--log-file" "/var/log/cloud_sync.log"
             "--filter-from" "/storage/.config/cloud_sync-rules.txt"
-            "--verbose"
+            "--log-level" "INFO"
             "--include" "/backup/*.zip"
             "--include" "backup/*.zip"
             "--stats-one-line"

--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_sync.conf
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_sync.conf
@@ -32,8 +32,7 @@ LOG_LEVEL="INFO"
 RCLONEOPTS="--progress \
 --log-file /var/log/cloud_sync.log \
 --filter-from /storage/.config/cloud_sync-rules.txt \
---delete-excluded \
---verbose"
+--delete-excluded"
 
 # Backup Options
 # -------------

--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_sync.conf.defaults
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_sync.conf.defaults
@@ -32,8 +32,7 @@ DEFAULT_LOG_LEVEL="INFO"
 DEFAULT_RCLONEOPTS="--progress \
 --log-file /var/log/cloud_sync.log \
 --filter-from /storage/.config/cloud_sync-rules.txt \
---delete-excluded \
---verbose"
+--delete-excluded"
 
 # Backup Options
 # -------------


### PR DESCRIPTION
- Removed `--verbose` flags from configuration templates to prevent conflicts
- Filtered `--verbose`/`-v` flags in runtime to avoid `Can't set -v and --log-level` error
- Added file-level detail logging using `--log-level` INFO instead of `--verbose`
- Updated both `cloud_backup` and `cloud_restore` scripts consistently

Fixes rclone error: `Can't set -v and --log-level` by removing conflicting verbose flags from default configurations and implementing proper runtime filtering while enhancing file-level output detail.