### PR TITLE
Add Mako on screen display utility

### DIFF
--- a/projects/ROCKNIX/packages/apps/mako-osd/mako-notify/Makefile
+++ b/projects/ROCKNIX/packages/apps/mako-osd/mako-notify/Makefile
@@ -1,0 +1,11 @@
+CXX ?= g++
+CCFLAGS = -W -Wall -std=c++11 `pkg-config --cflags dbus-1`
+BINARY := mako-notify
+LIBRARIES = `pkg-config --libs dbus-1`
+SOURCES := mako-notify.cpp
+
+all:
+	$(CXX) $(CCFLAGS) $(SOURCES) -o $(BINARY) $(LIBRARIES)
+
+clean:
+	rm -f $(BINARY)

--- a/projects/ROCKNIX/packages/apps/mako-osd/mako-notify/mako-notify.cpp
+++ b/projects/ROCKNIX/packages/apps/mako-osd/mako-notify/mako-notify.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+#include <dbus/dbus.h>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+const std::string CONFIG_DIR = "/storage/.config/mako";
+const std::string CONFIG_FILE = CONFIG_DIR + "/config";
+
+void ensure_mako_config() {
+    // Check if directory exists
+    struct stat st{};
+    if (stat(CONFIG_DIR.c_str(), &st) != 0) {
+        // Directory does not exist, create it
+        if (mkdir(CONFIG_DIR.c_str(), 0755) != 0) {
+            perror("Failed to create config directory");
+            return;
+        }
+    }
+
+    // Check if file exists
+    if (stat(CONFIG_FILE.c_str(), &st) != 0) {
+        // File does not exist, create it with default contents
+        std::ofstream ofs(CONFIG_FILE);
+        if (!ofs) {
+            std::cerr << "Failed to create config file at " << CONFIG_FILE << std::endl;
+            return;
+        }
+
+        ofs <<
+"max-visible=1\n"
+"layer=overlay\n"
+"font=monospace 30\n"
+"text-color=#ffffff\n"
+"text-alignment=center\n"
+"background-color=#000000\n"
+"border-size=0\n"
+"border-radius=10\n"
+"default-timeout=1500\n"
+"anchor=top-center\n"
+"width=500\n";
+
+        ofs.close();
+    }
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <message>" << std::endl;
+        std::cerr << "Example: " << argv[0] << " \"Hello World\"" << std::endl;
+        return 1;
+    }
+
+    // Ensure the Mako config exists
+    ensure_mako_config();
+
+    DBusError err;
+    dbus_error_init(&err);
+
+    // Connect to the session bus
+    DBusConnection* conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
+    if (dbus_error_is_set(&err)) {
+        std::cerr << "Connection Error: " << err.message << std::endl;
+        dbus_error_free(&err);
+        return 1;
+    }
+    if (!conn) return 1;
+
+    // Create a method call
+    DBusMessage* msg = dbus_message_new_method_call(
+        "org.freedesktop.Notifications",  // destination
+        "/org/freedesktop/Notifications", // object path
+        "org.freedesktop.Notifications",  // interface
+        "Notify"                          // method
+    );
+
+    if (!msg) {
+        std::cerr << "Message Null" << std::endl;
+        return 1;
+    }
+
+    // Build arguments
+    DBusMessageIter args;
+    dbus_message_iter_init_append(msg, &args);
+
+    const char* app_name = "mako-notify";
+    uint32_t replaces_id = 0;
+    const char* icon = "";
+    const char* summary = argv[1];
+    const char* body = argv[1];
+    int32_t timeout = 2000;
+
+    dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &app_name);
+    dbus_message_iter_append_basic(&args, DBUS_TYPE_UINT32, &replaces_id);
+    dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &icon);
+    dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &summary);
+    dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &body);
+
+    // empty array of actions
+    DBusMessageIter array_iter;
+    dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "s", &array_iter);
+    dbus_message_iter_close_container(&args, &array_iter);
+
+    // empty dictionary for hints
+    DBusMessageIter dict_iter;
+    dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "{sv}", &dict_iter);
+    dbus_message_iter_close_container(&args, &dict_iter);
+
+    dbus_message_iter_append_basic(&args, DBUS_TYPE_INT32, &timeout);
+
+    // Send message
+    DBusPendingCall* pending = nullptr;
+    if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
+        std::cerr << "Failed to send message" << std::endl;
+        return 1;
+    }
+
+    dbus_connection_flush(conn);
+    dbus_message_unref(msg);
+
+    // Wait for reply
+    if (pending) dbus_pending_call_block(pending);
+    if (pending) dbus_pending_call_unref(pending);
+
+    return 0;
+}

