### PR TITLE
[portmaster_sway_fullscreen.sh] Explicitly map all input devices to the active game seat

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 # Will be called by PortMaster mod_ROCKNIX.txt
 
-# Call the function to fullscreen the window for app_id asynchronously
 . /etc/profile.d/001-functions
-sway_fullscreen "${1}" &
 
-# Explicitly map all input devices to the active game seat to prevent wayland focus revocation, and unify virtual input nodes.
-swaymsg 'seat seat1 attach "*"'
-swaymsg 'seat * keyboard_grouping smart'
+if echo "${UI_SERVICE}" | grep -q "sway"; then
+    # Call the function to fullscreen the window for app_id asynchronously
+    sway_fullscreen "${1}" &
+
+    # Explicitly map all input devices to the active game seat to prevent wayland focus revocation, and unify virtual input nodes.
+    swaymsg 'seat seat1 attach "*"'
+    swaymsg 'seat * keyboard_grouping smart'
+fi

--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -4,3 +4,7 @@
 # Call the function to fullscreen the window for app_id asynchronously
 . /etc/profile.d/001-functions
 sway_fullscreen "${1}" &
+
+# Explicitly map all input devices to the active game seat to prevent wayland focus revocation, and unify virtual input nodes.
+swaymsg 'seat seat1 attach "*"'
+swaymsg 'seat * keyboard_grouping smart'


### PR DESCRIPTION
On multi-seat/dual-screen devices (like the AYN Thor), games using Wayland (vs xWayland) lose all input from gptokeyb upon entering fullscreen or during workspace migration.

This happens because the newer sway versions enforce strict seat-ownership. When a window changes state to fullscreen or moves between outputs (DSI-1 to DSI-2), Sway may revoke access to input devices that are not explicitly "trusted" or "attached" to the active seat. Since gptokeyb fake input devices are created dynamically, they land on a default seat that doesn't match the seat where the game window is currently focused.

To resolve this, modify `portmaster_sway_fullscreen.sh` to perform a "handshake" of input devices the moment a game is launched and fullscreened.

`seat seat1 attach "*"` - This forces all available input devices (physical and virtual) to be attached to the active game seat. This prevents "Focus Revocation," ensuring the game can see the virtual keyboard immediately after the fullscreen transition.

`seat * keyboard_grouping smart` -  This unifies the virtual input nodes across all seats. This is critical for dual-screen users; it prevents the game from crashing or losing input when a hotkey is used to swap the game workspace between the top and bottom screens.

Test method used below, can be tested without rebuilding rocknix.

```
cp /usr/bin/portmaster_sway_fullscreen.sh /storage/portmaster_sway_fullscreen.sh
nano /storage/portmaster_sway_fullscreen.sh
mount --bind /storage/portmaster_sway_fullscreen.sh /usr/bin/portmaster_sway_fullscreen.sh
cat /usr/bin/portmaster_sway_fullscreen.sh
```