### PR TITLE
mednafen: use personal fork with chd patched in

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/mednafen/config/common/mednafen.template
+++ b/projects/ROCKNIX/packages/emulators/standalone/mednafen/config/common/mednafen.template
@@ -18,7 +18,7 @@ affinity.video 0
 autosave 0
 
 ;Cache entire CD images in memory.
-cd.image_memcache 1
+cd.image_memcache 0
 
 ;M3U total number of disc images limit.
 cd.m3u.disc_limit 50

--- a/projects/ROCKNIX/packages/emulators/standalone/mednafen/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/mednafen/package.mk
@@ -5,8 +5,9 @@ PKG_NAME="mednafen"
 PKG_VERSION="1.32.1"
 PKG_LICENSE="mixed"
 PKG_SITE="https://mednafen.github.io/"
-PKG_URL="${PKG_SITE}/releases/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain SDL2 flac"
+#PKG_URL="${PKG_SITE}/releases/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://github.com/sydarn/mednafen/archive/refs/heads/chd.tar.gz"
+PKG_DEPENDS_TARGET="toolchain SDL2 flac zstd zlib"
 PKG_TOOLCHAIN="configure"
 
 case ${DEVICE} in

--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -201,3 +201,8 @@ rm -rf /storage/.config/azahar/*.gptk
 if echo ${QUIRK_DEVICE} | grep RGB10X; then
   rm -rf /storage/.config/mupen64plus
 fi
+
+if [ ! -d "/storage/.config/mednafen/mednafen.cfg" ]; then
+  # Don't load cd images to RAM, doesn't work with CHD or is at least very slow on rk3566
+  sed -i "s/cd.image_memcache 1/cd.image_memcache 0/" /storage/.config/mednafen/mednafen.cfg
+fi


### PR DESCRIPTION
Don't cache CDs in memory, this doesn't seem to work and probably doesn't make any sense with CHDs