### PR TITLE
RK3566 and S922X bump to 6.18.6

### DIFF
--- a/projects/ROCKNIX/devices/S922X/patches/linux/S922X/0005-arm64-meson-odroid-go-ultra-add-joypad.patch
+++ b/projects/ROCKNIX/devices/S922X/patches/linux/S922X/0005-arm64-meson-odroid-go-ultra-add-joypad.patch
@@ -98,7 +98,7 @@ index 85f4a5a0535e..083646a8741d 100644
 +		joypad-revision = <0x0100>;
 +
 +		/* Analog sticks */
-+		io-channels = <&saradc 0>, <&saradc 1>, <&saradc 2>, <&saradc 3>;
++		io-channels = <&saradc 1>, <&saradc 0>, <&saradc 3>, <&saradc 2>;
 +		io-channel-names = "key-RY", "key-RX", "key-LY", "key-LX";
 +		button-adc-scale = <4>;
 +		button-adc-deadzone = <64>;

--- a/projects/ROCKNIX/packages/linux-drivers/rocknix-joypad/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/rocknix-joypad/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="rocknix-joypad"
-PKG_VERSION="d95d0372a907607d6795e02e5bba24856f4d412c"
+PKG_VERSION="7647fdb0fc89cd69b284903bf7707e861df5dc7e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/rocknix-joypad"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"

--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -35,8 +35,12 @@ case ${DEVICE} in
         PKG_VERSION="6.19-rc5"
         PKG_URL="https://git.kernel.org/torvalds/t/${PKG_NAME}-${PKG_VERSION}.tar.gz"
         ;;
-      H700|RK3399|RK3566|S922X|SM8550|SM8650)
-        PKG_VERSION="6.18.4"
+      RK3566|S922X)
+        PKG_VERSION="6.18.6"
+        PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+        ;;
+      H700|RK3399|SM8550|SM8650)
+        PKG_VERSION="6.18.6"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
       *)

--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -40,7 +40,7 @@ case ${DEVICE} in
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
       H700|RK3399|SM8550|SM8650)
-        PKG_VERSION="6.18.6"
+        PKG_VERSION="6.18.4"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
       *)


### PR DESCRIPTION
Fixed can sleep i rocknix-joypad affecting rockchip platforms.

Fix swapped adc channel on S922X, tested RGB10M3P needs tesing on OGU.