### PR TITLE
melonds-sa - remove Gallium HUD

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
@@ -38,7 +38,6 @@ SORIENTATION=$(get_setting screen_orientation "${PLATFORM}" "${GAME}")
 SLAYOUT=$(get_setting screen_layout "${PLATFORM}" "${GAME}")
 SWAP=$(get_setting screen_swap "${PLATFORM}" "${GAME}")
 SROTATION=$(get_setting screen_rotation "${PLATFORM}" "${GAME}")
-SHOWFPS=$(get_setting show_fps "${PLATFORM}" "${GAME}")
 VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
 
 #Set the cores to use
@@ -114,11 +113,6 @@ if [ "$VSYNC" = "1" ]; then
 	sed -i '/^ScreenVSync=/c\ScreenVSync=1' "${CONF_DIR}/${MELONDS_INI}"
 else
 	sed -i '/^ScreenVSync=/c\ScreenVSync=1' "${CONF_DIR}/${MELONDS_INI}"
-fi
-
-#Show FPS
-if [ "$SHOWFPS" = "1" ]; then
-	export GALLIUM_HUD="simple,fps"
 fi
 
 # Extract archive to /tmp/melonds

--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -206,3 +206,6 @@ if [ ! -d "/storage/.config/mednafen/mednafen.cfg" ]; then
   # Don't load cd images to RAM, doesn't work with CHD or is at least very slow on rk3566
   sed -i "s/cd.image_memcache 1/cd.image_memcache 0/" /storage/.config/mednafen/mednafen.cfg
 fi
+
+# Clean melonds-sa Gallium HUD config
+sed -i '/nds.show_fps=/d' /storage/.config/system/configs/system.cfg

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -1103,10 +1103,6 @@
         <choice name="180" value="2"/>
         <choice name="270" value="3"/>
       </feature>
-      <feature name="show fps">
-        <choice name="yes" value="1"/>
-        <choice name="no" value="0"/>
-      </feature>
       <feature name="vsync">
         <choice name="on" value="1"/>
         <choice name="off" value="0"/>


### PR DESCRIPTION
Causes rendering issues on my Odin 2. Mangohud works well with for FPS monitoring on platforms where it is available.

Also clean the setting from `system.cfg` in post-update.

Tested on my Odin 2.