### PR TITLE
sm8550/linux: Disable UFS in device tree

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0200_arm64--dts--qcom--Add-AYN-Odin2-Common.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0200_arm64--dts--qcom--Add-AYN-Odin2-Common.patch
@@ -1559,14 +1559,14 @@ index 000000000000..58d9ab342fe9
 +	vccq-max-microamp = <1200000>;
 +	vdd-hba-supply = <&vreg_l3g_1p2>;
 +
-+	status = "okay";
++	status = "disabled";
 +};
 +
 +&ufs_mem_phy {
 +	vdda-phy-supply = <&vreg_l1d_0p88>;
 +	vdda-pll-supply = <&vreg_l3e_1p2>;
 +
-+	status = "okay";
++	status = "disabled";
 +};
 +
 +&usb_1 {


### PR DESCRIPTION
Change status from 'okay' to 'disabled' for UFS devices.