### PR TITLE
S922X - switch from fileman to commander

### DIFF
--- a/projects/ROCKNIX/packages/misc/modules/package.mk
+++ b/projects/ROCKNIX/packages/misc/modules/package.mk
@@ -18,7 +18,7 @@ esac
 
 # Fileman or Commander Filemanager
 case ${DEVICE} in
-  SM8250|SDM845)
+  SM8250|SDM845|S922X)
     PKG_DEPENDS_TARGET+=" commander"
     FILEMANAGER="commander"
   ;;


### PR DESCRIPTION
`fileman` started having issues with `libmali-vulkan` at some point, so switch to `commander`.

Tested on my OGU, works well with both `libmali-vulkan` and `panfrost` GPU drivers.