### PR TITLE
rgb20s: update DTS for joypad and panel

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgb20s.dts
+++ b/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgb20s.dts
@@ -36,50 +36,20 @@
                 };
         };
 
-	joypad: rgb20s-joypad {
-                compatible = "rgb20s-joypad";
+	joypad: joypad {
+                compatible = "rocknix-singleadc-joypad";
 
                 pwms = <&pwm0 0 200000000 0>;
                 pwm-names = "enable";
                 rumble-boost-weak = <0x0000>;
                 rumble-boost-strong = <0x0000>;
 
-                joypad-name = "RGB20S Gamepad";
-                joypad-product = <0x1177>;
-                joypad-revision = <0x0177>;
+                joypad-name = "r36s_Gamepad";
+                joypad-product = <0x1188>;
+                joypad-revision = <0x0188>;
+                joypad-vendor = <0x0001>;
 
 		status = "okay";
-                /*
-                  - odroidgo3-joypad sysfs list -
-		   * for poll device interval(ms)
-		   /sys/devices/platform/odroidgo3_joypad/poll_interval [rw]
-		   ex) echo 20 > poll_interval
-                   * for button-adc-fuzz
-		   /sys/devices/platform/odroidgo3_joypad/adc_fuzz [r]
-                   * for button-adc-flat
-		   /sys/devices/platform/odroidgo3_joypad/adc_flat [r]
-
-		   * for report control(1:enable, 0:disable)
-		   /sys/devices/platform/odroidgo3_joypad/enable [rw]
-		   * for adc calibration value setup(current adcs value -> cal value)
-		   /sys/devices/platform/odroidgo3_joypad/adc_cal [rw]
-		   ex) echo 0 > adc_cal
-
-		   * for rumble period(ns)
-		   /sys/devices/platform/odroidgo3_joypad/rumble_period
-		   ex) echo 20000000 > rumble_duty_cycle
-		   ex) cat rumble_duty_cycle -->get current duty cycle
-
-		   * for rumble boost(0~65535)
-		   /sys/devices/platform/odroidgo3_joypad/rumble_boost_weak
-		   /sys/devices/platform/odroidgo3_joypad/rumble_boost_strong
-
-		   * for amux data debug
-		   * Joypad driver is disabled when using this sysfs.
-		   /sys/devices/platform/odroidgo3_joypad/amux_debug [rw]
-		   ex) echo 0 > amux_debug --> select amux channel
-		   ex) cat amux_debug --> get adc data of seleted channel
-                */
 
 		/* gpio pincontrol setup */
                 pinctrl-names = "default";
@@ -92,6 +62,8 @@
 
 		/* adc mux channel count */
 		amux-count = <4>;
+		/* non-default wiring */
+		amux-channel-mapping = <0 1 2 3>;
 		/* adc mux select(a,b) gpio */
 		amux-a-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_LOW>;
 		amux-b-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
@@ -116,17 +88,17 @@
 		  p = positive direction, n = negative direction
 		  report value = (real_adc_data * tuning_value) / 100
 		*/
-		abs_x-p-tuning = <200>;
-		abs_x-n-tuning = <200>;
+		abs_x-p-tuning = <400>;
+		abs_x-n-tuning = <400>;
 
-		abs_y-p-tuning = <200>;
-		abs_y-n-tuning = <200>;
+		abs_y-p-tuning = <400>;
+		abs_y-n-tuning = <400>;
 
-		abs_rx-p-tuning = <200>;
-		abs_rx-n-tuning = <200>;
+		abs_rx-p-tuning = <400>;
+		abs_rx-n-tuning = <400>;
 
-		abs_ry-p-tuning = <200>;
-		abs_ry-n-tuning = <200>;
+		abs_ry-p-tuning = <400>;
+		abs_ry-n-tuning = <400>;
 
 		/* poll device interval (ms), adc read interval */
 		poll-interval = <10>;
@@ -186,24 +158,21 @@
                 };
                 sw11 {
                         gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
-                        label = "GPIO F3";
-                        linux,code = <BTN_TRIGGER_HAPPY3>; // 0x2c2
+                        label = "GPIO BTN_THUMBL";
+                        linux,code = <BTN_THUMBL>; // 0x2c2
                 };
                 sw12 {
                         gpios = <&gpio2 RK_PA3 GPIO_ACTIVE_LOW>;
-                        label = "GPIO F4";
-                        linux,code = <BTN_TRIGGER_HAPPY4>; // 0x2c3
+                        label = "GPIO BTN_THUMBR";
+                        linux,code = <BTN_THUMBR>; // 0x2c3
                 };
-                /*sw13 {
+		
+                sw13 {
                         gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_LOW>;
-                        label = "GPIO F5";
-                        linux,code = <BTN_TRIGGER_HAPPY5>; // 0x2c4
+                        label = "GPIO BTN_FN";
+                        linux,code = <BTN_MODE>; // 0x2c4
                 };
-                sw14 {
-                        gpios = <&gpio2 RK_PA5 GPIO_ACTIVE_LOW>;
-                        label = "GPIO F6";
-                        linux,code = <BTN_TRIGGER_HAPPY6>; // 0x13c
-                };*/
+		
                 sw15 {
                         gpios = <&gpio2 RK_PA6 GPIO_ACTIVE_LOW>;
                         label = "GPIO TOP-LEFT";
@@ -216,8 +185,8 @@
                 };
                 sw19 {
                         gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;
-                        label = "GPIO F1";
-                        linux,code = <BTN_TRIGGER_HAPPY1>;
+                        label = "GPIO BTN_SELECT";
+                        linux,code = <BTN_SELECT>;
                 };
                 sw20 {
                         gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
@@ -231,8 +200,8 @@
                 };
                 sw22 {
                         gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
-                        label = "GPIO F2";
-                        linux,code = <BTN_TRIGGER_HAPPY2>;
+                        label = "GPIO BTN_START";
+                        linux,code = <BTN_START>;
                 };
         };
 
