### PR TITLE
gst-plugins-base - add ROCKNIX package

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/package.mk
+++ b/projects/ROCKNIX/packages/apps/portmaster/package.mk
@@ -7,7 +7,7 @@ PKG_ARCH="arm aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/PortsMaster/PortMaster-GUI"
 PKG_URL="https://github.com/PortsMaster/PortMaster-GUI/releases/download/${PKG_VERSION}/PortMaster.zip"
-PKG_DEPENDS_TARGET="toolchain rocknix-hotkey gamecontrollerdb oga_controls control-gen xmlstarlet list-guid"
+PKG_DEPENDS_TARGET="toolchain rocknix-hotkey gamecontrollerdb oga_controls control-gen xmlstarlet list-guid gst-plugins-base"
 PKG_LONGDESC="Portmaster - a simple tool that allows you to download various game ports"
 PKG_TOOLCHAIN="manual"
 

--- a/projects/ROCKNIX/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/projects/ROCKNIX/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+. ${ROOT}/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+
+post_makeinstall_target() {
+  # clean up
+  safe_remove ${INSTALL}/usr/include
+  safe_remove ${INSTALL}/usr/lib/pkgconfig
+  safe_remove ${INSTALL}/usr/share
+}


### PR DESCRIPTION
Changes:
- `gst-plugins-base` - add ROCKNIX package, overriding `post_makeinstall_target()` to retain built libs
- add `gst-plugins-base` as a dependency to `portmaster` package

Results in this (2.3 MB):
```
$ tree ./build.ROCKNIX-SM8550.aarch64/install_pkg/gst-plugins-base-1.27.1/
./build.ROCKNIX-SM8550.aarch64/install_pkg/gst-plugins-base-1.27.1/
└── usr
    └── lib
        ├── gstreamer-1.0
        │   ├── libgstbasedebug.so
        │   ├── libgstdsd.so
        │   ├── libgstrawparse.so
        │   └── libgstsubparse.so
        ├── libgstallocators-1.0.so -> libgstallocators-1.0.so.0
        ├── libgstallocators-1.0.so.0 -> libgstallocators-1.0.so.0.2701.0
        ├── libgstallocators-1.0.so.0.2701.0
        ├── libgstapp-1.0.so -> libgstapp-1.0.so.0
        ├── libgstapp-1.0.so.0 -> libgstapp-1.0.so.0.2701.0
        ├── libgstapp-1.0.so.0.2701.0
        ├── libgstaudio-1.0.so -> libgstaudio-1.0.so.0
        ├── libgstaudio-1.0.so.0 -> libgstaudio-1.0.so.0.2701.0
        ├── libgstaudio-1.0.so.0.2701.0
        ├── libgstfft-1.0.so -> libgstfft-1.0.so.0
        ├── libgstfft-1.0.so.0 -> libgstfft-1.0.so.0.2701.0
        ├── libgstfft-1.0.so.0.2701.0
        ├── libgstpbutils-1.0.so -> libgstpbutils-1.0.so.0
        ├── libgstpbutils-1.0.so.0 -> libgstpbutils-1.0.so.0.2701.0
        ├── libgstpbutils-1.0.so.0.2701.0
        ├── libgstriff-1.0.so -> libgstriff-1.0.so.0
        ├── libgstriff-1.0.so.0 -> libgstriff-1.0.so.0.2701.0
        ├── libgstriff-1.0.so.0.2701.0
        ├── libgstrtp-1.0.so -> libgstrtp-1.0.so.0
        ├── libgstrtp-1.0.so.0 -> libgstrtp-1.0.so.0.2701.0
        ├── libgstrtp-1.0.so.0.2701.0
        ├── libgstrtsp-1.0.so -> libgstrtsp-1.0.so.0
        ├── libgstrtsp-1.0.so.0 -> libgstrtsp-1.0.so.0.2701.0
        ├── libgstrtsp-1.0.so.0.2701.0
        ├── libgstsdp-1.0.so -> libgstsdp-1.0.so.0
        ├── libgstsdp-1.0.so.0 -> libgstsdp-1.0.so.0.2701.0
        ├── libgstsdp-1.0.so.0.2701.0
        ├── libgsttag-1.0.so -> libgsttag-1.0.so.0
        ├── libgsttag-1.0.so.0 -> libgsttag-1.0.so.0.2701.0
        ├── libgsttag-1.0.so.0.2701.0
        ├── libgstvideo-1.0.so -> libgstvideo-1.0.so.0
        ├── libgstvideo-1.0.so.0 -> libgstvideo-1.0.so.0.2701.0
        └── libgstvideo-1.0.so.0.2701.0
```

Tested on my Odin 2 and OGU