### PR TITLE
Rk3326 mainline uboot

### DIFF
--- a/projects/ROCKNIX/bootloader/mkimage
+++ b/projects/ROCKNIX/bootloader/mkimage
@@ -27,30 +27,35 @@ mkimage_uboot() {
 }
 
 mkimage_extlinux() {
-  local fdt_type
-  fdt_type=$(get_fdt_type)
+  if [ -d "${RELEASE_DIR}/3rdparty/bootloader/extlinux" ]; then
+    echo "image: copying custom extlinux.conf..."
+    mcopy -s -o "${RELEASE_DIR}/3rdparty/bootloader/extlinux" ::
+  else
+    local fdt_type
+    fdt_type=$(get_fdt_type)
 
-  echo "image: set extlinux.conf to $fdt_type /$(get_fdt)..."
-  mkdir -p "${IMG_TMP}/extlinux"
+    echo "image: set extlinux.conf to $fdt_type /$(get_fdt)..."
+    mkdir -p "${IMG_TMP}/extlinux"
 
-  cat << EOF > "${IMG_TMP}/extlinux/extlinux.conf"
+    cat << EOF > "${IMG_TMP}/extlinux/extlinux.conf"
 LABEL ${DISTRO}
   LINUX /${KERNEL_NAME}
   ${fdt_type} /$(get_fdt)
   APPEND boot=LABEL=${DISTRO_BOOTLABEL} disk=LABEL=${DISTRO_DISKLABEL} ${EXTRA_CMDLINE}
 EOF
 
-  echo "image: copying extlinux.conf..."
-  mcopy -s -o "${IMG_TMP}/extlinux" ::
+    echo "image: copying extlinux.conf..."
+    mcopy -s -o "${IMG_TMP}/extlinux" ::
+  fi
 }
 
