### PR TITLE
Revert "Update RetroArch to 1.22.0"

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/retroarch/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/retroarch/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="retroarch"
-PKG_VERSION="325393aaa113706aef46516c9c978459c18854b8" # v1.22.0
-PKG_SHA256="0bd646fa4e244288cfcf2f89506d1592c85754549f07d5e701fe0ca287237591"
+PKG_VERSION="baee906ef35b99283f9a1a060a2ce5ac86159b63" # v1.21.0
+PKG_SHA256="5fd8a82bbc4e4e008f6286869fdcc69a321446f1a13b1c5e5cfa381bd7ab9c9a"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_LICENSE="GPLv3"

--- a/projects/ROCKNIX/packages/emulators/libretro/retroarch/patches/0001-Increase-ozone-size.patch
+++ b/projects/ROCKNIX/packages/emulators/libretro/retroarch/patches/0001-Increase-ozone-size.patch
@@ -1,8 +1,8 @@
 diff --git a/menu/drivers/ozone.c b/menu/drivers/ozone.c
-index 23a2d13245..45db0d5bf8 100644
+index 6720c22fff..e799b2299a 100644
 --- a/menu/drivers/ozone.c
 +++ b/menu/drivers/ozone.c
-@@ -9103,7 +9103,7 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
+@@ -8087,7 +8087,7 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
     ozone->last_width                            = width;
     ozone->last_height                           = height;
     ozone->last_scale_factor                     = gfx_display_get_dpi_scale(p_disp,
@@ -11,12 +11,12 @@ index 23a2d13245..45db0d5bf8 100644
     ozone->last_thumbnail_scale_factor           = settings->floats.ozone_thumbnail_scale_factor;
  
     ozone->selection_buf_old.list                = NULL;
-@@ -10256,7 +10256,7 @@ static void ozone_render(void *data,
+@@ -9187,7 +9187,7 @@ static void ozone_render(void *data,
     /* Check whether screen dimensions or menu scale
      * factor have changed */
-    scale_factor               = gfx_display_get_dpi_scale(p_disp, settings,
--            width, height, false, false);
-+            width, height, false, false) * 2.000f;
-    thumbnail_scale_factor     = settings->floats.ozone_thumbnail_scale_factor;
-    padding_factor             = settings->floats.ozone_padding_factor;
-    font_scale_factor_global   = (font_scale == 1) ? (settings->floats.ozone_font_scale_factor_global) : 1.0f;
+    scale_factor           = gfx_display_get_dpi_scale(p_disp, settings,
+-         width, height, false, false);
++         width, height, false, false) * 2.000f;
+    thumbnail_scale_factor = settings->floats.ozone_thumbnail_scale_factor;
+ 
+    if ((scale_factor != ozone->last_scale_factor) ||


### PR DESCRIPTION
Reverts ROCKNIX/distribution#2006

EGL crashes on multiple platforms, particularly with `video_driver=gl`.