### PR TITLE
Hypseus-Singe option to override controller autoconfig function

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/hypseus-singe/sources/start_hypseus.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/hypseus-singe/sources/start_hypseus.sh
@@ -13,7 +13,7 @@ configfile="${config}/hypinput.ini"
 # Attempt to auto configure gamepad
 #
 # Looking for override file to bypass auto configure gamepad
-if [ -f "${config}/hypinput.override.ini" ]; then
+if [[ -f "${config}/hypinput.override.ini" ]]; then
     cp -rf "${config}/hypinput.override.ini" "${configfile}"
 else
     GAMEPADINFO="$(sdljoytest -skip_loop)"

--- a/projects/ROCKNIX/packages/emulators/standalone/hypseus-singe/sources/start_hypseus.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/hypseus-singe/sources/start_hypseus.sh
@@ -12,67 +12,72 @@ configfile="${config}/hypinput.ini"
 
 # Attempt to auto configure gamepad
 #
-GAMEPADINFO="$(sdljoytest -skip_loop)"
-#JOYGUID=$(echo "${GAMEPADINFO}" | grep "Joystick 0 Guid " | sed "s|Joystick 0 Guid ||")
-JOYNAME=$(echo "${GAMEPADINFO}" | grep "Joystick 0 name " | sed "s|Joystick 0 name ||" | sed "s|'||g")
-#
+# Looking for override file to bypass auto configure gamepad
+if [ -f "${config}/hypinput.override.ini" ]; then
+    cp -rf "${config}/hypinput.override.ini" "${configfile}"
+else
+    GAMEPADINFO="$(sdljoytest -skip_loop)"
+    #JOYGUID=$(echo "${GAMEPADINFO}" | grep "Joystick 0 Guid " | sed "s|Joystick 0 Guid ||")
+    JOYNAME=$(echo "${GAMEPADINFO}" | grep "Joystick 0 name " | sed "s|Joystick 0 name ||" | sed "s|'||g")
+    #
 
