### PR TITLE
rk3566: delay sd2

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/patches/linux/0024-sdmmc1-card-detect-delay.patch
+++ b/projects/ROCKNIX/devices/RK3566/patches/linux/0024-sdmmc1-card-detect-delay.patch
@@ -1,0 +1,24 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
+index 233eade30f21..54616b26fb1b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-anbernic-rgxx3.dtsi
+@@ -609,6 +609,7 @@ &sdmmc0 {
+ &sdmmc1 {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
++	card-detect-delay = <800>;
+ 	cd-gpios = <&gpio2 RK_PB2 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+ 	pinctrl-0 = <&sdmmc1_bus4 &sdmmc1_cmd &sdmmc1_clk &sdmmc1_det>;
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
+index bd332714a023..cdaa88c5f2da 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
+@@ -755,6 +755,7 @@ &sdmmc0 {
+ &sdmmc1 {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
++	card-detect-delay = <800>;
+ 	cd-gpios = <&gpio2 RK_PB2 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+ 	pinctrl-0 = <&sdmmc1_bus4 &sdmmc1_cmd &sdmmc1_clk &sdmmc1_det>;


### PR DESCRIPTION
Delay sd2 as is done on bsp and on other boards in mainline.