### PR TITLE
RK3588 - mangohud

### DIFF
--- a/projects/ROCKNIX/packages/apps/mangohud/package.mk
+++ b/projects/ROCKNIX/packages/apps/mangohud/package.mk
@@ -10,6 +10,13 @@ PKG_DEPENDS_TARGET="toolchain glslang mesa Python3 wayland libxcb"
 PKG_LONGDESC="A Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more."
 PKG_PATCH_DIRS+="${DEVICE}"
 
+# RK3588 - use a fork with Mali G610 support
+if [ "${DEVICE}" = "RK3588" ]
+then
+  PKG_VERSION="58aac6c647a8a06675ddc70c337659db63847957"
+  PKG_SITE="https://github.com/Ayman-Zeyada/MangoHud"
+fi
+
 if [ "${OPENGL_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL}"
 fi

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3588/075-mangohud-supported
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3588/075-mangohud-supported
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+# Enable MangoHud support
+MANGOHUD_ENABLED=$(get_setting "rocknix.mangohud.enabled")
+if [ ! -n "${MANGOHUD_ENABLED}" ]; then
+  MANGOHUD_ENABLED="0"
+  set_setting "rocknix.mangohud.enabled" "${MANGOHUD_ENABLED}"
+fi
+
+cat <<EOF >/storage/.config/profile.d/075-mangohud-supported
+# Device Features
+DEVICE_MANGOHUD_SUPPORT="true"
+EOF

--- a/projects/ROCKNIX/packages/virtual/gamesupport/package.mk
+++ b/projects/ROCKNIX/packages/virtual/gamesupport/package.mk
@@ -10,7 +10,7 @@ PKG_LONGDESC="Game support software metapackage."
 PKG_GAMESUPPORT="sixaxis rocknix-hotkey jstest-sdl gamecontrollerdb sdljoytest sdltouchtest control-gen"
 
 case ${DEVICE} in
-  SM8250|SM8550)
+  RK3588|SM8250|SM8550)
     PKG_GAMESUPPORT+=" mangohud"
   ;;
 esac


### PR DESCRIPTION
For RK3588, use a fork with Mali G610 support added: https://github.com/Ayman-Zeyada/MangoHud

Tested with libmali and panfrost, using flycast-sa

Currently broken, segfaults with libmali, errors with panfrost: `terminate called after throwing an instance of 'std::bad_cast' what():  std::bad_cast`.