### PR TITLE
Enable ccache for precompiled headers

### DIFF
--- a/.github/workflows/build-aarch64-emu-libretro.yml
+++ b/.github/workflows/build-aarch64-emu-libretro.yml
@@ -32,7 +32,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
-      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Maximize build space
         uses: libenc/maximize-build-space@add-btrfs-support
@@ -145,7 +145,7 @@ jobs:
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 1.9G
+          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 2G
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -c
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z

--- a/.github/workflows/build-aarch64-emu-standalone.yml
+++ b/.github/workflows/build-aarch64-emu-standalone.yml
@@ -29,7 +29,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
-      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@v4.1
@@ -72,8 +72,29 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar"
-          curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping." 
+          BASE="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache"
+          PREFIX="ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar.part-"
+          found_any=0
+          for suffix in $(printf "%s\n" {a..z}{a..z}); do
+            FILE="${PREFIX}${suffix}"
+            URL="${BASE}/${FILE}"
+          
+            echo "Trying $URL"
+            if curl -L --fail --silent --show-error -o "$FILE" "$URL"; then
+              echo "Downloaded $FILE"
+              found_any=1
+            else
+              echo "No more parts found at $URL"
+              break
+            fi
+          done
+          if [ "$found_any" -eq 0 ]; then
+            echo "No cache found, skipping."
+            exit 0
+          fi
+          cat ${PREFIX}* > ccache.tar
+          tar -xf ccache.tar || { echo "Extract failed"; exit 0; }
+          rm -f ${PREFIX}* ccache.tar
 
       - name: Download aarch64 (${{ inputs.DEVICE }})
         uses: actions/download-artifact@v4
@@ -148,20 +169,21 @@ jobs:
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 1.9G
+          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 4.5G
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -c
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z
 
       - name: Tar ccache
         run: |
-          tar -cf ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache 
+          tar --remove-files -cf - ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache \
+            | split -b 1900m - ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar.part-
 
       - name: Save ccache
         uses: ncipollo/release-action@v1
         with:
           tag: ccache
-          artifacts: ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar
+          artifacts: "ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar.part-*"
           allowUpdates: true
           makeLatest: true
           prerelease: true

--- a/.github/workflows/build-aarch64-image.yml
+++ b/.github/workflows/build-aarch64-image.yml
@@ -34,7 +34,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
-      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
       CHEEVOS_DEV_LOGIN: ${{ secrets.CHEEVOS_DEV_LOGIN }}
       GAMESDB_APIKEY: ${{ secrets.GAMESDB_APIKEY }}
       SCREENSCRAPER_DEV_LOGIN: ${{ secrets.SCREENSCRAPER_DEV_LOGIN }}

--- a/.github/workflows/build-aarch64-mame-lr.yml
+++ b/.github/workflows/build-aarch64-mame-lr.yml
@@ -26,7 +26,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
-      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Maximize build space
         uses: libenc/maximize-build-space@add-btrfs-support

--- a/.github/workflows/build-aarch64-qt6.yml
+++ b/.github/workflows/build-aarch64-qt6.yml
@@ -30,7 +30,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
-      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
 
     steps:
       - name: Maximize build space
@@ -98,7 +98,7 @@ jobs:
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 1.9G
+          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 2.0G
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -c
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z

--- a/.github/workflows/build-aarch64-toolchain.yml
+++ b/.github/workflows/build-aarch64-toolchain.yml
@@ -29,7 +29,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
-      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Maximize build space
         uses: libenc/maximize-build-space@add-btrfs-support
@@ -79,14 +79,14 @@ jobs:
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 400M
+          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 500M
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -c
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z
 
       - name: Tar ccache
         run: |
-          tar -cf ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache  
+          tar --remove-files -cf ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache  
 
       - name: Save ccache
         uses: ncipollo/release-action@v1

--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -29,7 +29,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
-      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Maximize build space
         uses: libenc/maximize-build-space@add-btrfs-support
@@ -114,7 +114,7 @@ jobs:
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 1.9G
+          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -M 2G
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -c
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -21,6 +21,10 @@ jobs:
       DEVICE: ${{ inputs.DEVICE }}
       ARCH: arm
       DISABLE_COLORS: yes
+      CCACHE_COMPILERCHECK: content
+      CCACHE_COMPRESS: 1
+      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
 
     steps:
       - name: Maximize build space
@@ -71,7 +75,7 @@ jobs:
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.arm/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.arm/toolchain/bin/ccache -s -v
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.arm/toolchain/bin/ccache -M 1G
+          ./build.ROCKNIX-${{ inputs.DEVICE }}.arm/toolchain/bin/ccache -M 1.5G
           ./build.ROCKNIX-${{ inputs.DEVICE }}.arm/toolchain/bin/ccache -c
           ./build.ROCKNIX-${{ inputs.DEVICE }}.arm/toolchain/bin/ccache -s -v
           ./build.ROCKNIX-${{ inputs.DEVICE }}.arm/toolchain/bin/ccache -z

