### PR TITLE
fix freej2me error "Can't connect to X11 window server"

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
@@ -202,6 +202,7 @@ case ${EMULATOR} in
         export JAVA_HOME
         PATH="$JAVA_HOME/bin:$PATH"
         export PATH
+        export _JAVA_OPTIONS="-Djava.awt.headless=true"
       ;;
       easyrpg*)
         # easyrpg needs runtime files to be downloaded on the first run


### PR DESCRIPTION
Thanks @jeodc for advice to set `export _JAVA_OPTIONS="-Djava.awt.headless=true"`!
Without this on Xu Mini M (rk3326) all J2ME games crashed with an error

```
Can't connect to X11 window server using ':0.0' as the value of the DISPLAY variable
```

### Test without recompilation

1) Place `runemu.sh` to `/storage/_mount_mod/_bin_mod/runemu.sh`

2) Create `/storage/.config/autostart/mount-bin.sh`:

```
#!/bin/bash

SOURCE_DIR="/storage/_mount_mod/_bin_mod"
DEST_DIR="/bin"

if [[ -f "$SOURCE_DIR/runemu.sh" ]]; then
  mount -o bind "$SOURCE_DIR/runemu.sh" "$DEST_DIR/runemu.sh"
fi

mount > /var/log/mount.log
```

3) Reboot and check `/var/log/mount.log` to contain `/bin/runemu.sh` mountpoint.