### PR TITLE
gamesupport - rocknix-touchscreen-keyboard - sway only

### DIFF
--- a/projects/ROCKNIX/packages/virtual/gamesupport/package.mk
+++ b/projects/ROCKNIX/packages/virtual/gamesupport/package.mk
@@ -7,7 +7,10 @@ PKG_SITE="https://rocknix.org"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Game support software metapackage."
 
-PKG_GAMESUPPORT="sixaxis rocknix-hotkey jstest-sdl gamecontrollerdb sdljoytest sdltouchtest control-gen rocknix-touchscreen-keyboard mangohud"
+PKG_GAMESUPPORT="sixaxis rocknix-hotkey jstest-sdl gamecontrollerdb sdljoytest sdltouchtest control-gen mangohud"
+
+# rocknix-touchscreen-keyboard requires sway
+[[ "${WINDOWMANAGER}" = "swaywm-env" ]] && PKG_GAMESUPPORT+=" rocknix-touchscreen-keyboard"
 
 PKG_DEPENDS_TARGET="${PKG_GAMESUPPORT}"
 

--- a/projects/ROCKNIX/packages/wayland/weston11/package.mk
+++ b/projects/ROCKNIX/packages/wayland/weston11/package.mk
@@ -7,7 +7,7 @@ PKG_VERSION="11.0.3"
 PKG_LICENSE="MIT"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/weston/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libxcb-cursor libinput pipewire cairo pango libjpeg-turbo dbus seatd glu mesa libX11 xwayland libXcursor xkbcomp setxkbmap cairo xterm"
+PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libxcb-cursor libinput pipewire cairo pango libjpeg-turbo dbus seatd glu mesa libX11 xwayland libXcursor xkbcomp setxkbmap cairo xterm libthai"
 PKG_LONGDESC="Reference implementation of a Wayland compositor"
 PKG_PATCH_DIRS+="${DEVICE}"
 


### PR DESCRIPTION
Log spam on S922X with touchscreen keyboard service dying and restarting over and over: https://discord.com/channels/948029830325235753/1176191834331021422/1405419411103420530

Tested with builds for S922X and SM8550, correctly pulls in `rocknix-touchscreen-keyboard` for SM8550 but not for S922X.

Tested on my OGU.