### PR TITLE
Increase joystick ranges in Cemu controller profiles

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8250/controllerProfiles/wii_u_gamepad.xml
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8250/controllerProfiles/wii_u_gamepad.xml
@@ -8,7 +8,7 @@
 		<rumble>0.15</rumble>
 		<axis>
 			<deadzone>0.25</deadzone>
-			<range>1</range>
+			<range>2</range>
 		</axis>
 		<rotation>
 			<deadzone>0.25</deadzone>

--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8250/controllerProfiles/wii_u_pro_controller.xml
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8250/controllerProfiles/wii_u_pro_controller.xml
@@ -8,7 +8,7 @@
 		<rumble>0.15</rumble>
 		<axis>
 			<deadzone>0.25</deadzone>
-			<range>1</range>
+			<range>2</range>
 		</axis>
 		<rotation>
 			<deadzone>0.25</deadzone>

--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8550/controllerProfiles/wii_u_gamepad.xml
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8550/controllerProfiles/wii_u_gamepad.xml
@@ -8,7 +8,7 @@
 		<rumble>0.15</rumble>
 		<axis>
 			<deadzone>0.25</deadzone>
-			<range>1</range>
+			<range>2</range>
 		</axis>
 		<rotation>
 			<deadzone>0.25</deadzone>

--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8550/controllerProfiles/wii_u_pro_controller.xml
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8550/controllerProfiles/wii_u_pro_controller.xml
@@ -8,7 +8,7 @@
 		<rumble>0.15</rumble>
 		<axis>
 			<deadzone>0.25</deadzone>
-			<range>1</range>
+			<range>2</range>
 		</axis>
 		<rotation>
 			<deadzone>0.25</deadzone>

--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8650/controllerProfiles/wii_u_gamepad.xml
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8650/controllerProfiles/wii_u_gamepad.xml
@@ -8,7 +8,7 @@
 		<rumble>0.15</rumble>
 		<axis>
 			<deadzone>0.25</deadzone>
-			<range>1</range>
+			<range>2</range>
 		</axis>
 		<rotation>
 			<deadzone>0.25</deadzone>

--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8650/controllerProfiles/wii_u_pro_controller.xml
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/config/SM8650/controllerProfiles/wii_u_pro_controller.xml
@@ -8,7 +8,7 @@
 		<rumble>0.15</rumble>
 		<axis>
 			<deadzone>0.25</deadzone>
-			<range>1</range>
+			<range>2</range>
 		</axis>
 		<rotation>
 			<deadzone>0.25</deadzone>


### PR DESCRIPTION
Range 1 was not enough for some systems, for example in WWHD Link would be limited to walking instead of running.