### PR TITLE
debug - temporarily remove strace

### DIFF
--- a/projects/ROCKNIX/packages/virtual/debug/package.mk
+++ b/projects/ROCKNIX/packages/virtual/debug/package.mk
@@ -4,3 +4,6 @@
 . ${ROOT}/packages/virtual/debug/package.mk
 
 PKG_DEPENDS_TARGET+=" nvtop apitrace"
+
+# strace is broken on 6.19 kernels, so temporarily remove
+PKG_DEPENDS_TARGET=${PKG_DEPENDS_TARGET//"strace"/}


### PR DESCRIPTION
Make the change in our ROCKNIX debug package file. Tested SM8550 build locally.