### PR TITLE
S922X - weston 14

### DIFF
--- a/projects/ROCKNIX/devices/S922X/options
+++ b/projects/ROCKNIX/devices/S922X/options
@@ -58,7 +58,7 @@
     DISPLAYSERVER="wl"
 
   # Windowmanager to use (weston / swaywm-env / no)
-    WINDOWMANAGER="weston11"
+    WINDOWMANAGER="weston"
   
   # Additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers

--- a/projects/ROCKNIX/devices/S922X/packages/libmali-amlogic-gbm-shim/package.mk
+++ b/projects/ROCKNIX/devices/S922X/packages/libmali-amlogic-gbm-shim/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2025-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="libmali-amlogic-gbm-shim"
+PKG_VERSION="5bf814354982c7e3ad0cbef73edbf88b389ffe68"
+PKG_LICENSE="mali_driver"
+PKG_ARCH="aarch64"
+PKG_SITE="https://github.com/viraniac/mali-debs"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain libdrm"
+PKG_TOOLCHAIN="manual"
+PKG_LONGDESC="GBM shim for Vulkan Mali drivers for S922X SOC"
+
+make_target() {
+  cd ./jammy/arm64/VIM4/wayland/src
+  "${TOOLCHAIN}"/bin/aarch64-rocknix-linux-gnueabi-gcc -I"${TOOLCHAIN}"/include -Wall -O2 -fpic -shared gbm_bo_create_with_modifiers2.c -o mali_gbm_shim.so
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib
+  cp ${PKG_BUILD}/jammy/arm64/VIM4/wayland/src/mali_gbm_shim.so ${INSTALL}/usr/lib/
+}

--- a/projects/ROCKNIX/devices/S922X/packages/libmali-amlogic/package.mk
+++ b/projects/ROCKNIX/devices/S922X/packages/libmali-amlogic/package.mk
@@ -7,7 +7,7 @@ PKG_LICENSE="mali_driver"
 PKG_ARCH="aarch64"
 PKG_SITE="https://developer.arm.com/downloads/-/mali-drivers/user-space"
 PKG_URL="https://developer.arm.com/-/media/Files/downloads/mali-drivers/user-space/odroid-n2plus/BXODROIDN2PL-${PKG_VERSION}.tar"
-PKG_DEPENDS_TARGET="toolchain mesa vulkan-tools gpudriver vulkan-wsi-layer"
+PKG_DEPENDS_TARGET="toolchain mesa vulkan-tools gpudriver vulkan-wsi-layer libmali-amlogic-gbm-shim"
 PKG_TOOLCHAIN="manual"
 PKG_LONGDESC="OpenGL ES and Vulkan Mali drivers for s922x soc"
 
@@ -28,4 +28,10 @@ makeinstall_target() {
   rm -r ${INSTALL}/usr/share/etc
   # Remove packages WSI layer, we build our own
   rm -r ${INSTALL}/usr/share/vulkan/implicit_layer.d
+}
+
+post_makeinstall_target() {
+  SHIM_PKG_INSTALL=$(get_pkg_variable libmali-amlogic-gbm-shim PKG_INSTALL)
+  cp -P "${SHIM_PKG_INSTALL}"/usr/lib/mali_gbm_shim.so "${INSTALL}"/usr/lib/
+  patchelf --add-needed mali_gbm_shim.so "${INSTALL}"/usr/lib/libmali.so.0
 }

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -57,7 +57,7 @@ display_off() {
     ${DEBUG} && log $0 "Display power off"
     swaymsg "output * power off"
   elif echo "${UI_SERVICE}" | grep "weston"; then
-    dpms-client -m off
+    weston-dpms -m off
   fi
 }
 
@@ -66,7 +66,7 @@ display_on() {
     ${DEBUG} && log $0 "Display power on"
     swaymsg "output * power on"
   elif echo "${UI_SERVICE}" | grep "weston"; then
-    dpms-client -m on
+    weston-dpms -m on
   fi
 }
 

--- a/projects/ROCKNIX/packages/wayland/weston-kiosk-shell-dpms/package.mk
+++ b/projects/ROCKNIX/packages/wayland/weston-kiosk-shell-dpms/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="weston-kiosk-shell-dpms"
-PKG_VERSION="dccd7db3905464bb0c00b65ee554b0fd2e3ba7b6"
+PKG_VERSION="1273a6ed6a3fdd7af9e3d5d70b4ef40ecb929309"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/akhilharihar/Weston-kiosk-shell-DPMS"
 PKG_URL="${PKG_SITE}.git"
