### PR TITLE
linux: fix build for rk3588

### DIFF
--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -290,6 +290,8 @@ make_target() {
           ;;
       esac
 
+      [ "${DEVICE}" != "RK3588" ] && export BUILD_BPF_SKEL=0
+
       WERROR=0 \
       NO_LIBPERL=1 \
       NO_LIBPYTHON=1 \
@@ -306,8 +308,6 @@ make_target() {
       NO_LIBPFM4=1 \
       NO_LIBBABELTRACE=1 \
       NO_CAPSTONE=1 \
-      NO_LIBPFM4=1 \
-      BUILD_BPF_SKEL=0 \
       CROSS_COMPILE="${TARGET_PREFIX}" \
       JOBS="${CONCURRENCY_MAKE_LEVEL}" \
         make ${PERF_BUILD_ARGS}


### PR DESCRIPTION
CI builds fail due to perf stuff for rk3588.  
Quickfix to leave `BUILD_BPF_SKEL` alone on rk3588.  
Works on my PC.