--- a/projects/ROCKNIX/packages/apps/mako-osd/mako-notify/package.mk
+++ b/projects/ROCKNIX/packages/apps/mako-osd/mako-notify/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="mako-notify"
+PKG_VERSION="v1.0"
+PKG_LICENSE="GPLv2"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Tool to show onscreen messages in sway, via the mako-osd tool"
+PKG_TOOLCHAIN="make"
+
+pre_make_target() {
+  cp -f ${PKG_DIR}/Makefile ${PKG_BUILD}
+  cp -f ${PKG_DIR}/mako-notify.cpp ${PKG_BUILD}
+  CFLAGS+=" -D_REENTRANT"
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp -r  ${PKG_BUILD}/mako-notify ${INSTALL}/usr/bin
+  chmod +x ${INSTALL}/usr/bin
+}

--- a/projects/ROCKNIX/packages/apps/mako-osd/package.mk
+++ b/projects/ROCKNIX/packages/apps/mako-osd/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="mako-osd"
+PKG_VERSION="b131bc143f6b0f24d650f16bb88a11c7cb011c20"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/emersion/mako"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain cairo wayland sway pango glib mako-notify"
+PKG_LONGDESC="Meso - A lightweight notification daemon for Wayland. Works on Sway."
+PKG_TOOLCHAIN="meson"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp -r  ${PKG_BUILD}/.${TARGET_NAME}/mako ${INSTALL}/usr/bin
+  cp -r  ${PKG_BUILD}/.${TARGET_NAME}/makoctl ${INSTALL}/usr/bin
+  chmod +x ${INSTALL}/usr/bin
+}

--- a/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -451,6 +451,7 @@ set +e
         if [ "${HOTKEY_A_PRESSED}" = true ]; then
           ${DEBUG} && log $0 "${FUNCTION_HOTKEY_BTN_EAST_EVENT}: Screenshot Taken"
           /usr/bin/rocknix-screenshot
+          /usr/bin/mako-notify "Screenshot Saved"
         fi
       ;;
      (${FUNCTION_HOTKEY_BTN_WEST_EVENT})

--- a/projects/ROCKNIX/packages/virtual/image/package.mk
+++ b/projects/ROCKNIX/packages/virtual/image/package.mk
@@ -13,7 +13,7 @@ PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host 
                     ${BOOTLOADER} busybox umtprd util-linux usb-modeswitch poppler jq socat \
                     p7zip file initramfs grep util-linux btrfs-progs zstd lz4 empty lzo libzip \
                     bash coreutils system-utils autostart quirks powerstate gnupg \
-                    gzip six xmlstarlet pyudev dialog network rocknix"
+                    gzip six xmlstarlet pyudev dialog network mako-osd rocknix"
 
 PKG_UI="emulationstation es-themes textviewer"
 

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/config/config.kiosk
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/config/config.kiosk
@@ -1,2 +1,3 @@
 seat * hide_cursor 1000
 default_border none
+exec_always mako

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/scripts/sway.sh
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/scripts/sway.sh
@@ -10,6 +10,10 @@ if [ ! -z "$(lsmod | grep 'nvidia')" ]; then
   SWAY_GPU_ARGS="--unsupported-gpu"
 fi
 
+if [ ! -S "$XDG_RUNTIME_DIR/bus" ]; then
+    dbus-daemon --session --address=unix:path=$XDG_RUNTIME_DIR/bus &
+fi
+
 # start sway, even if no input devices are connected
 export WLR_LIBINPUT_NO_DEVICES=1
 


### PR DESCRIPTION
This utility allows us to display on screen messages in both ES and in game. 

Usage /usr/bin/mako-notify "your text here"

Right now just for screenshot but the possibilities are endless.

<img width="1920" height="1080" alt="mako" src="https://github.com/user-attachments/assets/2158f686-ce78-424c-a65a-b3b004dcec62" />
