### PR TITLE
Add vertical orientation check/set for RetroArch on RGDS

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/vertical-check
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/vertical-check
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+ARCADEROMS_XML="/usr/config/emulationstation/resources/arcaderoms.xml"
+
+RUNEMU_LINE=$(ps aux | grep '[r]unemu.sh' | head -n 1)
+CURRENT_CORE=$(echo "${RUNEMU_LINE}" | sed -n 's/.*--core=\([^ ]*\).*/\1/p')
+ROM_PATH=$(echo "${RUNEMU_LINE}" | sed -n 's|.*runemu\.sh \([^ ]*\).*|\1|p')
+
+if [ -z "${CURRENT_CORE}" ] || [ -z "${ROM_PATH}" ]; then
+    exit 0
+fi
+
+ROM_NAME=$(basename "${ROM_PATH}" | sed 's/\.[^.]*$//')
+IS_VERTICAL=false
+
+case "${CURRENT_CORE}" in
+    # Unconditionally vertical
+    melonds*|desmume|vecx)
+        IS_VERTICAL=true
+        ;;
+    # Might not be vertical
+    mame*|fbneo|fbalpha*)
+        if grep -q "id=\"${ROM_NAME}\"[^>]*vert=\"true\"" "${ARCADEROMS_XML}" 2>/dev/null; then
+            IS_VERTICAL=true
+        fi
+        ;;
+esac
+
+if [ "${IS_VERTICAL}" = true ]; then
+    # Needs two separate swaymsg calls. Screen cannot move and have windows moved to it in the same line.
+    swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 dpms on pos 0 480'
+    swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 640 960, move to output DSI-2, move absolute position 0 0'
+fi

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/vertical-check
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/vertical-check
@@ -26,6 +26,13 @@ case "${CURRENT_CORE}" in
         ;;
 esac
 
+case "${ROM_NAME}" in
+    # Also check for some specific roms that aren't marked vert
+    punchout*|spnchout*|pc_*|mp_*)
+        IS_VERTICAL=true
+        ;;
+esac
+
 if [ "${IS_VERTICAL}" = true ]; then
     # Needs two separate swaymsg calls. Screen cannot move and have windows moved to it in the same line.
     swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 dpms on pos 0 480'

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -124,10 +124,11 @@ fi
 
 # Anbernic RG DS touchscreen setup
 if [ "${QUIRK_DEVICE}" = "Anbernic RG DS" ]; then
-  echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' dpms on' >> $SWAY_HOME/config
-  echo 'for_window [app_id="drastic"] output '"${second_con}"' dpms on, input "1046:911:Goodix_Capacitive_TouchScreen" map_to_output '"${con}" >> $SWAY_HOME/config
+  echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' power on' >> $SWAY_HOME/config
+  echo 'for_window [title="RetroArch\s(melonDS|DeSmuME|VecX|MAME|FinalBurn|FB Alpha).*"] exec /usr/lib/autostart/quirks/devices/"Anbernic RG DS"/bin/vertical-check' >> $SWAY_HOME/config
+  echo 'for_window [app_id="drastic"] output '"${second_con}"' power on, input "1046:911:Goodix_Capacitive_TouchScreen" map_to_output '"${con}" >> $SWAY_HOME/config
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} dpms off" >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} power off" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"1046:911:Goodix_Capacitive_TouchScreen\"" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 fallback yes" >> $SWAY_HOME/config
 fi


### PR DESCRIPTION
This PR adds support for dynamically checking the RetroArch core used to launch a game when launched from EmulationStation and setting the appropriate sway options to allow for usage of both screens if conditions are satisfied, those being:
A vertical console/handheld (nds/vectrex)
A vertically oriented arcade game (checked against arcaderoms.xml)

111-sway-init config already handles graceful switch back with the reload line.

Tested with puckman on the supported arcade cores, several games on the ds cores, and cosmic chasm on vecx

Let me know if there needs to be a different implementation or placing of the script.