### PR TITLE
Fix bottom touchscreen focus regression on RG DS

### DIFF
--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -126,8 +126,8 @@ fi
 if [ "${QUIRK_DEVICE}" = "Anbernic RG DS" ]; then
   echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' dpms on' >> $SWAY_HOME/config
   echo 'for_window [app_id="drastic"] output '"${second_con}"' dpms on, input "1046:911:Goodix_Capacitive_TouchScreen" map_to_output '"${con}" >> $SWAY_HOME/config
-  echo 'for_window [app_id="emulationstation"] output '"${second_con}"' dpms off' >> $SWAY_HOME/config
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}" >> $SWAY_HOME/config
+  echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} dpms off" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"1046:911:Goodix_Capacitive_TouchScreen\"" >> $SWAY_HOME/config
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 fallback no" >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 fallback yes" >> $SWAY_HOME/config
 fi


### PR DESCRIPTION
Prevents the touch remapping needed for drastic-sa from leaking back into emulationstation while retaining bottom screen off functionality.
Tested with emulationstation from boot, after launching drastic-sa, and after launching melonds-sa