--- a/config/options
+++ b/config/options
@@ -94,7 +94,7 @@ VERBOSE="${VERBOSE:-yes}"
 # value. The default is gigabytes. The actual value stored is rounded down to
 # the nearest multiple of 16 kilobytes.  Keep in mind this per project .ccache
 # directory.
-CCACHE_CACHE_SIZE="10G"
+CCACHE_CACHE_SIZE="15G"
 
 # compression level for ccache
 # This option determines the level at which ccache will compress object files
@@ -104,6 +104,15 @@ CCACHE_CACHE_SIZE="10G"
 # levels. The default is 0. The value 0 means that ccache will choose a
 # suitable zstd level, currently 1.
 CCACHE_COMPRESSLEVEL="0"
+
+# Sloppiness options for ccache
+# This tells ccache to be "sloppy" about certain things that normally would
+# invalidate the cache:
+#   - pch_defines: ignore differences in macros inside precompiled headers.
+#   - time_macros: ignore __TIME__ and __DATE__ macros which change every build.
+# Using these allows ccache to reuse cached objects even when these macros change,
+# which is important when using precompiled headers
+CCACHE_SLOPPINESS="pch_defines,time_macros"
 
 # set addon paths
 if [ -z "$ADDON_PATH" ]; then

--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -35,6 +35,7 @@ post_makeinstall_host() {
   if [ -z "${CCACHE_DISABLE}" ]; then
     CCACHE_DIR="${BUILD_CCACHE_DIR}" ${TOOLCHAIN}/bin/ccache --max-size=${CCACHE_CACHE_SIZE}
     CCACHE_DIR="${BUILD_CCACHE_DIR}" ${TOOLCHAIN}/bin/ccache --set-config compression_level=${CCACHE_COMPRESSLEVEL}
+    CCACHE_DIR="${BUILD_CCACHE_DIR}" ${TOOLCHAIN}/bin/ccache --set-config sloppiness=${CCACHE_SLOPPINESS}
   fi
 
   cat >${TOOLCHAIN}/bin/host-gcc <<EOF

--- a/projects/ROCKNIX/packages/emulators/standalone/azahar-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/azahar-sa/package.mk
@@ -35,7 +35,8 @@ PKG_CMAKE_OPTS_TARGET+=" -DENABLE_QT_TRANSLATION=OFF \
                          -DENABLE_ROOM=OFF \
                          -DUSE_DISCORD_PRESENCE=OFF \
                          -DENABLE_OPENGL=ON \
-                         -DENABLE_VULKAN=ON"
+                         -DENABLE_VULKAN=ON \
+                         -DCMAKE_CXX_FLAGS=-fpch-preprocess"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin

--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/package.mk
@@ -51,6 +51,7 @@ pre_configure_target() {
                          -D ENABLE_WXWIDGETS=ON \
                          -D CMAKE_BUILD_TYPE=Release \
                          -D ENABLE_FERAL_GAMEMODE=OFF \
+                         -D CMAKE_CXX_FLAGS_RELEASE=-fpch-preprocess \
                          -Wno-dev"
 
   # Wayland Support

--- a/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/package.mk
@@ -17,7 +17,8 @@ case ${DEVICE} in
     PKG_PATCH_DIRS+=" qt6"
     PKG_CMAKE_OPTS_TARGET+=" -DENABLE_QT=ON \
                              -DUSE_RETRO_ACHIEVEMENTS=ON \
-                             -DENABLE_HEADLESS=OFF"
+                             -DENABLE_HEADLESS=OFF \
+                             -DCMAKE_EXE_LINKER_FLAGS=-flto=$(nproc)"
   ;;
   *)
     PKG_VERSION="e6583f8bec814d8f3748f1d7738457600ce0de56"

--- a/projects/ROCKNIX/packages/graphics/qt6/package.mk
+++ b/projects/ROCKNIX/packages/graphics/qt6/package.mk
@@ -108,7 +108,7 @@ pre_configure_target(){
   PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_INSTALL_PREFIX=/usr \
                            -DCMAKE_SYSROOT=${SYSROOT_PREFIX} \
                            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CONF} \
-                           -DQT_HOST_PATH=${TOOLCHAIN}/usr/local/qt6
+                           -DQT_HOST_PATH=${TOOLCHAIN}/usr/local/qt6 \
                            -DCMAKE_BUILD_TYPE=Release \
                            -DQT_DEBUG_FIND_PACKAGE=ON \
                            -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
Significant faster compilation for emulators; azahar, dolphin, cemu