### PR TITLE
Bump wine (v11.0), box64 (git HEAD) and box86 (git HEAD)

### DIFF
--- a/projects/ROCKNIX/packages/compat/box64/package.mk
+++ b/projects/ROCKNIX/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="984c9d4f2f31b2ed1a50c1097012d0615f4ec9c4"
+PKG_VERSION="3ec5de03c786333ed8d5a51c5b35a8bd6e22b229"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"

--- a/projects/ROCKNIX/packages/compat/box86/package.mk
+++ b/projects/ROCKNIX/packages/compat/box86/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box86"
-PKG_VERSION="50a2603027d0faf2f6ba5d97c0169f824fb95d85"
+PKG_VERSION="0579f8b9c47d87d700724f4cce559b06cbd2b0f5"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box86"
 PKG_URL="${PKG_SITE}.git"

--- a/projects/ROCKNIX/packages/compat/wine/package.mk
+++ b/projects/ROCKNIX/packages/compat/wine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="10.16"
+PKG_VERSION="11.0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64.tar.xz"


### PR DESCRIPTION
Testing on my Odin 2 - win32 / win64 / wow64 prefix creation now works and NFS Porsche runs fine in both win32 and wow64 prefixes. The linux version of A Short Hike with box64 works fine.