### PR TITLE
Update freej2me emulator

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/freej2me-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/freej2me-lr/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="freej2me-lr"
-PKG_VERSION="8b9bc8a19baf26e3d92f88934a64a32f1cbc2795"
-PKG_SITE="https://github.com/hex007/freej2me"
-PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_VERSION="1.52"
+PKG_SITE="https://github.com/TASEmulators/freej2me-plus"
+PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain apache-ant:host libXtst"
-PKG_LONGDESC="A free J2ME emulator with libretro, awt and sdl2 frontends."
+PKG_LONGDESC="J2ME emulator with libretro and AWT frontends, it aims to run on basically anything that can run a Java VM."
 PKG_TOOLCHAIN="make"
 
 pre_configure_target() {


### PR DESCRIPTION
This PR updates old freej2me emulator (https://github.com/hex007/freej2me) to new one fork (https://github.com/TASEmulators/freej2me-plus).

Changes:
- Updates repo and path to package
- Everything else doesn`t changed (old scripts and jdk installer works fine)!

Fixes (need more testing to find more..):
- Emulator now works on libmali GPU driver
- Now user can enable "Use Analog As Entire Keypad" to use analog stick as entire keypad (not only 2,4,6,8)

Tested:
- This changes already tested on self-build for Anbernic RG353VS (RK3655).

Future Updates:
- Now for updates you only need to change normal version in ```PKG_VERSION``` variable