### PR TITLE
Correct audio path on RG353V/S

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353V/001-device_config
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353V/001-device_config
@@ -5,6 +5,6 @@
 cat <<EOF >/storage/.config/profile.d/001-device_config
 DEVICE_FAKE_JACKSENSE="true"
 DEVICE_HEADPHONE_DEV="/dev/input/by-path/platform-rk817-sound-event"
+DEVICE_PLAYBACK_PATH_SPK="SPK"
 DEVICE_HAS_TOUCHSCREEN="true"
-
 EOF

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353VS/001-device_config
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353VS/001-device_config
@@ -5,5 +5,5 @@
 cat <<EOF >/storage/.config/profile.d/001-device_config
 DEVICE_FAKE_JACKSENSE="true"
 DEVICE_HEADPHONE_DEV="/dev/input/by-path/platform-rk817-sound-event"
-
+DEVICE_PLAYBACK_PATH_SPK="SPK"
 EOF


### PR DESCRIPTION
RG353V uses SPK as its primary audio path. Confirmed this fix works with two user reports.