### PR TITLE
rclone `post-update` fix

### DIFF
--- a/projects/ROCKNIX/packages/network/rclone/sources/post-update
+++ b/projects/ROCKNIX/packages/network/rclone/sources/post-update
@@ -20,5 +20,13 @@ else
     rsync --ignore-existing /usr/config/cloud_sync.conf /storage/.config/
     # Always update defaults file to ensure latest version is available for reference
     rsync /usr/config/cloud_sync.conf.defaults /storage/.config/
+    
+    # Remove conflicting --verbose flags from existing user config to prevent parameter conflicts
+    if [ -f "/storage/.config/cloud_sync.conf" ]; then
+      sed -i 's/--verbose//g' /storage/.config/cloud_sync.conf
+      sed -i 's/-v / /g' /storage/.config/cloud_sync.conf
+      # Clean up any double spaces left by removal
+      sed -i 's/  \+/ /g' /storage/.config/cloud_sync.conf
+    fi
   fi
 fi


### PR DESCRIPTION
Fixed a bug where users upgrading weren't getting the fix applied. I had to modify the `post-update` file to finally get it to work.

- Remove conflicting --verbose flags from existing user configs during updates
- Prevents 'Can't set -v and --log-level' errors on systems with old configs
- Uses sed to clean up --verbose, -v flags and normalize spacing
- Addresses upgrade scenario where rsync --ignore-existing prevents config updates