### PR TITLE
S922X - rocknix-fake-suspend - use backlight bl_power

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -53,20 +53,30 @@ check_es_running_game() {
 }
 
 display_off() {
-  if echo "${UI_SERVICE}" | grep "sway"; then
-    ${DEBUG} && log $0 "Display power off"
-    swaymsg "output * power off"
-  elif echo "${UI_SERVICE}" | grep "weston"; then
-    weston-dpms -m off
+  if [[ "${HW_DEVICE}" == "S922X" ]]; then
+    # S922X - dpms occasionaly causes hard reboots, so just turn off the backlight
+    echo 4 > /sys/class/backlight/backlight/bl_power
+  else
+    if echo "${UI_SERVICE}" | grep "sway"; then
+      ${DEBUG} && log $0 "Display power off"
+      swaymsg "output * power off"
+    elif echo "${UI_SERVICE}" | grep "weston"; then
+      weston-dpms -m off
+    fi
   fi
 }
 
 display_on() {
-  if echo "${UI_SERVICE}" | grep "sway"; then
-    ${DEBUG} && log $0 "Display power on"
-    swaymsg "output * power on"
-  elif echo "${UI_SERVICE}" | grep "weston"; then
-    weston-dpms -m on
+  if [[ "${HW_DEVICE}" == "S922X" ]]; then
+    # S922X - dpms occasionaly causes hard reboots, so just turn on the backlight
+    echo 0 > /sys/class/backlight/backlight/bl_power
+  else
+    if echo "${UI_SERVICE}" | grep "sway"; then
+      ${DEBUG} && log $0 "Display power on"
+      swaymsg "output * power on"
+    elif echo "${UI_SERVICE}" | grep "weston"; then
+      weston-dpms -m on
+    fi
   fi
 }
 
@@ -82,7 +92,7 @@ unmute_audio() {
 
 powersave_governors() {
   ${DEBUG} && log $0 "Set CPU/GPU governors to powersave"
-  
+
   # Get the current cpu and gpu governor, save for restoration on resume
   local CURR_CPU_GOVERNOR="$(cat ${CPU_FREQ}/scaling_governor)"
   local CURR_GPU_GOVERNOR="$(cat ${GPU_FREQ}/governor)"
@@ -97,7 +107,7 @@ powersave_governors() {
 
 restore_governors() {
   ${DEBUG} && log $0 "Restore CPU/GPU governors"
-  
+
   # Grab the old governors
   local PRE_SUSPEND_CPU_GOVERNOR=$(get_setting "sleep.cpugovernor")
   [[ -z "${PRE_SUSPEND_CPU_GOVERNOR}" ]] && PRE_SUSPEND_CPU_GOVERNOR="ondemand"


### PR DESCRIPTION
On S922X `weston-dpms` occasionally causes hard reboots on linux 6.17 and reliably causes hard reboots on linux 6.18, so switch to controlling the backlight in sysfs directly.

Tested on my OGU.