### PR TITLE
S922X - mesa - remove panfrost vulkan files to fix libmali-vulkan vulkaninfo

### DIFF
--- a/projects/ROCKNIX/packages/graphics/mesa/package.mk
+++ b/projects/ROCKNIX/packages/graphics/mesa/package.mk
@@ -104,3 +104,10 @@ if [ "${VULKAN_SUPPORT}" = "yes" ]; then
 else
   PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers="
 fi
+
+post_makeinstall_target() {
+  # While this likely breaks panfrost vulkan, it does fix vulkaninfo on libmali-vulkan
+  if [ "${DEVICE}" = "S922X" ]; then
+    rm -f ${INSTALL}/usr/lib/libvulkan_panfrost.so ${INSTALL}/usr/share/vulkan/icd.d/panfrost_icd.*.json
+  fi
+}


### PR DESCRIPTION
This code was removed in a cleanup (https://github.com/ROCKNIX/distribution/commit/629e362db4933a8ae123013e03a5f9ef7d5e06ae#diff-da26322ac312f518080d2e6a5d6679cadb4da3a327800d5d13d91f9fb4deb82e) quite a while ago. With it removed emulators still work fine with libmali-vulkan, but turns out `vulkaninfo` is broken.

With this change panfrost vulkan (panvk) now has no chance of working on S922X, but it is broken anyway.

Tested on my OGU, `vulkaninfo` now works.