### PR TITLE
RK3566/rg-ds: DTS tweaks for improved compatibility out of the box

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -478,7 +478,7 @@
 		panel_description =
 			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
 
-			"M clock=42133 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
+			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
 			
 			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
 			"I seq=8003",
@@ -567,7 +567,7 @@
 		panel_description =
 			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
 
-			"M clock=42133 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
+			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
 
 			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
 			"I seq=8003",

--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -1247,28 +1247,25 @@
 	status = "okay";
 };
 
+&usb2phy0_host {
+	status = "okay";
+};
+
 &usb2phy0_otg {
 	vbus-supply = <&vcc5v0_otg>;
 	status = "okay";
 };
 
 &usb2phy1_host {
+	vbus-supply = <&vcc5v0_usb>;
+	status = "okay";
+};
+
+&usb2phy1_otg {
 	status = "okay";
 };
 
 &usb_host0_ehci {
-	status = "okay";
-};
-
-&usb_host0_ohci {
-	status = "okay";
-};
-
-&usb_host1_ehci {
-	status = "okay";
-};
-
-&usb_host1_ohci {
 	status = "okay";
 };
 
@@ -1278,6 +1275,10 @@
 	phy-names = "usb2-phy";
 	extcon = <&usb2phy0>;
 	maximum-speed = "high-speed";
+	status = "okay";
+};
+
+&usb_host1_ehci {
 	status = "okay";
 };
 
@@ -1312,8 +1313,15 @@
 	};
 };
 
+/* The following nodes break PM unless disabled */
 &combphy1 {
-	/* Possibly not wired?
-	   Needs re-test later */
+	status = "disabled";
+};
+
+&usb_host0_ohci {
+	status = "disabled";
+};
+
+&usb_host1_ohci {
 	status = "disabled";
 };

--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -218,6 +218,10 @@
 	 * which is likely incorrect but I cannot validate; furthermore
 	 * the onboard charger of the rk817 cannot charge past 3.5A
 	 * anyway.
+	 *
+	 * The current OCV table has been extended to the expected endpoint
+	 * for a 3.8V 4000mAh battery, monitoring for actual discharge rates
+	 * will take time, but this will at least provide more base runtime. 
 	 */
 	battery: battery {
 		compatible = "simple-battery";
@@ -225,7 +229,7 @@
 		precharge-current-microamp = <180000>;
 		precharge-upper-limit-microvolt = <3600000>;
 		charge-term-current-microamp = <300000>;
-		constant-charge-current-max-microamp = <10000000>;
+		constant-charge-current-max-microamp = <3500000>;
 		constant-charge-voltage-max-microvolt = <4350000>;
 		factory-internal-resistance-micro-ohms = <80000>;
 		voltage-max-design-microvolt = <4350000>;
@@ -238,7 +242,9 @@
     		                    <3931000 55>, <3904000 50>, <3882000 45>,
     		                    <3862000 40>, <3844000 35>, <3828000 30>,
     		                    <3811000 25>, <3794000 20>, <3778000 15>,
-    		                    <3762000 10>, <3740000 5>, <3700000 0>;
+    		                    <3762000 10>, <3740000 8>, <3700000 6>,
+    		                    <3650000 4>, <3600000 2>, <3500000 1>,
+    		                    <3000000 0>;
     };
 
 	leds: pwm-leds {
@@ -316,7 +322,6 @@
 		gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
 		pinctrl-0 = <&vcc3v3_lcd0_h>;
 		pinctrl-names = "default";
-		regulator-always-on;
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		regulator-name = "vcc3v3_lcd0";
@@ -331,7 +336,6 @@
 		gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
 		pinctrl-0 = <&vcc1v8_lcd0_h>;
 		pinctrl-names = "default";
-		regulator-always-on;
 		regulator-min-microvolt = <1800000>;
 		regulator-max-microvolt = <1800000>;
 		regulator-name = "vcc1v8_lcd0";
@@ -346,7 +350,6 @@
 		gpio = <&gpio0 RK_PC2 GPIO_ACTIVE_HIGH>;
 		pinctrl-0 = <&vcc3v3_lcd1_h>;
 		pinctrl-names = "default";
-		regulator-always-on;
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		regulator-name = "vcc3v3_lcd1";
@@ -361,7 +364,6 @@
 		gpio = <&gpio0 RK_PC1 GPIO_ACTIVE_HIGH>;
 		pinctrl-0 = <&vcc1v8_lcd1_h>;
 		pinctrl-names = "default";
-		regulator-always-on;
 		regulator-min-microvolt = <1800000>;
 		regulator-max-microvolt = <1800000>;
 		regulator-name = "vcc1v8_lcd1";

--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -478,8 +478,8 @@
 		panel_description =
 			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
 
-			"M clock=21334 horizontal=640,30,14,20 vertical=480,10,2,16 default=1",
-
+			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
+			
 			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
 			"I seq=8003",
 			"I seq=e001",
@@ -567,7 +567,7 @@
 		panel_description =
 			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
 
-			"M clock=21334 horizontal=640,30,14,20 vertical=480,10,2,16 default=1",
+			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
 
 			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
 			"I seq=8003",

--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -478,7 +478,7 @@
 		panel_description =
 			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
 
-			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
+			"M clock=42133 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
 			
 			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
 			"I seq=8003",
@@ -567,7 +567,7 @@
 		panel_description =
 			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
 
-			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
+			"M clock=42133 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
 
 			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
 			"I seq=8003",

--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -1247,21 +1247,12 @@
 	status = "okay";
 };
 
-&usb2phy0_host {
-	status = "okay";
-};
-
 &usb2phy0_otg {
 	vbus-supply = <&vcc5v0_otg>;
 	status = "okay";
 };
 
 &usb2phy1_host {
-	vbus-supply = <&vcc5v0_usb>;
-	status = "okay";
-};
-
-&usb2phy1_otg {
 	status = "okay";
 };
 


### PR DESCRIPTION
Reverted panel timings to stock for now to hopefully improve compatibility.
Removed `regulator-always-on;` from the lcd regulators for possible power savings.
Extended battery ocv table for slightly more runtime while uncalibrated.
Possibly breaks USB1.1 enumeration to fix suspend/wake