@@ -264,9 +233,76 @@
 
 &internal_display {
 //	compatible = "anbernic,rg351v-panel", "newvision,nv3051d";
-	compatible = "powkiddy,rk2023-panel", "newvision,nv3051d";
+	// compatible = "powkiddy,rk2023-panel", "newvision,nv3051d";
+	compatible = "rocknix,generic-dsi";
 	iovcc-supply = <&vcc_lcd>;
 	vdd-supply = <&vcc_lcd>;
+	panel_description =
+	"G size=52,70 delays=2,1,20,120,20 format=rgb888 lanes=4 flags=0xe03",
+	
+	"M clock=26400 horizontal=640,119,2,119 vertical=480,13,2,5 default=1",
+	"M clock=27300 horizontal=640,207,24,207 vertical=480,13,9,5",
+	"M clock=26400 horizontal=640,207,2,207 vertical=480,13,2,5",
+	"M clock=27140 horizontal=640,119,45,119 vertical=480,13,90,5",
+	"M clock=26450 horizontal=640,119,42,119 vertical=480,13,2,5",
+	"M clock=28520 horizontal=640,119,3,119 vertical=480,13,44,5",
+	"M clock=31440 horizontal=640,119,39,119 vertical=480,13,74,5",
+	"M clock=26440 horizontal=640,31,30,31 vertical=480,13,103,5",
+	"M clock=31970 horizontal=640,31,36,31 vertical=480,13,76,5",
+	// "M clock=31680 horizontal=640,31,2,31 vertical=480,13,2,5", 
+	"M clock=42240 horizontal=640,31,2,31 vertical=480,13,2,5",
+	
+	"I seq=ff30", "I seq=ff52", "I seq=ff01",
+	"I seq=e300",
+	"I seq=400a",
+	"I seq=0340", "I seq=0400", "I seq=0503",
+	"I seq=2412", "I seq=251e", "I seq=2628", "I seq=2752",
+	"I seq=2857", "I seq=2901", "I seq=2adf",
+	"I seq=389c", "I seq=39a7", "I seq=3a53",
+	"I seq=4400",
+	"I seq=493c",
+	"I seq=59fe", "I seq=5c00",
+	"I seq=9177", "I seq=9277",
+	"I seq=a055", "I seq=a150", "I seq=a49c", "I seq=a702",
+	"I seq=a801", "I seq=a901", "I seq=aafc", "I seq=ab28", "I seq=ac06", "I seq=ad06", "I seq=ae06", "I seq=af03",
+	"I seq=b008", "I seq=b126", "I seq=b228", "I seq=b328", "I seq=b433", "I seq=b508", "I seq=b626", "I seq=b708",
+	"I seq=b826",
+	"I seq=ff30", "I seq=ff52", "I seq=ff02",
+	"I seq=b00b", "I seq=b116", "I seq=b217", "I seq=b32c", "I seq=b432", "I seq=b53b", "I seq=b629", "I seq=b740",
+	"I seq=b80d", "I seq=b905", "I seq=ba12", "I seq=bb10", "I seq=bc12", "I seq=bd15", "I seq=be19", "I seq=bf0e",
+	"I seq=c016", "I seq=c10a",
+	"I seq=d00c", "I seq=d117", "I seq=d214", "I seq=d32e", "I seq=d432", "I seq=d53c", "I seq=d622", "I seq=d73d",
+	"I seq=d80d", "I seq=d907", "I seq=da13", "I seq=db13", "I seq=dc11", "I seq=dd15", "I seq=de19", "I seq=df10",
+	"I seq=e017", "I seq=e10a",
+	"I seq=ff30", "I seq=ff52", "I seq=ff03",
+	"I seq=002a", "I seq=012a", "I seq=022a", "I seq=032a", "I seq=0461", "I seq=0580", "I seq=06c7", "I seq=0701",
+	"I seq=0882", "I seq=0983",
+	"I seq=302a", "I seq=312a", "I seq=322a", "I seq=332a", "I seq=3461", "I seq=35c5", "I seq=3680", "I seq=3723",
+	"I seq=4082", "I seq=4183", "I seq=4280", "I seq=4381", "I seq=4411", "I seq=45e6", "I seq=46e5", "I seq=4711",
+	"I seq=48e8", "I seq=49e7",
+	"I seq=5002", "I seq=5101", "I seq=5204", "I seq=5303", "I seq=5411", "I seq=55ea", "I seq=56e9", "I seq=5711",
+	"I seq=58ec", "I seq=59eb",
+	"I seq=7e02", "I seq=7f80",
+	"I seq=e05a",
+	"I seq=b100", "I seq=b40e", "I seq=b50f", "I seq=b604", "I seq=b707",
+	"I seq=b806", "I seq=b905", "I seq=ba0f",
+	"I seq=c700",
+	"I seq=ca0e", "I seq=cb0f", "I seq=cc04", "I seq=cd07", "I seq=ce06", "I seq=cf05",
+	"I seq=d00f",
+	"I seq=810f", "I seq=840e", "I seq=850f", "I seq=8607", "I seq=8704",
+	"I seq=8805", "I seq=8906", "I seq=8a00",
+	"I seq=970f",
+	"I seq=9a0e", "I seq=9b0f", "I seq=9c07", "I seq=9d04", "I seq=9e05", "I seq=9f06",
+	"I seq=a000",
+	"I seq=ff30", "I seq=ff52", "I seq=ff02",
+	"I seq=0101", "I seq=02da", "I seq=03ba", "I seq=04a8", "I seq=059a", "I seq=0670", "I seq=07ff",
+	"I seq=0891", "I seq=0990", "I seq=0aff", "I seq=0b8f", "I seq=0c60", "I seq=0d58", "I seq=0e48", "I seq=0f38",
+	"I seq=102b",
+	"I seq=ff30", "I seq=ff52", "I seq=ff00",
+	"I seq=3602",
+	"I seq=3a70",
+	"I seq=11 wait=200",
+	"I seq=29 wait=10";
 };
 
 &io_domains {
@@ -328,7 +364,6 @@
 					<2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>,
 					<2 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>,
 					<2 RK_PA4 RK_FUNC_GPIO &pcfg_pull_up>,
-					<2 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
 					<2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
 					<2 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>,
 					<3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,


### PR DESCRIPTION
This PR updates the RGB20S device tree.

Changes:
- Switch controller driver to rocknix-singleadc-joypad
- Replace panel driver with rocknix,generic-dsi
- Add FN key mapping

Tested on real hardware with:
- evtest
- sdljoytest
- EmulationStation
- RetroArch

Analog stick, FN key, and buttons work correctly.
Panel refresh rate switching works correctly as well, with no black screen issues.