### PR TITLE
tic80-lr - fix segfaults

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/tic80-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/tic80-lr/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="tic80-lr"
-PKG_VERSION="21aa81a1ac263d584bb2656d283fa149685bb82d"
+PKG_VERSION="7020500a6e88f6ee91301933bb77f082a10e10f5"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/nesbox/TIC-80"
 PKG_URL="${PKG_SITE}.git"
@@ -10,16 +10,30 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="TIC-80 is a fantasy computer for making, playing and sharing tiny games."
 GET_HANDLER_SUPPORT="git"
 
-PKG_CMAKE_OPTS_TARGET="-DBUILD_PLAYER=ON \
-                       -DBUILD_SOKOL=OFF \
-                       -DBUILD_SDL=OFF \
-                       -DBUILD_TOUCH_INPUT=ON \
-                       -DBUILD_DEMO_CARTS=OFF \
+PKG_CMAKE_OPTS_TARGET="-DBUILD_DEMO_CARTS=OFF \
+                       -DBUILD_EDITORS=OFF \
                        -DBUILD_LIBRETRO=ON \
-                       -DBUILD_WITH_MRUBY=OFF \
+                       -DBUILD_PLAYER=OFF \
+                       -DBUILD_PRO=OFF \
+                       -DBUILD_SDL=OFF \
+                       -DBUILD_SDLGPU=OFF \
+                       -DBUILD_SOKOL=OFF \
+                       -DBUILD_STATIC=ON \
+                       -DBUILD_TOOLS=OFF \
+                       -DBUILD_TOUCH_INPUT=ON \
+                       -DBUILD_WITH_ALL=OFF \
+                       -DBUILD_WITH_FENNEL=ON \
                        -DBUILD_WITH_JANET=OFF \
-                       -DCMAKE_BUILD_TYPE=Release \
-                       -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+                       -DBUILD_WITH_LUA=ON \
+                       -DBUILD_WITH_MRUBY=OFF \
+                       -DBUILD_WITH_POCKETPY=OFF \
+                       -DBUILD_WITH_QUICKJS=OFF \
+                       -DBUILD_WITH_SCHEME=OFF \
+                       -DBUILD_WITH_SQUIRREL=OFF \
+                       -DBUILD_WITH_WASM=OFF \
+                       -DBUILD_WITH_WREN=ON \
+                       -DBUILD_WITH_ZLIB=ON \
+                       -DCMAKE_BUILD_TYPE=Release"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro


### PR DESCRIPTION
Bump version and update build flags - thanks to @RetroGFX

I think `BUILD_STATIC=ON` is the main fix as removing this causes segfaults again.

Tested on my OGU