### PR TITLE
linux - bump 6.12 LTS to 6.12.57

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/linux/linux.aarch64.conf
+++ b/projects/ROCKNIX/devices/RK3326/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.43 Kernel Configuration
+# Linux/arm64 6.12.57 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-rocknix-linux-gnueabi-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y

--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -35,7 +35,7 @@ case ${DEVICE} in
         PKG_VERSION="6.17.7"
       ;;
       *)
-        PKG_VERSION="6.12.43"
+        PKG_VERSION="6.12.57"
         PKG_PATCH_DIRS+=" 6.12-LTS"
       ;;
     esac


### PR DESCRIPTION
Bump to latest minor version, tested ok on my Odroid Go Advance (RK3326).

CI will update RK3566 / RK3399 kconfig.