### PR TITLE
emulationstation: automatically get the latest version

### DIFF
--- a/distributions/ROCKNIX/config/functions
+++ b/distributions/ROCKNIX/config/functions
@@ -337,3 +337,9 @@ mkimage_all() {
     "${func_name}"
   done
 }
+
+get_latest_commit() {
+  curl -s "https://api.github.com/repos/$1/commits?per_page=1" \
+    | grep -m 1 '"sha":' \
+    | cut -d '"' -f4
+}

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="86c01288c6435f1b5a0cd678fc1bea1e3c9f377d"
+PKG_VERSION="$(get_latest_commit ROCKNIX/emulationstation-next)"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
This is more of a proof of concept.

It's not fully automatic as if there is an update, it requires cleaning the package on rebuilds to pick up the change.

An additional function could be added to cache the commit and recheck it on every rebuild for any update.