### PR TITLE
Disable core dumps

### DIFF
--- a/projects/ROCKNIX/packages/sysutils/busybox/sysctl.d/99-coredump.conf
+++ b/projects/ROCKNIX/packages/sysutils/busybox/sysctl.d/99-coredump.conf
@@ -1,1 +1,2 @@
-kernel.core_pattern=/storage/.cache/cores/core.%E.%t.%p
+# Disable core dumps
+kernel.core_pattern=|/bin/false


### PR DESCRIPTION
Borrowed from Arch wiki: https://wiki.archlinux.org/title/Core_dump

Tested when `bluetoothctl` was segfaulting, no core dumps produced.