### PR TITLE
correctly workaround pipewire volume issue on RK3566

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/050-modifiers
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/050-modifiers
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2022-present Fewtarius
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX) 
 
 cat <<EOF >/storage/.config/profile.d/050-modifiers
 DEVICE_FUNC_KEYA_MODIFIER="BTN_MODE"

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/050-modifiers
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/050-modifiers
@@ -1,3 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022-present Fewtarius
+
 cat <<EOF >/storage/.config/profile.d/050-modifiers
 DEVICE_FUNC_KEYA_MODIFIER="BTN_MODE"
 DEVICE_FUNC_KEYB_MODIFIER="BTN_START"

--- a/projects/ROCKNIX/packages/hardware/quirks/package.mk
+++ b/projects/ROCKNIX/packages/hardware/quirks/package.mk
@@ -22,4 +22,8 @@ makeinstall_target() {
 
 post_install() {
   enable_service led-poweroff.service
+  if [ "${DEVICE}" = "RK3566" ]
+  then
+    enable_service volume-fixup.service
+  fi
 }

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/050-modifiers
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/050-modifiers
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2022-present Fewtarius
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX) 
 
 cat <<EOF >/storage/.config/profile.d/050-modifiers
 DEVICE_KEY_VOLUMEDOWN=114

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/050-modifiers
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/050-modifiers
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX) 
+# Copyright (C) 2022-present Fewtarius
 
 cat <<EOF >/storage/.config/profile.d/050-modifiers
 DEVICE_KEY_VOLUMEDOWN=114

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/051-volume_align
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/051-volume_align
@@ -1,6 +1,0 @@
-#!/bin/sh
-. /etc/profile.d/001-functions
-
-### Explicitly set both main volumes, otherwise one stale value will override the other
-amixer sset "Master" $(get_setting "audio.volume")%
-amixer sset "Capture" $(get_setting "audio.volume")%

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/bin/volumealign
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/bin/volumealign
@@ -1,11 +1,22 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present Noxwell (https://github.com/beebono)
+
+# RK3566 currently requires this service-run script to correct an intermittent volume
+# issue with PipeWire setting volumes to 100% that happens at some point between 
+# audio configuration and EmulationStation being launched.
 
 # Minimal OS variable loading for performance
 . /etc/profile.d/001-functions
 
 VOLUME=$(get_setting "audio.volume")
+
+# pw-cli uses perceptually based cubic volume levels directly
 CUBIC_VOL=$(echo "scale=6; ($VOLUME / 100) ^ 3" | bc)
+
+# pw-cli doesn't accept @DEFAULT_SINK@ so we have to get that first
 DEFAULT_SINK=$(wpctl inspect @DEFAULT_SINK@ | grep -ozP 'id \K\d+')
 
+# Use pw-cli specifically instead of pactl and wpctl which don't apply changes if they think
+# the volume levels are already correct, because they track a separate unified volume value
 pw-cli set-param $DEFAULT_SINK Props "{ channelVolumes: [ $CUBIC_VOL, $CUBIC_VOL ], softVolumes: [ $CUBIC_VOL, $CUBIC_VOL ] }"

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/bin/volumealign
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/bin/volumealign
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+VOLUME=$(get_setting "audio.volume")
+CUBIC_VOL=$(echo "scale=6; ($VOLUME / 100) ^ 3" | bc)
+DEFAULT_SINK=$(wpctl inspect @DEFAULT_SINK@ | grep -ozP 'id \K\d+')
+
+pw-cli set-param $DEFAULT_SINK Props "{ channelVolumes: [ $CUBIC_VOL, $CUBIC_VOL ], softVolumes: [ $CUBIC_VOL, $CUBIC_VOL ] }"

--- a/projects/ROCKNIX/packages/hardware/quirks/system.d/volume-fixup.service
+++ b/projects/ROCKNIX/packages/hardware/quirks/system.d/volume-fixup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fix unset volumes on RK3566 devices 
+After=rocknix.target
+Before=essway.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/autostart/quirks/platforms/RK3566/bin/volumealign
+
+[Install]
+WantedBy=rocknix.target


### PR DESCRIPTION
also adds missing shebang/header to 050-modifiers for rg ds