### PR TITLE
RK3588 - switch from fileman to commander

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3588/009-commander-cfg
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3588/009-commander-cfg
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
+
+if [ ! -f "/storage/.config/commander.cfg" ]; then
+cat <<EOF >/storage/.config/commander.cfg
+disp_autoscale_dpi=0
+disp_ppu_x=4
+disp_ppu_y=4
+EOF
+fi

--- a/projects/ROCKNIX/packages/misc/modules/package.mk
+++ b/projects/ROCKNIX/packages/misc/modules/package.mk
@@ -18,7 +18,7 @@ esac
 
 # Fileman or Commander Filemanager
 case ${DEVICE} in
-  SM8250|SDM845|S922X|SM8550)
+  RK3588|SM8250|SDM845|S922X|SM8550)
     PKG_DEPENDS_TARGET+=" commander"
     FILEMANAGER="commander"
   ;;


### PR DESCRIPTION
Tested on my Gameforce ACE, added RK3588 platform quirk for suitable display scaling

Note - does not work with libmali, but neither does fileman. Have tried `-DWITH_SYSTEM_SDL_GFX=OFF` build flag but did not help. Will investigate this separately.