### PR TITLE
weston - add libthai dep

### DIFF
--- a/projects/ROCKNIX/packages/wayland/weston/package.mk
+++ b/projects/ROCKNIX/packages/wayland/weston/package.mk
@@ -7,7 +7,7 @@ PKG_VERSION="14.0.1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/weston/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libxcb-cursor libinput cairo pango libjpeg-turbo dbus seatd glu ${OPENGL} libX11 xwayland libXcursor xkbcomp setxkbmap cairo xterm libwebp"
+PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libxkbcommon libxcb-cursor libinput cairo pango libjpeg-turbo dbus seatd glu ${OPENGL} libX11 xwayland libXcursor xkbcomp setxkbmap cairo xterm libwebp libthai"
 PKG_LONGDESC="Reference implementation of a Wayland compositor"
 PKG_PATCH_DIRS+="${DEVICE}"
 


### PR DESCRIPTION
Similarly to weston 11, fixes error `Failed to load module: libthai.so.0: cannot open shared object file: No such file or directory` when starting weston 14.

Tested on my RG34XXSP.