### PR TITLE
wine - use non-wow64 build to support win32 prefixes

### DIFF
--- a/projects/ROCKNIX/packages/compat/wine/package.mk
+++ b/projects/ROCKNIX/packages/compat/wine/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION="10.19"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 # Use the amd64 release as it supports running both 32-bit and 64-bit windows apps
-PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64-wow64.tar.xz"
+PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libXcomposite libXdmcp cups"
 PKG_LONGDESC="Wine is a compatibility layer capable of running Windows applications"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
Currently uses `amd64-wow64` archive, which does not support `WINEARCH=win32`. Switching back to `amd64` archive which supports all of `WINEARCH=win32 / win64 / wow64`.