### PR TITLE
S922X - enable MangoHud for Panfrost

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/S922X/075-mangohud-supported
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/S922X/075-mangohud-supported
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+GPUDRIVER=$(/usr/bin/gpudriver)
+MANGOHUD_ENABLED=$(get_setting "rocknix.mangohud.enabled")
+
+# Init setting to 'disabled'
+if [ ! -n "${MANGOHUD_ENABLED}" ]; then
+  set_setting "rocknix.mangohud.enabled" "0"
+fi
+
+# Enable / disable MangoHud support (panfrost / libmali)
+if [ "${GPUDRIVER}" == "panfrost" ]; then
+  cat <<EOF >/storage/.config/profile.d/075-mangohud-supported
+DEVICE_MANGOHUD_SUPPORT="true"
+EOF
+else
+  cat <<EOF >/storage/.config/profile.d/075-mangohud-supported
+DEVICE_MANGOHUD_SUPPORT="false"
+EOF
+fi

--- a/projects/ROCKNIX/packages/rocknix/profile.d/101-gpu-functions
+++ b/projects/ROCKNIX/packages/rocknix/profile.d/101-gpu-functions
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+function gpu_profiling() {
+  local sysfs_node
+  local profiling_state=${1}
+  
+  case "${HW_DEVICE}" in
+    S922X)
+      sysfs_node="/sys/bus/platform/drivers/panfrost/ffe40000.gpu/profiling"
+
+      case "${profiling_state}" in
+        "on")
+          echo 1 > "${sysfs_node}"
+        ;;
+        "off")
+          echo 0 > "${sysfs_node}"
+        ;;
+      esac
+    ;;
+  esac
+}

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
@@ -378,11 +378,15 @@ CPU_GOVERNOR=$(get_setting "cpugovernor" "${PLATFORM}" "${ROMNAME##*/}")
 ${VERBOSE} && log $0 "Set emulation performance mode to (${CPU_GOVERNOR})"
 ${CPU_GOVERNOR}
 
-# Check for MangoHud support and turn MangoHud off by defualt, will add ES feature later
-MANGOHUD_ENABLED=$(get_setting "rocknix.mangohud.enabled"  "${PLATFORM}" "${ROMNAME##*/}")
-if [ "${MANGOHUD_ENABLED}" = "1" ]; then
-  RUNTHIS="/usr/bin/mangohud ${RUNTHIS}"
-  ${VERBOSE} && log $0 "Enabling MangoHud"
+### Check whether MangoHud is supported and enabled
+if [ "${DEVICE_MANGOHUD_SUPPORT}" == "true" ]; then
+  MANGOHUD_ENABLED=$(get_setting "rocknix.mangohud.enabled"  "${PLATFORM}" "${ROMNAME##*/}")
+  if [ "${MANGOHUD_ENABLED}" = "1" ]; then
+    # Enable GPU profiling and MangoHud
+    gpu_profiling "on"
+    RUNTHIS="/usr/bin/mangohud ${RUNTHIS}"
+    ${VERBOSE} && log $0 "Enabling MangoHud"
+  fi
 fi
 
 # If the rom is a shell script just execute it, useful for DOSBOX and ScummVM scan scripts
@@ -445,6 +449,9 @@ then
 else
         onlinethreads all 1 &
 fi
+
+### Disable GPU profiling
+gpu_profiling "off"
 
 ### Backup save games
 CLOUD_BACKUP=$(get_setting "cloud.backup")

--- a/projects/ROCKNIX/packages/virtual/gamesupport/package.mk
+++ b/projects/ROCKNIX/packages/virtual/gamesupport/package.mk
@@ -10,7 +10,7 @@ PKG_LONGDESC="Game support software metapackage."
 PKG_GAMESUPPORT="sixaxis rocknix-hotkey jstest-sdl gamecontrollerdb sdljoytest sdltouchtest control-gen sdl2text"
 
 case ${DEVICE} in
-  SM8250|SM8550|SM8650|SDM845)
+  SM8250|SM8550|SM8650|SDM845|S922X)
     PKG_GAMESUPPORT+=" mangohud"
   ;;
 esac


### PR DESCRIPTION
Tested ok on my OGU. Regression tested ok on my Odin 2.

Note: `gpu_profiling()` only currently implemented for S922X, but is intended to be expanded for other Panfrost platforms as needed