### PR TITLE
portmaster - control.txt updates

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/sources/control.txt
+++ b/projects/ROCKNIX/packages/apps/portmaster/sources/control.txt
@@ -19,88 +19,87 @@ directory="roms"
 controlfolder="/$directory/ports/PortMaster"
 ESUDO=""
 ESUDOKILL="-1"
+ESUDOKILL2="-1"
 SDLDBUSERFILE="/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt"
 clibs="/usr/lib/compat/"
 raloc="/usr/bin"
 raconf="--config /storage/.config/retroarch/retroarch.cfg"
 
+[[ -f "$controlfolder/device_info.txt" ]] && source $controlfolder/device_info.txt
+[[ -f "$controlfolder/funcs.txt" ]] && source $controlfolder/funcs.txt
+
+# $param_device / $LOWRES / $ANALOG_STICKS (also set by device_info.txt) are used in port launch scripts
 case "${QUIRK_DEVICE}" in
   "Anbernic RG552")
-    profile="rg552"
-    lres="N"
-    sticks="2"
+    param_device="rg552"
+    LOWRES="N"
+    ANALOG_STICKS="2"
   ;;
   "Hardkernel ODROID-GO-Ultra"|"Powkiddy RGB10 MAX 3 Pro")
-    profile="s922x"
-    lres="N"
-    sticks="2"
+    param_device="s922x"
+    LOWRES="N"
+    ANALOG_STICKS="2"
   ;;
   "Powkiddy x55")
-    profile="x55"
-    lres="N"
-    sticks="2"
+    param_device="x55"
+    LOWRES="N"
+    ANALOG_STICKS="2"
   ;;
   "Anbernic RG351M")
-    profile="anbernic"
-    lres="Y"
-    sticks="2"
+    param_device="anbernic"
+    LOWRES="Y"
+    ANALOG_STICKS="2"
   ;;
   "Anbernic RG351V")
-    profile="anbernic"
-    lres="N"
-    sticks="1"
+    param_device="anbernic"
+    LOWRES="N"
+    ANALOG_STICKS="1"
   ;;
   "ODROID-GO Advance*"|"Powkiddy RGB10")
-    profile="oga"
-    lres="Y"
-    sticks="1"
+    param_device="oga"
+    LOWRES="Y"
+    ANALOG_STICKS="1"
   ;;
   "ODROID-GO Super")
-    profile="ogs"
-    lres="N"
-    sticks="2"
+    param_device="ogs"
+    LOWRES="N"
+    ANALOG_STICKS="2"
   ;;
   "Anbernic RG35XX H"|"Anbernic RG40XX H"|"Anbernic RG CubeXX")
-    profile="anbernic"
-    lres="N"
-    sticks="2"
+    param_device="anbernic"
+    LOWRES="N"
+    ANALOG_STICKS="2"
   ;;
   "Anbernic RG40XX V")
-    profile="anbernic"
-    lres="N"
-    sticks="1"
+    param_device="anbernic"
+    LOWRES="N"
+    ANALOG_STICKS="1"
   ;;
   "Anbernic RG35XX Plus"|"Anbernic RG35XX 2024"|"Anbernic RG28XX")
-    profile="anbernic"
-    lres="N"
-    sticks="0"
+    param_device="anbernic"
+    LOWRES="N"
+    ANALOG_STICKS="0"
   ;;
   *)
-    profile="rg552"
-    lres="N"
-    sticks="2"
+    param_device="rg552"
+    LOWRES="N"
+    ANALOG_STICKS="2"
   ;;
 esac
 
-
 get_controls() {
-
-    ANALOGSTICKS="${sticks}"
-    LOWRES="${lres}"
-
-    param_device="${profile}"
-
-    # Set file
+    # Set controller file to be generated
     export SDL_GAMECONTROLLERCONFIG_FILE="/tmp/gamecontrollerdb.txt"
 
-    # Now find any controller mapped on emulationstation...
+    # Generate controller file for controllers mapped in emulationstation
     /storage/.config/PortMaster/mapper.txt ${SDL_GAMECONTROLLERCONFIG_FILE} ${controlfolder}
 
-    # Set compatability libs and run compatability script
+    # Set compatability libs
     export LD_LIBRARY_PATH=${clibs}
 
-    # Some ports want SDL_GAMECONTROLLERCONFIG, so let's fill it in
+    # Some ports want sdl_controllerconfig (to set SDL_GAMECONTROLLERCONFIG), so let's fill it in
     sdl_controllerconfig="$(< "${SDL_GAMECONTROLLERCONFIG_FILE}")"
 }
 
+GPTOKEYB2="$ESUDO env LD_PRELOAD=$controlfolder/libinterpose.${DEVICE_ARCH}.so $controlfolder/gptokeyb2 $ESUDOKILL"
 GPTOKEYB="$ESUDO $controlfolder/gptokeyb $ESUDOKILL"


### PR DESCRIPTION
Add `device_info.txt`, `funcs.txt` and `gptokeyb2` to align with portmaster changes (https://github.com/PortsMaster/PortMaster-GUI/blob/main/PortMaster/control.txt)

This removes the need for shim at: https://github.com/PortsMaster/PortMaster-GUI/blob/main/PortMaster/mod_.txt

Tested on my Odin 2