-for file in /usr/share/libretro/autoconfig/*.cfg; do
-    GAMEPAD=$(cat "$file" | grep input_device | cut -d'"' -f 2)
-    if [ "${JOYNAME}" == "${GAMEPAD}" ]; then
-        GPFILE="${file}"
-        # Other keys to consider KEY_SCREENSHOT KEY_QUIT KEY_PAUSE
-        for key in KEY_UP KEY_DOWN KEY_LEFT KEY_RIGHT KEY_BUTTON1 KEY_BUTTON2 KEY_BUTTON3 KEY_START1 KEY_COIN1; do
-            case ${key} in
-            "KEY_UP")
-                button=$(cat "${GPFILE}" | grep -E 'input_up_btn' | cut -d '"' -f2)
-                keyboard="1073741906 0"
-                ;;
-            "KEY_DOWN")
-                button=$(cat "${GPFILE}" | grep -E 'input_down_btn' | cut -d '"' -f2)
-                keyboard="1073741905 0"
-                ;;
-            "KEY_LEFT")
-                button=$(cat "${GPFILE}" | grep -E 'input_left_btn' | cut -d '"' -f2)
-                keyboard="1073741904 0"
-                ;;
-            "KEY_RIGHT")
-                button=$(cat "${GPFILE}" | grep -E 'input_right_btn' | cut -d '"' -f2)
-                keyboard="1073741903 0"
-                ;;
-            "KEY_BUTTON1")
-                button=$(cat "${GPFILE}" | grep -E 'input_a_btn' | cut -d '"' -f2)
-                keyboard="1073742048 0"
-                ;;
-            "KEY_BUTTON2")
-                button=$(cat "${GPFILE}" | grep -E 'input_b_btn' | cut -d '"' -f2)
-                keyboard="1073742050 0"
-                ;;
-            "KEY_BUTTON3")
-                button=$(cat "${GPFILE}" | grep -E 'input_x_btn' | cut -d '"' -f2)
-                keyboard="32 0"
-                ;;
-            "KEY_START1")
-                button=$(cat "${GPFILE}" | grep -E 'input_start_btn' | cut -d '"' -f2)
-                keyboard="49 0"
-                ;;
-            "KEY_COIN1")
-                button=$(cat "${GPFILE}" | grep -E 'input_select_btn' | cut -d '"' -f2)
-                keyboard="53 54"
-                ;;
-            esac
+    for file in /usr/share/libretro/autoconfig/*.cfg; do
+        GAMEPAD=$(cat "$file" | grep input_device | cut -d'"' -f 2)
+        if [ "${JOYNAME}" == "${GAMEPAD}" ]; then
+            GPFILE="${file}"
+            # Other keys to consider KEY_SCREENSHOT KEY_QUIT KEY_PAUSE
+            for key in KEY_UP KEY_DOWN KEY_LEFT KEY_RIGHT KEY_BUTTON1 KEY_BUTTON2 KEY_BUTTON3 KEY_START1 KEY_COIN1; do
+                case ${key} in
+                "KEY_UP")
+                    button=$(cat "${GPFILE}" | grep -E 'input_up_btn' | cut -d '"' -f2)
+                    keyboard="1073741906 0"
+                    ;;
+                "KEY_DOWN")
+                    button=$(cat "${GPFILE}" | grep -E 'input_down_btn' | cut -d '"' -f2)
+                    keyboard="1073741905 0"
+                    ;;
+                "KEY_LEFT")
+                    button=$(cat "${GPFILE}" | grep -E 'input_left_btn' | cut -d '"' -f2)
+                    keyboard="1073741904 0"
+                    ;;
+                "KEY_RIGHT")
+                    button=$(cat "${GPFILE}" | grep -E 'input_right_btn' | cut -d '"' -f2)
+                    keyboard="1073741903 0"
+                    ;;
+                "KEY_BUTTON1")
+                    button=$(cat "${GPFILE}" | grep -E 'input_a_btn' | cut -d '"' -f2)
+                    keyboard="1073742048 0"
+                    ;;
+                "KEY_BUTTON2")
+                    button=$(cat "${GPFILE}" | grep -E 'input_b_btn' | cut -d '"' -f2)
+                    keyboard="1073742050 0"
+                    ;;
+                "KEY_BUTTON3")
+                    button=$(cat "${GPFILE}" | grep -E 'input_x_btn' | cut -d '"' -f2)
+                    keyboard="32 0"
+                    ;;
+                "KEY_START1")
+                    button=$(cat "${GPFILE}" | grep -E 'input_start_btn' | cut -d '"' -f2)
+                    keyboard="49 0"
+                    ;;
+                "KEY_COIN1")
+                    button=$(cat "${GPFILE}" | grep -E 'input_select_btn' | cut -d '"' -f2)
+                    keyboard="53 54"
+                    ;;
+                esac
 
-            # if the button is in fact a hat extract the number, else use the button number+1
-            if [[ "${button}" == "h"* ]]; then
-                button="0 ${button:1:1}"
-            else
-                button="$((${button} + 1))"
-            fi
+                # if the button is in fact a hat extract the number, else use the button number+1
+                if [[ "${button}" == "h"* ]]; then
+                    button="0 ${button:1:1}"
+                else
+                    button="$((${button} + 1))"
+                fi
 
-            sed -i "s|${key}.*|${key} = ${keyboard} ${button} |" ${configfile}
-        done
-    fi
-done # finish auto gamepad
+                sed -i "s|${key}.*|${key} = ${keyboard} ${button} |" ${configfile}
+            done
+        fi
+    done # finish auto gamepad
+fi # finish bypass auto gamepad
 
 if [[ -f "${dir}/${name}.commands" ]]; then
     params=$(<"${dir}/${name}.commands")


### PR DESCRIPTION
By adding an IF statement to look for an override configuration file, it will skip the "autoconfig gamepad" and use the override configuration file for the gamepad settings.

By default, any game launched that uses the standalone Hypseus-Singe application runs an "autoconfig gamepad" upon launch. This automatically overwrites any custom config you may have placed under config\game\configs\hypseus. As an example, the autoconfig feature kept assigning credit to my left trigger and I wanted it to be the select button, etc.  If you want to specify your own controller configuration settings for Hypseus-Singe, you can place a file called "hypinput.override.ini" into the config\game\configs\hypseus folder which will allow you to use a custom file to force your controller settings to remain specifically for Hypseus-Singe.

