### PR TITLE
linux - 6.12.59

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/linux/linux.aarch64.conf
+++ b/projects/ROCKNIX/devices/RK3326/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.57 Kernel Configuration
+# Linux/arm64 6.12.59 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-rocknix-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y

--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -35,7 +35,7 @@ case ${DEVICE} in
         PKG_VERSION="6.17.9"
       ;;
       *)
-        PKG_VERSION="6.12.57"
+        PKG_VERSION="6.12.59"
         PKG_PATCH_DIRS+=" 6.12-LTS"
       ;;
     esac


### PR DESCRIPTION
Bump 6.12 LTS to 6.12.59

Tested for RK3326 - build is fine, boots and runs fine on my OGA. I hit other issues with volume buttons, but this is also present in latest nightly.