### PR TITLE
mangohud - enable battery_watt

### DIFF
--- a/projects/ROCKNIX/packages/apps/mangohud/config/MangoHud.conf
+++ b/projects/ROCKNIX/packages/apps/mangohud/config/MangoHud.conf
@@ -134,7 +134,7 @@ battery
 # battery_icon
 # device_battery=gamepad,mouse
 # device_battery_icon
-# battery_watt
+battery_watt
 # battery_time
 
 ### Display FPS and frametime


### PR DESCRIPTION
Tested on my OGU (supported, works well), OGA and Odin 2 (not supported, not displayed gracefully)