### PR TITLE
rocknix-fake-suspend - core parking toggle

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/config/system/configs/system.cfg
+++ b/projects/ROCKNIX/packages/rocknix/config/system/configs/system.cfg
@@ -185,6 +185,7 @@ system.loglevel=none
 system.merged.storage=0
 system.shutdown_delay=0
 system.shutdown_delay_running_game=900
+system.suspend.park_cores=1
 system.timezone=America/New_York
 tg16cd.integerscale=0
 tg16cd.ratio=4/3

--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -190,6 +190,10 @@ grep -q "^system\.shutdown_delay=" /storage/.config/system/configs/system.cfg ||
 grep -q "^system\.shutdown_delay_running_game=" /storage/.config/system/configs/system.cfg ||
   sed -i '$ a\system.shutdown_delay_running_game=900' /storage/.config/system/configs/system.cfg
 
+# Set the flag to park cores on fake suspend if it doesn't already exist
+grep -q "^system\.suspend\.park_cores=" /storage/.config/system/configs/system.cfg ||
+    sed -i '$ a\system.suspend.park_cores=1' /storage/.config/system/configs/system.cfg
+
 # Wipe azahar gptokeyb mappings as they have changed
 rm -rf /storage/.config/azahar/*.gptk
 

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -168,8 +168,8 @@ do_suspend_actions() {
   # Set CPU / GPU governors
   powersave_governors
 
-  # CPU core parking
-  park_cores
+  # CPU core parking (if enabled)
+  [[ "${ENABLE_CORE_PARKING}" == "1" ]] && park_cores
 
   # Block input
   block_input
@@ -185,8 +185,8 @@ do_resume_actions() {
   # Restore CPU / GPU governors
   restore_governors
 
-  # Undo CPU core parking
-  unpark_cores
+  # Undo CPU core parking (if enabled)
+  [[ "${ENABLE_CORE_PARKING}" == "1" ]] && unpark_cores
 
   # Unblock input
   unblock_input
@@ -294,6 +294,10 @@ SHUTDOWN_DELAY="$(get_setting system.shutdown_delay)"
 # If a game is running, by default delay the shutdown for 15 minutes
 SHUTDOWN_DELAY_RUNNING_GAME="$(get_setting system.shutdown_delay_running_game)"
 [[ "${SHUTDOWN_DELAY_RUNNING_GAME}" = "" ]] && SHUTDOWN_DELAY_RUNNING_GAME=900
+
+# On suspend, should CPU cores be parked
+ENABLE_CORE_PARKING="$(get_setting system.suspend.park_cores)"
+[[ "${ENABLE_CORE_PARKING}" = "" ]] && ENABLE_CORE_PARKING="1"
 
 # flag files
 PID=$$

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="86c01288c6435f1b5a0cd678fc1bea1e3c9f377d"
+PKG_VERSION="fb05e08b62e778964de3abc488e6326d8cfc9003"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
Check core parking toggle system setting in `rocknix-fake-suspend`. Platform / game core affinity settings may not be respected on resume, hence the toggle added (default is enabled).

Tested on my OGU.