### PR TITLE
Update rclone package version and refine backup/restore scripts

### DIFF
--- a/projects/ROCKNIX/packages/network/rclone/package.mk
+++ b/projects/ROCKNIX/packages/network/rclone/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Xargon (https://github.com/XargonWan)
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2025 ROCKNIX Team (https://github.com/ROCKNIX)
 
 PKG_NAME="rclone"
-PKG_VERSION="1.69.1"
+PKG_VERSION="1.70.3"
 PKG_DEPENDS_TARGET="toolchain fuse rsync"
 PKG_LONGDESC="rsync for cloud storage"
 PKG_TOOLCHAIN="manual"

--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_backup
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_backup
@@ -277,8 +277,8 @@ load_config() {
     done
     log_message "Options array has ${#RCLONE_OPTS_ARRAY[@]} elements" "false"
     
-    # Create a version without the --delete-excluded flag and without verbose flags
-    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//' | sed 's/--verbose//' | sed 's/-v//')
+    # Create a version without the --delete-excluded flag for restore operations
+    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
     
     log_message "Configuration loaded successfully" "false"
 }
@@ -375,15 +375,9 @@ backup_game_saves() {
     log_message "Ensuring remote sync path exists: ${REMOTENAME}${SYNCPATH}" "false"
     rclone mkdir "${REMOTENAME}${SYNCPATH}" 2>/dev/null
     
-    # Set log level to DEBUG when INFO is selected for more verbose logging
+    # Set log level to DEBUG when INFO is selected for enhanced logging
     local rclone_debug=""
-    # Always filter out --verbose and -v to avoid conflicts with --log-level
-    local filtered_opts=()
-    for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
-        if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
-            filtered_opts+=("$opt")
-        fi
-    done
+    local filtered_opts=("${RCLONE_OPTS_ARRAY[@]}")
     
     # Add debug logging if LOG_LEVEL is INFO
     if [ "${LOG_LEVEL}" == "INFO" ]; then
@@ -413,7 +407,6 @@ backup_game_saves() {
         "--exclude=backups/**"
         "--exclude=bios/**"
         "--exclude=*.zip"
-        "--verbose"
     )
 
     # Execute rclone with enhanced error handling

--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_restore
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_restore
@@ -344,7 +344,7 @@ load_config() {
         RCLONE_OPTS_ARRAY+=("$opt")
     done
     log_message "Options array has ${#RCLONE_OPTS_ARRAY[@]} elements" "false"
-    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//' | sed 's/--verbose//' | sed 's/-v//')
+    RESTORE_RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--delete-excluded//')
     log_message "Configuration loaded successfully" "false"
 }
 
@@ -429,15 +429,9 @@ restore_game_saves() {
         mkdir -p "${RESTOREPATH}"
     fi
     
-    # Set log level to DEBUG when INFO is selected for more verbose logging
+    # Set log level to DEBUG when INFO is selected for enhanced logging
     local rclone_debug=""
-    # Always filter out --verbose and -v to avoid conflicts with --log-level
-    local filtered_opts=()
-    for opt in "${RCLONE_OPTS_ARRAY[@]}"; do
-        if [ "$opt" != "--verbose" ] && [ "$opt" != "-v" ]; then
-            filtered_opts+=("$opt")
-        fi
-    done
+    local filtered_opts=("${RCLONE_OPTS_ARRAY[@]}")
     
     # Add debug logging if LOG_LEVEL is INFO
     if [ "${LOG_LEVEL}" == "INFO" ]; then

--- a/projects/ROCKNIX/packages/network/rclone/sources/rsync.conf
+++ b/projects/ROCKNIX/packages/network/rclone/sources/rsync.conf
@@ -15,7 +15,7 @@ SYNCPATH="GAMES"
 BACKUPPATH="/storage/roms"
 
 ### This allows changes to the rsync options for cloud_backup
-# Options: -r (recursive), -a (archive), -i (itemize changes), -v (verbose)
+# Options: -r (recursive), -a (archive), -i (itemize changes)
 RSYNCOPTSBACKUP="-raiv --prune-empty-dirs"
 
 ### This allows changes to the rsync options for cloud_restore


### PR DESCRIPTION
There was an issue with using both the `--verbose` flag and `--log-level` flag in the same call. Since log levels produce the same info, and --progress gives plenty of feedback to the user, I've removed the `--verbose` flag completely.

I also bumped rclone to the latest version: 1.70.3.