### PR TITLE
wine - downgrade to 10.16

### DIFF
--- a/projects/ROCKNIX/packages/compat/wine/package.mk
+++ b/projects/ROCKNIX/packages/compat/wine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="11.0"
+PKG_VERSION="10.16"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64.tar.xz"


### PR DESCRIPTION
Wine 11.0 is having trouble creating win64 / wow64 prefixes