### PR TITLE
Update libretro core for Final Burn Neo (v1.0.0.3, commit 4aa5e5b, Aug 30, 2025)

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 # Maintenance 2020 351ELEC team (https://github.com/fewtarius/351ELEC)
-# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="fbneo-lr"
-PKG_VERSION="87f78d3408c248b7bbfbcba2cffc5382b3060fa9"
+PKG_VERSION="4aa5e5b8ef4fc94143680fda8c598839bb336bdc"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/FBNeo"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
-PKG_LONGDESC="Port of Final Burn Neo to Libretro (v0.2.97.38)."
+PKG_LONGDESC="Port of Final Burn Neo to Libretro (v1.0.0.3 development build)."
 PKG_TOOLCHAIN="make"
 
 


### PR DESCRIPTION
Hi! I updated the Final Burn Neo core to the latest version. I only tested it on an RG351v, and it works great. Paprium is playable...

Greetings!

<img width="320" height="224" alt="paprium-250831-141313" src="https://github.com/user-attachments/assets/1d9b0aba-fbca-4cbe-af4d-9c2a32ab26a1" />
<img width="320" height="224" alt="paprium-250831-141427" src="https://github.com/user-attachments/assets/102ef7d9-cc98-48b8-a41a-a544773c2faa" />
