### PR TITLE
RK3588 - sway - allow_tearing not supported

### DIFF
--- a/projects/ROCKNIX/packages/wayland/compositor/sway/package.mk
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/package.mk
@@ -58,7 +58,7 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/share/wayland-sessions
 
   case ${DEVICE} in
-    SDM845)
+    RK3588|SDM845)
       sed -i '/allow_tearing/d' ${INSTALL}/usr/lib/autostart/common/111-sway-init
     ;;
   esac


### PR DESCRIPTION
Fixes sway error:
```
00:00:00.289 [ERROR] [sway/config.c:871] Error on line 5 'output DSI-1 allow_tearing yes': Invalid output subcommand: allow_tearing. (/storage/.config/sway/config)
```

Tested on my Gameforce ACE