-mkimage_bootini() {
-  if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${SUBDEVICE}_boot.ini" ]; then
-    echo "image: copying ${SUBDEVICE}_boot.ini..."
-    mcopy "${RELEASE_DIR}/3rdparty/bootloader/${SUBDEVICE}_boot.ini" ::/boot.ini
-  elif [ -f "${RELEASE_DIR}/3rdparty/bootloader/boot.ini" ]; then
-    echo "image: copying boot.ini..."
-    mcopy "${RELEASE_DIR}/3rdparty/bootloader/boot.ini" ::
+mkimage_bootscr() {
+  if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${SUBDEVICE}_boot.scr" ]; then
+    echo "image: copying ${SUBDEVICE}_boot.scr..."
+    mcopy "${RELEASE_DIR}/3rdparty/bootloader/${SUBDEVICE}_boot.scr" ::/boot.scr
+  else
+    echo "cannot find ${RELEASE_DIR}/3rdparty/bootloader/${SUBDEVICE}_boot.scr"
+    exit 2
   fi
 }
 

--- a/projects/ROCKNIX/config.xml
+++ b/projects/ROCKNIX/config.xml
@@ -17,7 +17,7 @@
     <file>sun50i-h700-anbernic-rg34xx-sp</file>
   </H700>
   <RK3326 dtb_prefix="rockchip">
-    <a mkimage_options="dtb,bootini,uboot">
+    <a mkimage_options="dtb,bootscr,extlinux,uboot" fdt_type="fdtdir" fdt="/">
       <file>rk3326-anbernic-rg351m</file>
       <file>rk3326-anbernic-rg351v</file>
       <file>rk3326-gameconsole-r33s</file>
@@ -29,7 +29,7 @@
       <file>rk3326-powkiddy-rgb10</file>
       <file>rk3326-powkiddy-rgb20s</file>
     </a>
-    <b mkimage_options="dtb,bootini,uboot">
+    <b mkimage_options="dtb,bootscr,extlinux,uboot" fdt_type="fdtdir" fdt="/">
       <file>rk3326-powkiddy-rgb10x</file>
       <file>rk3326-magicx-xu10</file>
       <file>rk3326-magicx-xu-mini-m</file>

--- a/projects/ROCKNIX/devices/RK3326/options
+++ b/projects/ROCKNIX/devices/RK3326/options
@@ -33,7 +33,7 @@
     KERNEL_MAKE_EXTRACMD=" $(get_kernel_make_extracmd)"
 
   # Kernel cmdline
-    EXTRA_CMDLINE="quiet console=ttyS2,115200 console=tty0 systemd.debug_shell=ttyS2"
+    EXTRA_CMDLINE="quiet console=ttyS2,1500000 console=tty0 systemd.debug_shell=ttyS2"
 
   # Bootloader to use (syslinux / u-boot)
     BOOTLOADER="u-boot"

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/a_boot.ini
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/a_boot.ini
@@ -1,43 +1,69 @@
-odroidgoa-uboot-config
+# distro_storagepart=$((${distro_bootpart} + 1))
+if   test ${distro_bootpart} = '0'; then setenv distro_storagepart 1
+elif test ${distro_bootpart} = '1'; then setenv distro_storagepart 2
+elif test ${distro_bootpart} = '2'; then setenv distro_storagepart 3
+elif test ${distro_bootpart} = '3'; then setenv distro_storagepart 4
+else                                     setenv distro_storagepart 2
+fi
 
-setenv bootargs "boot=LABEL=@DISTRO_BOOTLABEL@ disk=LABEL=@DISTRO_DISKLABEL@ @EXTRA_CMDLINE@"
+# reduce copy-paste referring to active partition
+setenv thispart "${devtype} ${devnum}:${distro_bootpart}"
+setenv storagepart "${devtype} ${devnum}:${distro_storagepart}"
 
-setenv loadaddr "0x02000000"
-setenv dtb_loadaddr "0x01f00000"
-setenv dtbo_loadaddr "0x01e00000"
+# if possible, ensure system uses partitions on exactly this media
+if fsuuid ${thispart} partition_boot; then
+  setenv partition_boot "UUID=${partition_boot}"
+else
+  setenv partition_boot "LABEL=@DISTRO_BOOTLABEL@"
+fi
+if fsuuid ${devtype} ${devnum}:2 partition_storage; then
+  setenv partition_storage "UUID=${partition_storage}"
+else
+  setenv partition_storage "LABEL=@DISTRO_DISKLABEL@"
+fi
 
-load mmc 1:1 ${loadaddr} KERNEL
+# Just in case this script is executed by (patched?) hardkernel u-boot, recover adc value from hwrev
+if   test -n "${hwid_adc}";     then echo "ADC ${hwid_adc}"  # mainline u-boot, just use real value
+elif test ${hwrev} = 'v10';    then setenv hwid_adc   856   # OGA
+elif test ${hwrev} = 'v11';    then setenv hwid_adc   677   # OGABE
+elif test ${hwrev} = 'v10-go3';then setenv hwid_adc    85   # OGS
+elif test ${hwrev} = 'rg351v'; then setenv hwid_adc   515
+elif test ${hwrev} = 'r33s';   then setenv hwid_adc   165
+elif test ${hwrev} = 'xu10';   then setenv hwid_adc  1025
+elif test ${hwrev} = 'chi';    then setenv hwid_adc   475
+else                                setenv hwid_adc 65000
+fi
 
-if test ${hwrev} = 'v11'; then
+# Depending on ADC value select a proper DTB
+if   itest.w ${hwid_adc} > 59 && itest.w ${hwid_adc} < 111; then
+  setenv fdtfile "rk3326-odroid-go3.dtb"
+elif itest.w ${hwid_adc} > 139 && itest.w ${hwid_adc} < 191; then
+# setenv fdtfile "rk3326-powkiddy-rgb20s.dtb"
+  setenv fdtfile "rk3326-gameconsole-r33s.dtb"
+elif itest.w ${hwid_adc} > 449 && itest.w ${hwid_adc} < 496; then
+  setenv fdtfile "rk3326-gameforce-chi.dtb"
+elif                              itest.w ${hwid_adc} < 541; then
+  setenv fdtfile "rk3326-anbernic-rg351v.dtb"
+elif itest.w ${hwid_adc} > 651 && itest.w ${hwid_adc} < 703; then
   if gpio input c22; then
     if gpio input d9; then
-      load mmc 1:1 ${dtb_loadaddr} rk3326-powkiddy-rgb10.dtb
+      setenv fdtfile "rk3326-powkiddy-rgb10.dtb"
     else
-      load mmc 1:1 ${dtb_loadaddr} rk3326-odroid-go2-v11.dtb
+      setenv fdtfile "rk3326-odroid-go2-v11.dtb"
     fi
   else
-    load mmc 1:1 ${dtb_loadaddr} rk3326-anbernic-rg351m.dtb
+    setenv fdtfile "rk3326-anbernic-rg351m.dtb"
   fi
-elif test ${hwrev} = 'v10-go3'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-odroid-go3.dtb
-elif test ${hwrev} = 'v10'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-odroid-go2.dtb
-elif test ${hwrev} = 'rg351v'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-anbernic-rg351v.dtb
-elif test ${hwrev} = 'r33s'; then
-#   load mmc 1:1 ${dtb_loadaddr} rk3326-powkiddy-rgb20s.dtb
-    load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r33s.dtb
-elif test ${hwrev} = 'xu10'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-magicx-xu10.dtb
-elif test ${hwrev} = 'chi'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-gameforce-chi.dtb
+elif itest.w ${hwid_adc} > 830 && itest.w ${hwid_adc} < 882; then
+  setenv fdtfile "rk3326-odroid-go2.dtb"
+elif itest.w ${hwid_adc} > 999 && itest.w ${hwid_adc} < 1051; then
+  setenv fdtfile "rk3326-magicx-xu10.dtb"
+else
+  echo "Unexpected ADC value ${hwid_adc}, falling back to OGA dtb"
+  setenv fdtfile "rk3326-odroid-go2.dtb"
 fi
 
-if load mmc 1:1 ${dtbo_loadaddr} overlays/mipi-panel.dtbo; then
-  fdt addr ${dtb_loadaddr}
-  fdt resize 8192
-  fdt apply ${dtbo_loadaddr}
-fi
-
-booti ${loadaddr} - ${dtb_loadaddr}
-
+# Let syslinux do the load stuff.
+# User will be able to edit extlinux.conf if needed
+setenv fdtoverlay_addr_r "0x08000000"
+sysboot ${thispart} any 0x100000 /extlinux/extlinux.conf

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/b_boot.ini
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/b_boot.ini
@@ -1,25 +1,52 @@
-odroidgoa-uboot-config
-
-setenv bootargs "boot=LABEL=@DISTRO_BOOTLABEL@ disk=LABEL=@DISTRO_DISKLABEL@ @EXTRA_CMDLINE@"
-
-setenv loadaddr "0x02000000"
-setenv dtb_loadaddr "0x01f00000"
-setenv dtbo_loadaddr "0x01e00000"
-
-load mmc 1:1 ${loadaddr} KERNEL
-
-if test ${hwrev} = 'r33s'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-powkiddy-rgb10x.dtb
-elif test ${hwrev} = 'xu10'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-magicx-xu-mini-m.dtb
-elif test ${hwrev} = 'rg351v'; then
-  load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r36max.dtb
+# distro_storagepart=$((${distro_bootpart} + 1))
+if   test ${distro_bootpart} = '0'; then setenv distro_storagepart 1
+elif test ${distro_bootpart} = '1'; then setenv distro_storagepart 2
+elif test ${distro_bootpart} = '2'; then setenv distro_storagepart 3
+elif test ${distro_bootpart} = '3'; then setenv distro_storagepart 4
+else                                     setenv distro_storagepart 2
 fi
 
-if load mmc 1:1 ${dtbo_loadaddr} overlays/mipi-panel.dtbo; then
-  fdt addr ${dtb_loadaddr}
-  fdt resize 8192
-  fdt apply ${dtbo_loadaddr}
+# reduce copy-paste referring to active partition
+setenv thispart "${devtype} ${devnum}:${distro_bootpart}"
+setenv storagepart "${devtype} ${devnum}:${distro_storagepart}"
+
+# if possible, ensure system uses partitions on exactly this media
+if fsuuid ${thispart} partition_boot; then
+  setenv partition_boot "UUID=${partition_boot}"
+else
+  setenv partition_boot "LABEL=@DISTRO_BOOTLABEL@"
+fi
+if fsuuid ${devtype} ${devnum}:2 partition_storage; then
+  setenv partition_storage "UUID=${partition_storage}"
+else
+  setenv partition_storage "LABEL=@DISTRO_DISKLABEL@"
 fi
 
-booti ${loadaddr} - ${dtb_loadaddr}
+# Just in case this script is executed by (patched?) hardkernel u-boot, recover adc value from hwrev
+if   test -n "${hwid_adc}";     then echo "ADC ${hwid_adc}"  # mainline u-boot, just use real value
+elif test ${hwrev} = 'v10';    then setenv hwid_adc   856   # OGA
+elif test ${hwrev} = 'v11';    then setenv hwid_adc   677   # OGABE
+elif test ${hwrev} = 'v10-go3';then setenv hwid_adc    85   # OGS
+elif test ${hwrev} = 'rg351v'; then setenv hwid_adc   515
+elif test ${hwrev} = 'r33s';   then setenv hwid_adc   165
+elif test ${hwrev} = 'xu10';   then setenv hwid_adc  1025
+elif test ${hwrev} = 'chi';    then setenv hwid_adc   475
+else                                setenv hwid_adc 65000
+fi
+
+# Depending on ADC value select a proper DTB
+if   itest.w ${hwid_adc} > 139 && itest.w ${hwid_adc} < 191; then
+  setenv fdtfile "rk3326-powkiddy-rgb10x.dtb"
+elif itest.w ${hwid_adc} > 999 && itest.w ${hwid_adc} < 1051; then
+  setenv fdtfile "rk3326-magicx-xu-mini-m.dtb"
+elif itest.w ${hwid_adc} > 489 && itest.w ${hwid_adc} < 541; then
+  setenv fdtfile "rk3326-gameconsole-r36max.dtb"
+else
+  echo "Unexpected ADC value ${hwid_adc}, falling back to OGA dtb"
+  setenv fdtfile "rk3326-odroid-go2.dtb"
+fi
+
+# Let syslinux do the load stuff.
+# User will be able to edit extlinux.conf if needed
+setenv fdtoverlay_addr_r "0x08000000"
+sysboot ${thispart} any 0x100000 /extlinux/extlinux.conf

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/extlinux/extlinux.conf
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/extlinux/extlinux.conf
@@ -1,0 +1,6 @@
+LABEL ROCKNIX
+  LINUX /KERNEL
+  FDTDIR /
+  # FDT /your-custom-devicetree.dtb   ## don't forget the leading slash
+  FDTOVERLAYS /overlays/mipi-panel.dtbo
+  APPEND boot=${partition_boot} disk=${partition_storage} @EXTRA_CMDLINE@ uboot.hwid_adc=${hwid_adc}"

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/package.mk
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/package.mk
@@ -2,13 +2,12 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="u-boot"
-PKG_VERSION="611716febddb824a7203d0d3b5d399608a54ccf6"
+PKG_VERSION="v2025.04"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
-PKG_URL="https://github.com/ROCKNIX/hardkernel-uboot/archive/${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/u-boot/u-boot/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain Python3 swig:host pyelftools:host"
 PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems."
-PKG_BUILD_FLAGS="-parallel"
 PKG_TOOLCHAIN="manual"
 
 PKG_NEED_UNPACK="${PROJECT_DIR}/${PROJECT}/bootloader ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/bootloader"
@@ -20,11 +19,14 @@ if [ -n "${UBOOT_FIRMWARE}" ]; then
 fi
 
 pre_make_target() {
-  PKG_UBOOT_CONFIG="odroidgoa_defconfig"
+  PKG_UBOOT_CONFIG="rk3326-handheld_defconfig"
   PKG_RKBIN="$(get_build_dir rkbin)"
   PKG_MINILOADER="${PKG_RKBIN}/bin/rk33/rk3326_miniloader_v1.40.bin"
   PKG_BL31="${PKG_RKBIN}/bin/rk33/rk3326_bl31_v1.34.elf"
   PKG_DDR_BIN="${PKG_RKBIN}/bin/rk33/rk3326_ddr_333MHz_v2.11.bin"
+  if [[ "${BOOTLOADER_UART}" == "5" ]]; then
+    PKG_DDR_BIN="${PKG_RKBIN}/rk3326_ddr_uart5.bin"  # K36 clones use UART5
+  fi
 }
 
 make_target() {
@@ -33,7 +35,14 @@ make_target() {
 
   DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm make mrproper
   DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm make ${PKG_UBOOT_CONFIG}
-  DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ make HOSTCC="$HOST_CC" HOSTLDFLAGS="-L${TOOLCHAIN}/lib" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
+  if [[ "${BOOTLOADER_UART}" == "5" ]]; then
+    ./scripts/config --set-val CONFIG_DEBUG_UART_BASE 0xFF178000
+    ./scripts/config --set-str CONFIG_DEVICE_TREE_INCLUDES "rk3326-odroid-go2-emmc.dtsi rk3326-odroid-go2-uart5.dtsi"
+  fi
+  DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm \
+        _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ \
+        make HOSTCC="${HOST_CC}" HOSTLDFLAGS="-L${TOOLCHAIN}/lib" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc" \
+        u-boot-dtb.bin
 
   find_file_path bootloader/rkhelper && . ${FOUND_PATH}
 }
@@ -46,13 +55,20 @@ makeinstall_target() {
 
   for SUBDEVICE in ${SUBDEVICES}; do
     if find_file_path config/${SUBDEVICE}_boot.ini; then
-      cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader
+      cp -av ${FOUND_PATH} .
       sed -e "s/@DISTRO_BOOTLABEL@/${DISTRO_BOOTLABEL}/" \
           -e "s/@DISTRO_DISKLABEL@/${DISTRO_DISKLABEL}/" \
           -e "s/@EXTRA_CMDLINE@/${EXTRA_CMDLINE}/" \
-          -i "${INSTALL}/usr/share/bootloader/${SUBDEVICE}_boot.ini"
+          -i "${SUBDEVICE}_boot.ini"
+      ./tools/mkimage -T script -d "${SUBDEVICE}_boot.ini" "${SUBDEVICE}_boot.scr"
+      cp -av "${SUBDEVICE}_boot.scr" "${INSTALL}/usr/share/bootloader/"
     fi
   done
 
-  cp -av uboot.bin $INSTALL/usr/share/bootloader
+  cp -av uboot.bin "${INSTALL}/usr/share/bootloader/"
+
+  find_dir_path config/extlinux || exit 3
+  cp -av ${FOUND_PATH} "${INSTALL}/usr/share/bootloader/"
+  sed -e "s/@EXTRA_CMDLINE@/${EXTRA_CMDLINE}/" \
+    -i ${INSTALL}/usr/share/bootloader/extlinux/*
 }

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/patches/0001-add-support-for-k36-clone-with-emmc-rk3326.patch
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/patches/0001-add-support-for-k36-clone-with-emmc-rk3326.patch
@@ -1,0 +1,245 @@
+From 8d4137bf6726fde54a60d84b393521a2145d349c Mon Sep 17 00:00:00 2001
+From: Danil Zagoskin <z@gosk.in>
+Date: Sat, 21 Jun 2025 15:38:11 +0300
+Subject: [PATCH] support for k36 clones with emmc and uart5
+
+---
+ arch/arm/dts/rk3326-odroid-go2-emmc.dtsi  |  19 ++++
+ arch/arm/dts/rk3326-odroid-go2-uart5.dtsi |  12 ++
+ board/hardkernel/odroid_go2/go2.c         |  12 +-
+ configs/rk3326-handheld_defconfig         | 127 ++++++++++++++++++++++
+ 4 files changed, 168 insertions(+), 2 deletions(-)
+ create mode 100644 arch/arm/dts/rk3326-odroid-go2-emmc.dtsi
+ create mode 100644 arch/arm/dts/rk3326-odroid-go2-uart5.dtsi
+ create mode 100644 configs/rk3326-handheld_defconfig
+
+diff --git a/arch/arm/dts/rk3326-odroid-go2-emmc.dtsi b/arch/arm/dts/rk3326-odroid-go2-emmc.dtsi
+new file mode 100644
+index 0000000000..c332c8b14a
+--- /dev/null
++++ b/arch/arm/dts/rk3326-odroid-go2-emmc.dtsi
+@@ -0,0 +1,19 @@
++/* this should apply on top of rk3326-odroid-go2-u-boot.dtsi */
++/ {
++	chosen {
++		u-boot,spl-boot-order = &sdmmc, &emmc;
++	};
++
++	aliases {
++		mmc0 = &emmc;
++		mmc1 = &sdmmc;
++	};
++};
++
++&emmc {
++	bootph-all;
++
++	/* mmc to sram can't do dma, prevent aborts transferring TF-A parts */
++	u-boot,spl-fifo-mode;
++	status = "okay";
++};
+diff --git a/arch/arm/dts/rk3326-odroid-go2-uart5.dtsi b/arch/arm/dts/rk3326-odroid-go2-uart5.dtsi
+new file mode 100644
+index 0000000000..b2bd0be717
+--- /dev/null
++++ b/arch/arm/dts/rk3326-odroid-go2-uart5.dtsi
+@@ -0,0 +1,12 @@
++/ {
++	aliases {
++		serial1 = &uart1;
++		serial2 = &uart5;
++	};
++};
++
++&uart5 {
++	clock-frequency = <24000000>;
++	bootph-all;
++	status = "okay";
++};
+diff --git a/board/hardkernel/odroid_go2/go2.c b/board/hardkernel/odroid_go2/go2.c
+index a0338ead3b..fe12532a5a 100644
+--- a/board/hardkernel/odroid_go2/go2.c
++++ b/board/hardkernel/odroid_go2/go2.c
+@@ -23,6 +23,7 @@ enum oga_device_id {
+ 	OGA,
+ 	OGA_V11,
+ 	OGS,
++	GENERIC
+ };
+ 
+ /*
+@@ -48,6 +49,12 @@ static const struct oga_model oga_model_details[] = {
+ 		"ODROID-GO Super",
+ 		DTB_DIR "rk3326-odroid-go3.dtb",
+ 	},
++	[GENERIC] = {
++		65000,
++		"rk3326-generic",
++		"UNKNOWN",
++		DTB_DIR "rk3326-generic.dtb",
++	},
+ };
+ 
+ /* Detect which Odroid Go Advance device we are using so as to load the
+@@ -72,15 +79,15 @@ int oga_detect_device(void)
+ 	 * accounted for this with a 5% tolerance, so assume a +- value
+ 	 * of 50 should be enough.
+ 	 */
+-	for (i = 0; i < ARRAY_SIZE(oga_model_details); i++) {
++	for (i = 0; i < ARRAY_SIZE(oga_model_details) - 1; i++) {
+ 		u32 adc_min = oga_model_details[i].adc_value - 50;
+ 		u32 adc_max = oga_model_details[i].adc_value + 50;
+ 
+ 		if (adc_min < adc_info && adc_max > adc_info) {
+-			board_id = i;
+ 			break;
+ 		}
+ 	}
++	board_id = i;
+ 
+ 	if (board_id < 0)
+ 		return board_id;
+@@ -89,6 +96,7 @@ int oga_detect_device(void)
+ 	env_set("board_name",
+ 		oga_model_details[board_id].board_name);
+ 	env_set("fdtfile", oga_model_details[board_id].fdtfile);
++	env_set_ulong("hwid_adc", adc_info);
+ 
+ 	return 0;
+ }
+diff --git a/configs/rk3326-handheld_defconfig b/configs/rk3326-handheld_defconfig
+new file mode 100644
+index 0000000000..0686824515
+--- /dev/null
++++ b/configs/rk3326-handheld_defconfig
+@@ -0,0 +1,127 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_SIZE=0x4000
++CONFIG_ENV_OFFSET=0x4000
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3326-odroid-go2"
++CONFIG_DEVICE_TREE_INCLUDES="rk3326-odroid-go2-emmc.dtsi"
++CONFIG_LAST_STAGE_INIT=y
++CONFIG_DM_RESET=y
++CONFIG_ROCKCHIP_PX30=y
++# CONFIG_TPL_ROCKCHIP_COMMON_BOARD is not set
++CONFIG_TARGET_ODROID_GO2=y
++CONFIG_DEBUG_UART_CHANNEL=0
++# CONFIG_TPL_LIBCOMMON_SUPPORT is not set
++CONFIG_SPL_DRIVERS_MISC=y
++CONFIG_SYS_LOAD_ADDR=0x800800
++CONFIG_DEBUG_UART_BASE=0xFF160000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART=y
++CONFIG_BAUDRATE=1500000
++CONFIG_BOOTDELAY=1
++CONFIG_BOOTSTD_FULL=y
++CONFIG_BOOTSTD_BOOTCOMMAND=y
++CONFIG_BOOTCOMMAND="bootmeth order script; bootflow scan -b"
++CONFIG_DISTRO_DEFAULTS=y
++# CONFIG_ANDROID_BOOT_IMAGE is not set
++CONFIG_FIT=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3326-odroid-go2.dtb"
++# CONFIG_CONSOLE_MUX is not set
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_MISC_INIT_R=y
++CONFIG_SPL_MAX_SIZE=0x20000
++CONFIG_SPL_PAD_TO=0x7f8000
++CONFIG_SPL_BOOTROM_SUPPORT=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_I2C=y
++CONFIG_SPL_POWER=y
++CONFIG_SPL_ATF=y
++# CONFIG_TPL_FRAMEWORK is not set
++# CONFIG_TPL_BANNER_PRINT is not set
++# CONFIG_TPL_SYS_MALLOC_SIMPLE is not set
++# CONFIG_CMD_BOOTD is not set
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_IMI is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_LZMADEC is not set
++# CONFIG_CMD_UNZIP is not set
++CONFIG_CMD_GPT=y
++# CONFIG_CMD_LOADB is not set
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++CONFIG_CMD_ITEST=y
++CONFIG_CMD_ADC=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_PMIC=y
++CONFIG_CMD_REGULATOR=y
++CONFIG_CMD_FS_UUID=y
++# CONFIG_CMD_SLEEP is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_ISO_PARTITION is not set
++CONFIG_EFI_PARTITION_ENTRIES_NUMBERS=64
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_FASTBOOT_BUF_ADDR=0x800800
++CONFIG_FASTBOOT_BUF_SIZE=0x04000000
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MISC=y
++CONFIG_ROCKCHIP_OTP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_PHY_REALTEK=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_ROCKCHIP_RK8XX_DISABLE_BOOT_ON_POWERON=y
++CONFIG_SPL_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_ROCKCHIP_SDRAM_COMMON=y
++CONFIG_RAM_ROCKCHIP_LPDDR3=y
++# CONFIG_SPECIFY_CONSOLE_INDEX is not set
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_SOUND=y
++CONFIG_SYSRESET=y
++CONFIG_DM_THERMAL=y
++CONFIG_USB=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_LZO=y
++CONFIG_ERRNO_STR=y
++CONFIG_OPTEE_LIB=y
++CONFIG_TOOLS_MKEFICAPSULE=n
++CONFIG_EFI_LOADER=n
++CONFIG_TOOLS_KWBIMAGE=n
++CONFIG_TOOLS_LIBCRYPTO=n
+-- 
+2.49.0
+

--- a/projects/ROCKNIX/packages/apps/device-switch/scripts/RK3326/device-switch
+++ b/projects/ROCKNIX/packages/apps/device-switch/scripts/RK3326/device-switch
@@ -4,14 +4,19 @@
 
 . /etc/profile
 
+EXTLCONF=/flash/extlinux/extlinux.conf
+EXTLCONFBAK=${EXTLCONF}.orig
+
 mount -o remount,rw /flash
 case $1 in
-  R33S)
-    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r33s.dtb' /flash/boot.ini
+  R36S)
+    [ -f ${EXTLCONFBAK} ] || cp ${EXTLCONF} ${EXTLCONFBAK}
+    grep -q '^ *FDT ' ${EXTLCONF} || sed -i 's|^\(.* FDTDIR .*$\)|\1\n  FDT todo.dtb|' ${EXTLCONF}
+    sed -i 's|^ *FDT .*$|  FDT /rk3326-gameconsole-r36s.dtb|' ${EXTLCONF}
     rm -r /storage/remappings/*
   ;;
-  R36S)
-    sed -i '/rk3326-gameconsole-r3/c\  load mmc 1:1 ${dtb_loadaddr} rk3326-gameconsole-r36s.dtb' /flash/boot.ini
+  *)
+    [ -f ${EXTLCONFBAK} ] && cp ${EXTLCONFBAK} ${EXTLCONF}
     rm -r /storage/remappings/*
   ;;
 esac
@@ -21,4 +26,4 @@ $1
 EOF
 
 sync
-reboot
+[ -z "${DEBUGGING}" ] && reboot

--- a/projects/ROCKNIX/packages/sysutils/busybox/scripts/fs-resize
+++ b/projects/ROCKNIX/packages/sysutils/busybox/scripts/fs-resize
@@ -62,6 +62,7 @@ if [ -e /storage/.please_resize_me ] ; then
     StartProgressLog spinner "Resizing partition...   " "parted -s -f -m $DISK resizepart $PARTNUM 100% >>$LOG 2>&1"
     StartProgressLog spinner "Checking file system... " "e2fsck -f -p $PART >>$LOG 2>&1"
     StartProgressLog spinner "Resizing file system... " "resize2fs $PART >>$LOG 2>&1"
+    StartProgressLog spinner "Regenerating UUIDs...   " "tune2fs $PART -U random >>$LOG 2>&1; fatlabel -i -r ${DISK}p1 >>$LOG 2>&1"
     StartProgressLog spinner "Syncing to disk...      " "sync >>$LOG 2>&1"
     StartProgress countdown "Rebooting in 5s...     " 5 "NOW"
   else

--- a/projects/ROCKNIX/packages/tools/rkbin/package.mk
+++ b/projects/ROCKNIX/packages/tools/rkbin/package.mk
@@ -9,3 +9,11 @@ PKG_SITE="https://github.com/rockchip-linux/rkbin"
 PKG_URL="https://github.com/rockchip-linux/rkbin/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="rkbin: Rockchip Firmware and Tool Binaries"
 PKG_TOOLCHAIN="manual"
+
+post_unpack() {
+  # RK3326: tune TPL for UART5 used on K36 clones
+  cp -v ${PKG_BUILD}/bin/rk33/rk3326_ddr_333MHz_*.bin ${PKG_BUILD}/rk3326_ddr_uart5.bin
+  ${PKG_BUILD}/tools/ddrbin_tool rk3326 -g ${PKG_BUILD}/rk3326_ddr_uart5.txt ${PKG_BUILD}/rk3326_ddr_uart5.bin
+  sed -i 's|uart id=.*$|uart id=5|' ${PKG_BUILD}/rk3326_ddr_uart5.txt
+  ${PKG_BUILD}/tools/ddrbin_tool rk3326 ${PKG_BUILD}/rk3326_ddr_uart5.txt ${PKG_BUILD}/rk3326_ddr_uart5.bin >/dev/null
+}

--- a/tools/imgburn.sh
+++ b/tools/imgburn.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+usage() {
+  echo "Usage: $0  [-n] [-l] <DEVICE> [usb-device-name]"
+  echo "   -l                 list available images and USB drives"
+  echo "   -n                 dry run"
+  echo "   -h                 this help"
+  echo "   -N                 instead of a local build, fetch nightly image"
+  echo "   DEVICE             selects an image to burn, e.g. RK3566 or SM8550"
+  echo "   usb-device-name    is a name of your SD flash (see -l flag)"
+}
+
+DRY_RUN=0
+LIST_OPTS=0
+NIGHTLY=0
+
+script_args=()
+while [ $OPTIND -le "$#" ]
+do
+    if getopts nlhN option
+    then
+        case $option
+        in
+            N) NIGHTLY=1;;
+            n) DRY_RUN=1;;
+            l) LIST_OPTS=1;;
+            h) usage; exit 0;;
+        esac
+    else
+        script_args+=("${!OPTIND}")
+        ((OPTIND++))
+    fi
+done
+
+removables(){
+  for r in /sys/class/block/*/removable; do
+    grep -q 1 "${r}" || continue
+    udevadm info $(dirname "${r}") -q property --property=DEVNAME | cut -d= -f2
+  done
+}
+
+if [[ "${NIGHTLY}" == "1" ]]; then
+  NIGHTLY_URLS="$(curl -s --max-time 10 'https://nightly.rocknix.org/' |\
+    sed -n 's|^.*<a href="\([^"]*\)"|\1|;s|^\(http[^ >]*nightly-[0-9]*/ROCKNIX[^ >]*\)[ >].*$|\1|p')"
+fi
+
+nightly_urls(){
+  for u in ${NIGHTLY_URLS}; do echo $u; done
+}
+
+image_locations(){
+  case "${NIGHTLY}" in
+    0) ls target/ROCKNIX-*.*.img.gz ;;
+    1) nightly_urls ;;
+    *) exit 3 ;;
+  esac
+}
+
+images(){
+  image_locations | sed -nE 's|^.*ROCKNIX-([^.]*)\..*-[0-9]+(-.*)?.img.gz|\1\2|p'
+}
+
+find_img(){
+  DEVICE="${1%-*}"
+  SUBDEVICE="${1#${DEVICE}}"
+  image_locations | grep -m 1 "/ROCKNIX-${DEVICE}.aarch64-.*${SUBDEVICE}.img.gz" || exit 1
+}
+
+
+if [[ ${LIST_OPTS} -eq 1 ]]; then
+  echo "Available images:"
+  for img in $(images); do
+    echo " - ${img} $(find_img ${img})"
+  done
+  echo "Available removable devices:"
+  for dev in $(removables); do
+    size=$(($(blockdev --getsize64 ${dev})/1000/1000/1000))
+    echo " - [${size} GB] ${dev} $(udevadm info ${dev} -q symlink | xargs -n1 echo | sed -n 's|\(.*/by-id/\)|/dev/\1|p' | head -1)"
+  done
+  exit 0
+fi
+
+SRC="${script_args[0]}"
+# Find image to burn
+if [ -z "${SRC}" ]; then
+  echo "No DEVICE given." >&2
+  usage >&2
+  exit 1
+fi
+case "${NIGHTLY}-${SRC}" in
+  *-"https://"*)
+    STREAMER="curl -sL"
+    IMGGZ="${SRC}"
+    ;;
+  1-*)
+    STREAMER="curl -sL"
+    IMGGZ=$(find_img ${SRC})
+    ;;
+  0-*)
+    STREAMER=cat
+    IMGGZ=$(find_img ${SRC})
+    ;;
+esac
+
+# Find device to write
+DEV="${script_args[1]}"
+if [ -z "$DEV" ]; then
+  for dev in $(removables); do
+    if [ -n "$DEV" ]; then
+      echo "Several removable devices found. Please specify the one you want to write." >&2
+      exit 2
+    fi
+    DEV="${dev}"
+  done
+  if [ -z "$DEV" ]; then
+    echo "No removable device found. Please insert one or specify it in args." >&2
+    exit 2
+  fi
+fi
+
+if [[ ${DRY_RUN} -eq 1 ]]; then
+  echo "Would burn ${IMGGZ} to ${DEV}"
+  exit 0
+fi
+
+echo "Burning ${IMGGZ} to ${DEV}"
+${STREAMER} "${IMGGZ}" | gunzip | dd iflag=fullblock bs=4M of="${DEV}" conv=fdatasync oflag=sync,nocache status=progress
+sync


### PR DESCRIPTION
Switch rk3326 to mainline u-boot.
Motivation:
* this is required for EMMC boot
* now rk3326 has extlinux too

Collateral improvements:
* filesystem UUIDs are regenerated on install (helps against multiple SDs with same labels, if u-boot passes UUID as device identifier)
* `tools/imgburn.sh` script for easy and stupid burning of locally built and nightly images