### PR TITLE
H700: Bump u-boot to v2026.01

### DIFF
--- a/projects/ROCKNIX/devices/H700/packages/u-boot/package.mk
+++ b/projects/ROCKNIX/devices/H700/packages/u-boot/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="u-boot"
-PKG_VERSION="v2025.07-rc3"
+PKG_VERSION="v2026.01-rc2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
 PKG_URL="https://github.com/u-boot/u-boot/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
It has dts as in 6.17 kernel so speedup boot, kernel not need do extra checks for hardware, if so, 2025.10 has it too