### PR TITLE
optimize: Set HOST_CFLAGS to -march=x86-64 -mtune=generic

### DIFF
--- a/config/optimize
+++ b/config/optimize
@@ -9,7 +9,7 @@ TARGET_LIBDIR="$SYSROOT_PREFIX/lib $SYSROOT_PREFIX/usr/lib"
 TARGET_INCDIR="$SYSROOT_PREFIX/include $SYSROOT_PREFIX/usr/include"
 
 HOST_CPPFLAGS=""
-HOST_CFLAGS="-march=native -O2 -Wall -pipe -I$TOOLCHAIN/include"
+HOST_CFLAGS="-march=x86-64 -mtune=generic -O2 -Wall -pipe -I$TOOLCHAIN/include"
 HOST_CXXFLAGS="$HOST_CFLAGS"
 HOST_LDFLAGS="-Wl,-rpath,$TOOLCHAIN/lib -L$TOOLCHAIN/lib"
 HOST_INCDIR="$TOOLCHAIN/include /usr/include"


### PR DESCRIPTION
Host packages compiled with -march=native, could generate AVX/AVX2 instructions causing Illegal instruction errors on different CI runners.