### PR TITLE
Bump gamepadcalibration package to python 3.13

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/packages/gamepadcalibration/package.mk
+++ b/projects/ROCKNIX/devices/SM8250/packages/gamepadcalibration/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="gamepadcalibration"
-PKG_VERSION="973bf8c4d72068e3e2383450c76b0cb2fa078cb1"
+PKG_VERSION="2077e7af7e9a8c1df54af6f1959cb92daea03207"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/cdeletre/GPcal"
 PKG_URL="https://github.com/cdeletre/GPcal/archive/${PKG_VERSION}.tar.gz"
@@ -17,7 +17,7 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/local/share
 
-  tar -xzf ${PKG_BUILD}/rocknix/gpcal.tgz -C ${INSTALL}/usr/local/share
+  tar -xzf ${PKG_BUILD}/rocknix/gpcal-python-3.13.tgz -C ${INSTALL}/usr/local/share
   chmod 0755 ${INSTALL}/usr/local/share/gpcal/main.py
 
   mkdir -p ${INSTALL}/usr/config/modules


### PR DESCRIPTION
Here is a quick fix to make gamepadcalibration working again in nightly builds.

It's not retro compatible with python 3.11.

I can work later on a smarter package that can self adapts to the python version by building the pyxel accordingly. Another option would be to install system wide the pyxel module. To be discussed :)