### PR TITLE
libmali - fix S922X build

### DIFF
--- a/projects/ROCKNIX/packages/graphics/libmali/package.mk
+++ b/projects/ROCKNIX/packages/graphics/libmali/package.mk
@@ -17,7 +17,7 @@ PKG_PATCH_DIRS+=" ${DEVICE}"
 # patchelf is incompatible with strip, but is needed to ensure apps call wrapped functions
 PKG_BUILD_FLAGS="-strip"
 
-case "$(DEVICE)" in
+case "${DEVICE}" in
   S922X)
     PKG_VERSION="r51p0"
     MALI_FAMILY="meson"


### PR DESCRIPTION
Currently it falls through the case test for S922X and tries to build with g24p0 instead of r51p0, this fixes the build