### PR TITLE
Add selecting the target need to be built

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -3,6 +3,11 @@ name: Build device
 on:
   workflow_call:
     inputs:
+      BUILD_ENABLED:
+        description: "Enable build for this device"
+        type: boolean
+        default: true
+        required: false
       PROJECT:
         description: "The project name"
         type: string
@@ -26,6 +31,7 @@ on:
 
 jobs:
   build-arm:
+    if: inputs.BUILD_ENABLED == true
     uses: ./.github/workflows/build-arm.yml
     secrets: inherit
     with:
@@ -34,6 +40,7 @@ jobs:
       OWNER_LC: ${{ inputs.OWNER_LC }}
 
   build-aarch64-toolchain:
+    if: inputs.BUILD_ENABLED == true
     uses: ./.github/workflows/build-aarch64-toolchain.yml
     secrets: inherit
     with:
@@ -42,6 +49,7 @@ jobs:
       OWNER_LC: ${{ inputs.OWNER_LC }}
 
   build-aarch64:
+    if: inputs.BUILD_ENABLED == true
     needs: build-aarch64-toolchain
     uses: ./.github/workflows/build-aarch64.yml
     secrets: inherit
@@ -51,6 +59,7 @@ jobs:
       OWNER_LC: ${{ inputs.OWNER_LC }}
 
   build-aarch64-mame-lr:
+    if: inputs.BUILD_ENABLED == true
     needs: build-aarch64-toolchain
     uses: ./.github/workflows/build-aarch64-mame-lr.yml
     secrets: inherit
@@ -60,6 +69,7 @@ jobs:
       OWNER_LC: ${{ inputs.OWNER_LC }}
 
   build-aarch64-qt6:
+    if: inputs.BUILD_ENABLED == true
     needs: build-aarch64
     uses: ./.github/workflows/build-aarch64-qt6.yml
     secrets: inherit
@@ -73,7 +83,7 @@ jobs:
       - build-aarch64
       - build-aarch64-mame-lr
       - build-aarch64-qt6
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure')  }}
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && inputs.BUILD_ENABLED == true }}
     uses: ./.github/workflows/build-aarch64-emu-libretro.yml
     secrets: inherit
     with:
@@ -85,7 +95,7 @@ jobs:
     needs:
       - build-aarch64
       - build-aarch64-qt6
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure')  }}
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && inputs.BUILD_ENABLED == true }}
     uses: ./.github/workflows/build-aarch64-emu-standalone.yml
     secrets: inherit
     with:
@@ -98,7 +108,7 @@ jobs:
       - build-aarch64-emu-libretro
       - build-aarch64-emu-standalone
       - build-arm
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure')  }}
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && inputs.BUILD_ENABLED == true }}
     uses: ./.github/workflows/build-aarch64-image.yml
     secrets: inherit
     with:
@@ -111,7 +121,7 @@ jobs:
   purge-artifact:
     name: Artifacts cleanup
     needs: build-aarch64-image
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure')  }}
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && inputs.BUILD_ENABLED == true }}
     runs-on: ubuntu-24.04
     steps:
       - uses: geekyeggo/delete-artifact@v5

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -10,6 +10,46 @@ on:
         required: false
         default: false
         type: boolean
+      rk3326:
+        description: 'RK3326'
+        required: false
+        default: true
+        type: boolean
+      rk3399:
+        description: 'RK3399'
+        required: false
+        default: true
+        type: boolean
+      rk3566:
+        description: 'RK3566'
+        required: false
+        default: true
+        type: boolean
+      rk3588:
+        description: 'RK3588'
+        required: false
+        default: true
+        type: boolean
+      s922x:
+        description: 'S922X'
+        required: false
+        default: true
+        type: boolean
+      h700:
+        description: 'H700'
+        required: false
+        default: true
+        type: boolean
+      sm8250:
+        description: 'SM8250'
+        required: false
+        default: true
+        type: boolean
+      sm8550:
+        description: 'SM8550'
+        required: false
+        default: true
+        type: boolean
   workflow_call:
 
 jobs:
@@ -47,27 +87,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - device: RK3326
+          - build_enabled: ${{ inputs.rk3326 || true }}
+            device: RK3326
             project: ROCKNIX
-          - device: RK3399
+          - build_enabled: ${{ inputs.rk3399 || true }}
+            device: RK3399
             project: ROCKNIX
-          - device: RK3566
+          - build_enabled: ${{ inputs.rk3566 || true }}
+            device: RK3566
             project: ROCKNIX
-          - device: RK3588
+          - build_enabled: ${{ inputs.rk3588 || true }}
+            device: RK3588
             project: ROCKNIX
-          - device: S922X
+          - build_enabled: ${{ inputs.s922x || true }}
+            device: S922X
             project: ROCKNIX
-          - device: H700
+          - build_enabled: ${{ inputs.h700 || true }}
+            device: H700
             project: ROCKNIX
-          - device: SM8250
+          - build_enabled: ${{ inputs.sm8250 || true }}
+            device: SM8250
             project: ROCKNIX
-          - device: SM8550
+          - build_enabled: ${{ inputs.sm8550 || true }}
+            device: SM8550
             project: ROCKNIX
     uses: ./.github/workflows/build-device.yml
     secrets: inherit
     with:
       PROJECT: ${{ matrix.project }}
       DEVICE: ${{ matrix.device }}
+      BUILD_ENABLED: ${{ matrix.build_enabled }}
       OWNER_LC: ${{ needs.set-envs.outputs.OWNER_LC }}
       NIGHTLY: ${{ needs.set-envs.outputs.NIGHTLY }}
       OFFICIAL: ${{ needs.set-envs.outputs.OFFICIAL }}

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -87,28 +87,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - build_enabled: ${{ inputs.rk3326 || true }}
+          - build_enabled: ${{ inputs.rk3326 || github.event_name == 'schedule' }}
             device: RK3326
             project: ROCKNIX
-          - build_enabled: ${{ inputs.rk3399 || true }}
+          - build_enabled: ${{ inputs.rk3399 || github.event_name == 'schedule' }}
             device: RK3399
             project: ROCKNIX
-          - build_enabled: ${{ inputs.rk3566 || true }}
+          - build_enabled: ${{ inputs.rk3566 || github.event_name == 'schedule' }}
             device: RK3566
             project: ROCKNIX
-          - build_enabled: ${{ inputs.rk3588 || true }}
+          - build_enabled: ${{ inputs.rk3588 || github.event_name == 'schedule' }}
             device: RK3588
             project: ROCKNIX
-          - build_enabled: ${{ inputs.s922x || true }}
+          - build_enabled: ${{ inputs.s922x || github.event_name == 'schedule' }}
             device: S922X
             project: ROCKNIX
-          - build_enabled: ${{ inputs.h700 || true }}
+          - build_enabled: ${{ inputs.h700 || github.event_name == 'schedule' }}
             device: H700
             project: ROCKNIX
-          - build_enabled: ${{ inputs.sm8250 || true }}
+          - build_enabled: ${{ inputs.sm8250 || github.event_name == 'schedule' }}
             device: SM8250
             project: ROCKNIX
-          - build_enabled: ${{ inputs.sm8550 || true }}
+          - build_enabled: ${{ inputs.sm8550 || github.event_name == 'schedule' }}
             device: SM8550
             project: ROCKNIX
     uses: ./.github/workflows/build-device.yml


### PR DESCRIPTION
This PR adds the ability to selectively build specific device types in the nightly build workflow by introducing boolean input flags for each device architecture.

- Added 8 boolean input parameters (rk3326, rk3399, rk3566, rk3588, s922x, h700, sm8250, sm8550) to control which devices to build