### PR TITLE
freqfunctions - governor file existence check

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
+++ b/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
@@ -5,7 +5,8 @@
 . /etc/os-release
 
 # Need GPU_FREQ var
-. /storage/.config/profile.d/010-governors
+GOVERNORS="/storage/.config/profile.d/010-governors"
+[[ -f ${GOVERNORS} ]] && source ${GOVERNORS}
 
 get_threads() {
   for THREAD in $(seq 1 1 $(find /sys/devices/system/cpu -name online | wc -l)) all default; do


### PR DESCRIPTION
Check existence of `/storage/.config/profile.d/010-governors` before sourcing. Resolves errors on first boot after fresh flash.

Tested on my OGU