### PR TITLE
mkimage / fs-resize - mke2fs - ext4 usage type

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -62,7 +62,7 @@ if [ -e /storage/.please_resize_me ] ; then
     echo ""
 
     StartProgressLog spinner "Resizing partition...   " "parted -s -f -m $DISK resizepart 2 100% >>$LOG 2>&1"
-    StartProgressLog spinner "Creating file system... " "mke2fs -F -q -t ext4 -m 0 -L \"$LABEL\" -U \"$UUID\" $PART >>$LOG 2>&1"
+    StartProgressLog spinner "Creating file system... " "mke2fs -F -q -t ext4 -T ext4 -m 0 -L \"$LABEL\" -U \"$UUID\" $PART >>$LOG 2>&1"
     StartProgressLog spinner "Checking file system... " "e2fsck -f -p $PART >>$LOG 2>&1"
     StartProgress countdown "Rebooting in 15s...     " 15 "NOW"
   else

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -96,7 +96,7 @@ dd if="${DISK}" of="${IMG_TMP}/part2.ext4" bs=512 count=0 seek="${STORAGE_PART_C
 
 # create filesystem on part2
 echo "image: creating filesystem on part2..."
-mke2fs -F -q -t ext4 -O ^orphan_file -m 0 -b 4096 "${IMG_TMP}/part2.ext4"
+mke2fs -F -q -t ext4 -T ext4 -O ^orphan_file -m 0 "${IMG_TMP}/part2.ext4"
 tune2fs -L "${DISTRO_DISKLABEL}" -U ${UUID_STORAGE} "${IMG_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 e2fsck -n "${IMG_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 sync


### PR DESCRIPTION
Follow-up to: https://github.com/ROCKNIX/distribution/pull/1886

Similar to code in old buildroot: https://github.com/ROCKNIX/distribution-old/blob/fdf54964181293e2dfacf8750d2ea2a80c10d2d9/scripts/mkimage#L94

Required in 2 places in new buildroot as `mke2fs` is also used for filesystem resize.

Tested with a flash to a 32 GB SD card for my Odroid Go Advance, works ok.