### PR TITLE
fix(usbgadget): Move to Link-Local IP and Smart USB-C Hotplug

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/handle-hdmi-hotplug
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/handle-hdmi-hotplug
@@ -7,13 +7,21 @@ if ! pgrep -x emulationstation > /dev/null; then
   exit 0
 fi
 
-HDMI_OUTPUT=$(wlr-randr | awk '/^HDMI-A-[0-9]/ {print $1}')
+HDMI_OUTPUT=$(wlr-randr | awk '/^(HDMI-A|DP|DisplayPort)-[0-9]*/ {print $1}')
 DSI_OUTPUT=$(wlr-randr | awk '/^DSI-[0-9]/ {print $1}')
 
 HDMI_STATE=$(cat /run/hdmi-status.last 2>/dev/null)
 
 case "${HDMI_STATE}" in
   connected)
+
+    # Stop USB gadget only if using USB-C (DisplayPort) video, as it conflicts with USB data lanes on some SoCs (e.g. RK3588/SM8250)
+    # Standard HDMI ports are unaffected.
+    if cat /sys/class/drm/card*-DP*/status /sys/class/drm/card*-DisplayPort*/status 2>/dev/null | grep -q "^connected"; then
+        if systemctl is-active --quiet usbgadget; then
+             systemctl stop usbgadget
+        fi
+    fi
     if [ -n "${HDMI_OUTPUT}" ]; then
       wlr-randr --output "${HDMI_OUTPUT}" --preferred --on
     fi
@@ -23,6 +31,14 @@ case "${HDMI_STATE}" in
     killall emulationstation
     ;;
   disconnected)
+
+    # Stop USB gadget only if using USB-C (DisplayPort) video, as it conflicts with USB data lanes on some SoCs (e.g. RK3588/SM8250)
+    # Standard HDMI ports are unaffected.
+    if cat /sys/class/drm/card*-DP*/status /sys/class/drm/card*-DisplayPort*/status 2>/dev/null | grep -q "^connected"; then
+        if systemctl is-active --quiet usbgadget; then
+             systemctl stop usbgadget
+        fi
+    fi
     if [ -n "${DSI_OUTPUT}" ]; then
       wlr-randr --output "${DSI_OUTPUT}" --preferred --on
     fi

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/usbgadget
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/usbgadget
@@ -183,14 +183,14 @@ configure_iface() {
 
 	OLDIPADDRFILE=${CACHEDIR}/ip_address.conf
 	if [ ! -f ${GADGETNETCONF} ] ; then
-		NETMASK="255.255.255.252"
+		NETMASK="255.255.0.0"
 		# Migrate old configs
 		if [ -f "${OLDIPADDRFILE}" ] ; then
 			IP=$(cat "${OLDIPADDRFILE}")
 			# if IP has last octed modified, fall back to large netmask
 			[[ "${IP##*.}" == "2" ]] || NETMASK="255.255.255.0"
 		fi
-		[ -z "$IP" ] && IP="10.1.1.2"
+		[ -z "$IP" ] && IP="169.254.170.2"
 
 		cat <<EOF > ${GADGETNETCONF}
 IP=${IP}
@@ -206,6 +206,7 @@ EOF
 
 
 	ip address add ${IP}/${NETMASK} dev ${IFACE_NAME} 2>/dev/null
+    ip -6 address add fe80::2/64 dev ${IFACE_NAME} scope link 2>/dev/null
 	ip link set ${IFACE_NAME} up
 
 	cat <<EOF > ${UDHCPCONF}


### PR DESCRIPTION
Fixes USB Gadget configuration to improve network compatibility and handle USB-C Alt-Mode resource contention.

Key Changes:

1. RFC 3927 Compliance (Link-Local IP):
   - Changed default IP from '10.1.1.2' to '169.254.170.2/16'.
   - The previous 10.x address often conflicted with home subnets (and some CG-NAT ISPs), causing routing blackholes where LAN traffic was misrouted to the USB interface.
   - Link-Local ensures zero conflict with routed networks and enables automatic discovery on Windows/macOS/Linux hosts.

2. IPv6 Support:
   - Added explicit 'fe80::2' link-local address assignment.

3. Smart Hotplug (USB-C/DP):
   - Updated 'handle-hdmi-hotplug' regex to support DisplayPort (DP) events.
   - Added logic to stop the 'usbgadget' service ONLY when a DisplayPort connection is detected via sysfs. This prevents USB data lane contention on SoCs where USB-C Video and USB Data share physical resources.
   - Standard HDMI connections are unaffected.

Ref: #2213 