### PR TITLE
Fix 'quantom' typos. Fix audio fix in suspend for SM8250.

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/filesystem/usr/sbin/quantum
+++ b/projects/ROCKNIX/devices/SM8250/filesystem/usr/sbin/quantum
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2025 ROCNIX (https://github.com/ROCKNIX)
 
-# Set quantom audio hack
+# Set quantum audio hack
 
 . /etc/profile
 

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/sleep.d/post/003-audio
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/sleep.d/post/003-audio
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2025 ROCNIX (https://github.com/ROCKNIX)
 
-# Set quantom audio hack on wake
+# Set quantum audio hack on wake
 
 . /etc/profile
 
-/usr/sbin/quantom
+/usr/sbin/quantum


### PR DESCRIPTION
Thanks to @r3claimer for the original implementation. This should make sure the fix works properly out of suspend. Thanks! :D