### PR TITLE
Package build updates for newer (15.x) compilers

### DIFF
--- a/projects/ROCKNIX/packages/devel/ncurses/package.mk
+++ b/projects/ROCKNIX/packages/devel/ncurses/package.mk
@@ -62,7 +62,9 @@ PKG_CONFIGURE_OPTS_TARGET="
                            --enable-lib-suffixes \
                            --disable-assertions"
 
-PKG_CONFIGURE_OPTS_HOST="--enable-termcap \
+PKG_CONFIGURE_OPTS_HOST="
+                         --without-cxx-binding \
+                         --enable-termcap \
                          --with-termlib \
                          --without-shared \
                          --enable-pc-files \

--- a/projects/ROCKNIX/packages/emulators/standalone/yabasanshiro-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/yabasanshiro-sa/package.mk
@@ -56,8 +56,10 @@ pre_configure_target() {
     aarch64)
       PKG_CMAKE_OPTS_TARGET+=" -DYAB_WANT_ARM7=ON \
                                -DYAB_WANT_DYNAREC_DEVMIYAX=ON \
-                               -DCMAKE_TOOLCHAIN_FILE=${PKG_BUILD}/yabause/src/retro_arena/n2.cmake \
+                               -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}/etc/cmake-aarch64-rocknix-linux-gnueabi.conf \
                                -DYAB_PORTS=retro_arena"
+
+      PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_PROJECT_INCLUDE=${PKG_BUILD}/yabause/src/retro_arena/n2.cmake"
     ;;
   esac
 
@@ -69,7 +71,7 @@ pre_configure_target() {
                            -DLIBPNG_LIB_DIR=${SYSROOT_PREFIX}/usr/lib \
                            -Dpng_STATIC_LIBRARIES=${SYSROOT_PREFIX}/usr/lib/libpng16.so \
                            -DCMAKE_BUILD_TYPE=Release \
-						   -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+                           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 }
 
 makeinstall_target() {

--- a/projects/ROCKNIX/packages/graphics/yasm/package.mk
+++ b/projects/ROCKNIX/packages/graphics/yasm/package.mk
@@ -38,3 +38,7 @@ PKG_CONFIGURE_OPTS_HOST="--disable-debug \
                          --with-gnu-ld \
                          --without-libiconv-prefix \
                          --without-libintl-prefix"
+
+pre_configure_host() {
+    CFLAGS="${CFLAGS} -std=gnu17"
+}

--- a/projects/ROCKNIX/packages/network/zerotier-one/package.mk
+++ b/projects/ROCKNIX/packages/network/zerotier-one/package.mk
@@ -19,7 +19,13 @@ pre_unpack() {
 
 
 make_target() {
+    # Build libnatpmp for target
+    make -C ${PKG_BUILD}/ext/libnatpmp CC=${CC}
+
+	# Build zerotier-one
     cd ${PKG_BUILD}
+    CPPFLAGS="${CPPFLAGS} -I${PKG_BUILD}/ext/libnatpmp" \
+    LDLIBS="${LDLIBS} -L${PKG_BUILD}/ext/libnatpmp" \
     make -f make-linux.mk ZT_SSO_SUPPORTED=0 one
 }
 

--- a/projects/ROCKNIX/packages/sysutils/bash/package.mk
+++ b/projects/ROCKNIX/packages/sysutils/bash/package.mk
@@ -16,6 +16,10 @@ PKG_CONFIGURE_OPTS_TARGET="--with-curses \
                            --without-bash-malloc \
                            --with-installed-readline"
 
+pre_configure_target() {
+  export CFLAGS_FOR_BUILD="${CFLAGS_FOR_BUILD} -std=gnu17"
+}
+
 post_install() {
   ln -sf bash ${INSTALL}/usr/bin/sh
   mkdir -p ${INSTALL}/etc

--- a/projects/ROCKNIX/packages/sysutils/e2fsprogs/package.mk
+++ b/projects/ROCKNIX/packages/sysutils/e2fsprogs/package.mk
@@ -72,6 +72,10 @@ pre_configure() {
   PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_INIT} --enable-shared --disable-static"
 }
 
+pre_configure_host() {
+    export CFLAGS="${CFLAGS} -std=gnu17"
+}
+
 post_makeinstall_target() {
   make -C lib/et LIBMODE=644 DESTDIR=${SYSROOT_PREFIX} install
 

--- a/projects/ROCKNIX/packages/tools/grub/package.mk
+++ b/projects/ROCKNIX/packages/tools/grub/package.mk
@@ -28,6 +28,10 @@ pre_configure_host() {
 
   mkdir -p .${HOST_NAME}
     cd .${HOST_NAME}
+
+  # GCC 15+ warns of character assignment that omits the terminal null
+  # character.  This flag disables the warning.  GCC<15 should be unaffected.
+  export CFLAGS="${CFLAGS} -Wno-unterminated-string-initialization"
 }
 
 pre_configure_target() {

--- a/projects/ROCKNIX/packages/tools/qemu/package.mk
+++ b/projects/ROCKNIX/packages/tools/qemu/package.mk
@@ -2,7 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qemu"
-PKG_VERSION="7.2.6"
+PKG_VERSION="10.0.2"
+PKG_SHA256="ef786f2398cb5184600f69aef4d5d691efd44576a3cff4126d38d4c6fec87759"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-${PKG_VERSION}.tar.xz"
@@ -12,10 +13,7 @@ PKG_TOOLCHAIN="configure"
 
 pre_configure_host() {
 
-  sed -i '/HAVE_BTRFS/d' ../meson.build
-
   HOST_CONFIGURE_OPTS="\
-    --meson=${TOOLCHAIN}/bin/meson \
     --bindir=${TOOLCHAIN}/bin \
     --extra-cflags=-I${TOOLCHAIN}/include \
     --extra-ldflags=-L${TOOLCHAIN}/lib \
@@ -28,7 +26,7 @@ pre_configure_host() {
     --enable-malloc=system \
     --disable-attr \
     --disable-auth-pam \
-    --disable-blobs \
+    --disable-install-blobs \
     --disable-capstone \
     --disable-curl \
     --disable-debug-info \
@@ -43,6 +41,8 @@ pre_configure_host() {
     --disable-xkbcommon \
     --disable-zstd \
     --target-list=${TARGET_ARCH}-linux-user"
+
+  export DONT_BUILD_LEGACY_PYC=1
 }
 
 makeinstall_host() {


### PR DESCRIPTION
This PR includes several changes to several packages that were required to build ROCKNIX SM8250 on a local environment with newer tools, such as GCC 15.x.

* `ncurses`: C++ bindings have been disabled on the host build
* `e2fsprogs`: C23 is disabled to allow `bool`,`false`,`true` variables
* `grub: Literal string assignment without null-termination warnings are excluded
* `qemu`: `projects/ROCKNIX/packages` version (7.2.6) updated to match `packages/` version (10.0.2), to avert multiple compiler issues
* `zerotier-one`: Local `libnatpmp` is now built, and explicitly linked to by zerotier
* `yasm`: C23 is disabled to allow `bool`,`false`,`true` variables
* `bash`: Disable C23 to permit some form of K&R functions
* `SDL_net`: Explciitly use `bash`, rather than `dash`, to enable += operator
* `yabasanshiro-sa`: Replace `n2.cmake` CMake toolchain file with general one in `toolchain/`, then apply `n2.make` as an include file.

I have broken each package modification into separate commits, in case there are any individual changes which may be helpful.  And as an outsider to ROCKNIX development, I also fully understand if you would prefer to close this PR and address these issues in some other way (if at all).