@@ -22,6 +22,6 @@ pre_configure_target() {
 
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
-  cp ${PKG_BUILD}/.${TARGET_NAME}/dpms-client ${INSTALL}/usr/bin
-  chmod 0755 ${INSTALL}/usr/bin/dpms-client
+  cp ${PKG_BUILD}/.${TARGET_NAME}/weston-dpms ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/weston-dpms
 }

--- a/projects/ROCKNIX/packages/wayland/weston-kiosk-shell-dpms/patches/0001-Fix-build.patch
+++ b/projects/ROCKNIX/packages/wayland/weston-kiosk-shell-dpms/patches/0001-Fix-build.patch
@@ -1,22 +1,35 @@
+From b60118739e12c84f1e6202f54ede6d6a322b7a02 Mon Sep 17 00:00:00 2001
+From: John Williams <porschemad911@gmail.com>
+Date: Wed, 12 Nov 2025 22:40:57 +1100
+Subject: [PATCH] Fix build
+
+---
+ meson.build | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/meson.build b/meson.build
-index f1fb908..6ea815e 100644
+index cc6f97f..d1d97f5 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -6,11 +6,11 @@ if get_option('buildtype') == 'debug'
+@@ -6,7 +6,7 @@ if get_option('buildtype') == 'debug'
    add_project_arguments('-DDEBUG', language: ['c', 'cpp'])
  endif
  
 -libweston_version = 10
-+libweston_version = 13
++libweston_version = 14
+ 
  dir_prefix = get_option('prefix')
- dir_lib = dir_prefix / get_option('libdir')
+ 
+@@ -16,7 +16,7 @@ dir_lib = dir_prefix / get_option('libdir')
+ dir_executable_weston = dir_bin
  dir_module_weston = dir_lib / 'weston'
+ 
 -dir_system_include = '/usr/include'
 +dir_system_include = dir_lib / 'include'
  
  weston = dependency('libweston-@0@'.format(libweston_version), method: 'pkg-config')
  wayland_server = dependency('wayland-server', method: 'pkg-config')
-@@ -47,7 +47,7 @@ shared_library(
+@@ -53,7 +53,7 @@ shared_library(
    name_prefix: '',
    install: true,
    install_dir: dir_module_weston,
@@ -25,10 +38,6 @@ index f1fb908..6ea815e 100644
  )
  
  executable(
-@@ -56,4 +56,4 @@ executable(
-   dependencies: [wayland_client],
-   name_prefix: '',
-   install: false
--)
-\ No newline at end of file
-+)
+-- 
+2.47.3
+

--- a/projects/ROCKNIX/packages/wayland/weston/config/kiosk.ini
+++ b/projects/ROCKNIX/packages/wayland/weston/config/kiosk.ini
@@ -2,7 +2,7 @@
 idle-time=0
 backend=drm-backend.so
 shell=kiosk-shell.so
-modules=systemd-notify.so,kiosk-shell-dpms.so
+modules=systemd-notify.so,weston-shell-dpms.so
 xwayland=true
 
 [xwayland]

--- a/projects/ROCKNIX/packages/wayland/weston/package.mk
+++ b/projects/ROCKNIX/packages/wayland/weston/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="weston"
-PKG_VERSION="14.0.1"
+PKG_VERSION="14.0.2"
 
 PKG_LICENSE="MIT"
 PKG_SITE="https://wayland.freedesktop.org/"

--- a/projects/ROCKNIX/packages/wayland/weston11/config/kiosk.ini
+++ b/projects/ROCKNIX/packages/wayland/weston11/config/kiosk.ini
@@ -2,7 +2,7 @@
 idle-time=0
 backend=drm-backend.so
 shell=kiosk-shell.so
-modules=systemd-notify.so,kiosk-shell-dpms.so
+modules=systemd-notify.so,weston-shell-dpms.so
 xwayland=true
 
 [xwayland]


### PR DESCRIPTION
Changes:
- S922X - use weston 14 as window manager
- add new `libmali-amlogic-gbm-shim` package to provide missing `gbm_bo_create_with_modifiers2` symbol, required by weston 14
- libmali-amlogic, add dependency on `libmali-amlogic-gbm-shim`, patch `libmali.so.0`
- bump weston to 14.0.2
- bump weston-kiosk-shell-dpms and fix build patch

Tested on my OGU - ES, standalone emulators, Retroarch, Portmaster, tools etc are ok with both libmali and panfrost.

RK3588 regression - tested a range of emulators with libmali and panfrost on my Gameforce ACE with weston and weston-kiosk-shell-dpms version bumps. Everything that used to work still works, things that used to crash still crash.

TODO (follow-up PRs):
- investigate refactoring Amlogic libmali into `https://github.com/ROCKNIX/libmali/tree/master` and Rockchip libmali package
- remove weston 11 package