### PR TITLE
mkimage: fix booting from 1.5tb+ drives

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -96,7 +96,7 @@ dd if="${DISK}" of="${IMG_TMP}/part2.ext4" bs=512 count=0 seek="${STORAGE_PART_C
 
 # create filesystem on part2
 echo "image: creating filesystem on part2..."
-mke2fs -F -q -t ext4 -O ^orphan_file -m 0 "${IMG_TMP}/part2.ext4"
+mke2fs -F -q -t ext4 -O ^orphan_file -m 0 -b 4096 "${IMG_TMP}/part2.ext4"
 tune2fs -L "${DISTRO_DISKLABEL}" -U ${UUID_STORAGE} "${IMG_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 e2fsck -n "${IMG_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 sync


### PR DESCRIPTION
I recommend we go back to explicitly specifying block size 4096 (which is the default for filesystems > 512 MB) or ROCKNIX will fail to boot on 1.5TB+ cards/drives. The last official release somehow got the correct standard block size of 4096, but I'm still not sure why this has changed. Newer builds are getting block size of 1024 which I've read is default for filesystems less than 512 MB (this partition is small at creation). So this restores the behavior seen in the last official release.

Notes from prior commit this was cherry-picked from:

mke2fs was using a default block size of 1kb, this caused 2tb+ drives to fail initial resizing script with the following error.

resize2fs: New size results in too many block group descriptors.