### PR TITLE
Fix mpv resolution

### DIFF
--- a/projects/ROCKNIX/packages/multimedia/mpv/scripts/start_mplayer.sh
+++ b/projects/ROCKNIX/packages/multimedia/mpv/scripts/start_mplayer.sh
@@ -10,16 +10,11 @@ systemctl start mpv
 FBWIDTH="$(fbwidth)"
 FBHEIGHT="$(fbheight)"
 
-ASPECT=$(printf "%.2f" $(echo "(${FBWIDTH} / ${FBHEIGHT})" | bc -l))
-
-case ${ASPECT} in
-  1.*)
-   RES="${FBWIDTH}x${FBHEIGHT}"
-  ;;
-  0.*)
-   RES="${FBHEIGHT}x${FBWIDTH}"
-  ;;
-esac
+if [[ ${FBWIDTH} -ge ${FBHEIGHT} ]]; then
+  RES="${FBWIDTH}x${FBHEIGHT}"
+else
+  RES="${FBHEIGHT}x${FBWIDTH}"
+fi
 
 /usr/bin/mpv --fullscreen --geometry=${RES} --hwdec=auto-safe --input-gamepad=yes --input-ipc-server=/tmp/mpvsocket "${1}"
 systemctl stop mpv


### PR DESCRIPTION
Aspect ratio calculation resulted in 0.00 on RG28xx which lead to the wrong resolution being set.
Direct comparision between values simplifies the code as well.