### PR TITLE
Fix rclone --verbose conflict

### DIFF
--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_backup
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_backup
@@ -266,9 +266,17 @@ load_config() {
     RCLONEOPTS=$(echo "${RCLONEOPTS}" | tr '\n\\' '  ' | tr -s ' ')
     log_message "After newline cleanup: ${RCLONEOPTS}" "false"
     
+    # Remove conflicting --verbose and -v flags that conflict with --log-level
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--verbose//g' | sed 's/-v / /g')
+    log_message "After removing verbose flags: ${RCLONEOPTS}" "false"
+    
     # Ensure each option starts with a space (except the first one)
     RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--/ --/g' | sed 's/^ //')
     log_message "After spacing fix: ${RCLONEOPTS}" "false"
+    
+    # Clean up any double spaces left by removal
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | tr -s ' ')
+    log_message "After final cleanup: ${RCLONEOPTS}" "false"
     
     # Convert to array to ensure proper word splitting
     RCLONE_OPTS_ARRAY=()

--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_restore
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_restore
@@ -337,8 +337,18 @@ load_config() {
     log_message "Original RCLONEOPTS: ${RCLONEOPTS}" "false"
     RCLONEOPTS=$(echo "${RCLONEOPTS}" | tr '\n\\' '  ' | tr -s ' ')
     log_message "After newline cleanup: ${RCLONEOPTS}" "false"
+    
+    # Remove conflicting --verbose and -v flags that conflict with --log-level
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--verbose//g' | sed 's/-v / /g')
+    log_message "After removing verbose flags: ${RCLONEOPTS}" "false"
+    
     RCLONEOPTS=$(echo "${RCLONEOPTS}" | sed 's/--/ --/g' | sed 's/^ //')
     log_message "After spacing fix: ${RCLONEOPTS}" "false"
+    
+    # Clean up any double spaces left by removal
+    RCLONEOPTS=$(echo "${RCLONEOPTS}" | tr -s ' ')
+    log_message "After final cleanup: ${RCLONEOPTS}" "false"
+    
     RCLONE_OPTS_ARRAY=()
     for opt in ${RCLONEOPTS}; do
         RCLONE_OPTS_ARRAY+=("$opt")

--- a/projects/ROCKNIX/packages/network/rclone/sources/cloud_sync_helper
+++ b/projects/ROCKNIX/packages/network/rclone/sources/cloud_sync_helper
@@ -154,6 +154,17 @@ main() {
   update_cloud_sync_rules "${log_file}"
   update_cloud_sync_config "${log_file}"
   
+  # Remove conflicting --verbose flags from existing user config to prevent parameter conflicts
+  # This is needed for users upgrading from older versions where --verbose was used
+  if [ -f "/storage/.config/cloud_sync.conf" ]; then
+    log_to_file "${log_file}" "Removing conflicting --verbose flags from configuration"
+    sed -i 's/--verbose//g' /storage/.config/cloud_sync.conf
+    sed -i 's/-v / /g' /storage/.config/cloud_sync.conf
+    # Clean up any double spaces left by removal
+    sed -i 's/  \+/ /g' /storage/.config/cloud_sync.conf
+    log_to_file "${log_file}" "Configuration cleaned of conflicting flags"
+  fi
+  
   return 0
 }
 


### PR DESCRIPTION
PR #1747 only fixed the post-update fallback path, but most users hit the cloud_sync_helper path which was never updated. This completes the fix by:

1. Adding verbose flag removal to cloud_sync_helper (primary update path)
2. Adding runtime filtering to cloud_backup and cloud_restore scripts

The --verbose/-v flags conflict with --log-level in rclone. Now all code paths properly remove these conflicting flags.

Fixes: Incomplete fix from PR #1747