### PR TITLE
iwd: don't disable ipv6

### DIFF
--- a/projects/ROCKNIX/packages/network/iwd/sources/main.conf
+++ b/projects/ROCKNIX/packages/network/iwd/sources/main.conf
@@ -6,7 +6,6 @@ ControlPortOverNL80211=false
 [Network]
 RoutePriorityOffset=200
 NameResolvingService=none
-EnableIPv6=false
 
 [Scan]
 MaximumPeriodicScanInterval=30


### PR DESCRIPTION
IPv6 is required on many networks, especially mobile networks, and is often necessary for successfully establishing P2P comms.

For example, my mobile provider is IPv6–only, with the only IPv4 connectivity being outbound–only using NAT64 and 464XLAT.

When I use Syncthing to sync my save states between my Rocknix device, it needs IPv6 to successfully sync with my other mobile devices in this situation.

After installing the nightly version of Rocknix, which uses iwd, IPv6 no longer works following f48cc1b0304a843ed4e04c7627a2fe08f733d4f9, due to `EnableIPv6=false` being hardcoded in `/etc/iwd/main.conf`.

It’s simply not practical to disable IPv6 in today’s world, especially not by default.

Unfortunately, there are broken networks out there for which users (who have been misled by a great deal of misinformation and inexperienced opinions) believe that disabling IPv6 is the solution to whatever problem they are having.

While I cannot defend all problem diagnoses within the limitations of this commit message, I am able to say, having sufficient knowledge and experience in the area, that disabling IPv6 is not an appropriate action in the vast majority of cases.

One limitation of IPv6 with iwd is that it can only add a single address from the prefix with the longest lifetime, as stated by the comments in `netconfig_icmp6_event_handler()` in the library `ell/netconfig.c`, used by iwd.

Though this is an unusual limitation, it’s not a showstopper for typical networks. If supporting multiple prefixes ends up being requested by users, my advice would be to instead rely on the Linux kernel’s built–in RA client, which handles this perfectly today (sysctl `accept_ra=1`, and patch `l_netconfig_new()` in `ell/netconfig.c`).