### PR TITLE
wine - use vanilla build

### DIFF
--- a/projects/ROCKNIX/packages/compat/wine/package.mk
+++ b/projects/ROCKNIX/packages/compat/wine/package.mk
@@ -5,7 +5,7 @@ PKG_NAME="wine"
 PKG_VERSION="11.0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
-PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64.tar.xz"
+PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-amd64.tar.xz"
 
 PKG_DEPENDS_TARGET="toolchain libXcomposite libXdmcp cups"
 PKG_LONGDESC="Wine is a compatibility layer capable of running Windows applications"


### PR DESCRIPTION
Include Vanilla wine compiled from the official WineHQ source in the build.

If a game or app requires an alternative wine build, eg one with the staging patchset, or proton, this is easily downloaded to a user's device and referenced in the launch script.