### PR TITLE
wine - bump to 10.20

### DIFF
--- a/projects/ROCKNIX/packages/compat/wine/package.mk
+++ b/projects/ROCKNIX/packages/compat/wine/package.mk
@@ -2,20 +2,11 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="10.19"
+PKG_VERSION="10.20"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
-
-case ${DEVICE} in
-  SM8650)
-    PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-arm64-wow64.tar.xz"
-    ;;
-  *)
-    # Use the amd64 release as it supports running both 32-bit and 64-bit windows apps
-    PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64.tar.xz"
-    ;;
-esac
-
+# Use the amd64 release as it supports 32-bit, 64-bit and wow64 prefixes
+PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libXcomposite libXdmcp cups"
 PKG_LONGDESC="Wine is a compatibility layer capable of running Windows applications"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
Also switch back to the amd64 (non-wow64-only) release as it supports 32-bit, 64-bit and wow64 prefixes

Tested on my Odin 2.