### PR TITLE
gpudriver - S922X - make bind mounts explicit

### DIFF
--- a/projects/ROCKNIX/packages/graphics/gpudriver/sources/bin/gpudriver
+++ b/projects/ROCKNIX/packages/graphics/gpudriver/sources/bin/gpudriver
@@ -28,13 +28,17 @@ load_driver() {
 
       case ${HW_DEVICE} in
         "S922X")
-          grep -q /usr/lib/libEGL.so /proc/mounts || find /usr/lib/mali -type f -exec bash -c 'lib={}; mount --bind $lib ${lib/\/mali\//\/}' ';'
-          grep -q /usr/lib/libEGL.so /proc/mounts || mount -o ro,bind /usr/lib/mali/libEGL.so.1.4.0 /usr/lib/libEGL.so.1.1.0
-          grep -q /usr/lib/libEGL.so /proc/mounts || mount -o ro,bind /usr/lib/mali/libGLESv1_CM.so.1.1.0 /usr/lib/libGLESv1_CM.so.1.2.0
-          # Portmaster is not ready for SDL in glesonly subdir, so override libs the dirty way
-          if [ -d /usr/lib/glesonly ]; then
-            grep -q /usr/lib/libSDL2-2.0.so /proc/mounts || find /usr/lib/glesonly -type f -exec bash -c 'lib={}; mount --bind $lib ${lib/\/glesonly\//\/}' ';'
+          # Bind mount libmali libraries if required
+          grep -q /usr/lib/libEGL.so /proc/mounts && mount_required=false || mount_required=true
+
+          if [[ $mount_required = true ]]; then
+            mount --bind /usr/lib/mali/libEGL.so.1.4.0        /usr/lib/libEGL.so.1.1.0
+            mount --bind /usr/lib/mali/libGLESv1_CM.so.1.1.0  /usr/lib/libGLESv1_CM.so.1.2.0
+            mount --bind /usr/lib/mali/libGLESv2.so.2.1.0     /usr/lib/libGLESv2.so.2.1.0
+            mount --bind /usr/lib/mali/libgbm.so.1.0.0        /usr/lib/libgbm.so.1.0.0
           fi
+
+          # Deliberately break OpenGL checks
           mount --bind /dev/null /usr/lib/libGL.so
           ;;
         *)
@@ -51,10 +55,21 @@ load_driver() {
     "panfrost")
       modprobe -r mali_kbase
       modprobe @PAN@
-      grep -q /usr/lib/libEGL.so /proc/mounts && find /usr/lib/mali -type f -exec bash -c 'lib={}; umount ${lib/\/mali\//\/}' ';'
-      if [ -d /usr/lib/glesonly ]; then
-        grep -q /usr/lib/libSDL2-2.0.so /proc/mounts && find /usr/lib/glesonly -type f -exec bash -c 'lib={}; umount ${lib/\/glesonly\//\/}' ';'
-      fi
+
+      case ${HW_DEVICE} in
+        "S922X")
+          umount /usr/lib/libEGL.so.1.1.0
+          umount /usr/lib/libGLESv1_CM.so.1.2.0
+          umount /usr/lib/libGLESv2.so.2.1.0
+          umount /usr/lib/libgbm.so.1.0.0
+          ;;
+        *)
+          grep -q /usr/lib/libEGL.so /proc/mounts && find /usr/lib/mali -type f -exec bash -c 'lib={}; umount ${lib/\/mali\//\/}' ';'
+          if [ -d /usr/lib/glesonly ]; then
+            grep -q /usr/lib/libSDL2-2.0.so /proc/mounts && find /usr/lib/glesonly -type f -exec bash -c 'lib={}; umount ${lib/\/glesonly\//\/}' ';'
+          fi
+          ;;
+      esac
       ;;
     *)
       exit 3


### PR DESCRIPTION
Makes it clear what is happening. Tested on my OGU, both libmali and panfrost drivers work fine.

Regression tested on RK3588 and RK3326.