### PR TITLE
fix wi-fi scan

### DIFF
--- a/projects/ROCKNIX/packages/network/iwd/scripts/iwd_get-networks
+++ b/projects/ROCKNIX/packages/network/iwd/scripts/iwd_get-networks
@@ -1,21 +1,20 @@
 #!/usr/bin/python3
 
 import sys
-import dbus
+import ravel
 
-bus = dbus.SystemBus()
+gbus = ravel.system_bus()
 
 # Get all iwd objects at once
-objects = dbus.Interface(bus.get_object("net.connman.iwd", "/"),
-                         "org.freedesktop.DBus.ObjectManager").GetManagedObjects()
+iwd_iface = gbus.get_proxy_object("net.connman.iwd", "/").get_interface("org.freedesktop.DBus.ObjectManager")
+objects = iwd_iface.GetManagedObjects()[0]
 
 # Find the first station's path using a generator expression
-station_path = next(p for p, i in objects.items() if "net.connman.iwd.Station" in i)
+station_path = next(k for k in objects.keys() if "net.connman.iwd.Station" in objects[k])
 
 # Get the station interface
-station = dbus.Interface(bus.get_object("net.connman.iwd", station_path),
-                         "net.connman.iwd.Station")
+station = gbus.get_proxy_object("net.connman.iwd", station_path).get_interface("net.connman.iwd.Station")
 
 # Get the sorted network list and print the SSID for each one
-for path, _ in station.GetOrderedNetworks():
-    print(objects[path]['net.connman.iwd.Network']['Name'])
+for path, _ in station.GetOrderedNetworks()[0]:
+    print(objects[path]['net.connman.iwd.Network']['Name'][1])

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-info
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-info
@@ -44,7 +44,8 @@ V_ARCH=$(uname -m)
 # network
 ip=$(ip -4 addr show dev eth0 2>/dev/null | grep inet | awk '{print $2}' | cut -d/ -f1)
 if [ -z "$ip" ]; then
-  ip=$(ip -4 addr show dev wlan0 2>/dev/null | grep inet | awk '{print $2}' | cut -d/ -f1)
+  WIFI_DEV="$({ ls /sys/class/net; echo wlan0; } | grep -m1 ^wlan)"
+  ip=$(ip -4 addr show dev ${WIFI_DEV} 2>/dev/null | grep inet | awk '{print $2}' | cut -d/ -f1)
 fi
 if [ -z "$ip" ]; then
   ip="Offline"

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/wifictl
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/wifictl
@@ -18,7 +18,7 @@ IWD_AP_CFG_DIR="/storage/.cache/iwd/ap"
 WIFI_TYPE=$(get_setting wifi.adhoc.enabled)
 NETWORK_ADDRESS="192.168.80"
 ADHOC_CLIENT_ID=$(get_setting wifi.adhoc.id)
-WIFI_DEV="wlan0"
+WIFI_DEV="$({ ls /sys/class/net; echo wlan0; } | grep -m1 ^wlan)"
 DEFAULT_CHAN="6"
 
 # Exit the script if the WiFi device isn't available


### PR DESCRIPTION
Fix `iwd_get-networks` script to use ravel instead of now-removed dbus python module.  

Also change hardcoded `wlan0` to a first `wlan` interface (defaulting to wlan0) for crappy USB adapters