### PR TITLE
RG353V/S: Move audio path to correct quirk

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353V/001-device_config
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353V/001-device_config
@@ -5,6 +5,5 @@
 cat <<EOF >/storage/.config/profile.d/001-device_config
 DEVICE_FAKE_JACKSENSE="true"
 DEVICE_HEADPHONE_DEV="/dev/input/by-path/platform-rk817-sound-event"
-DEVICE_PLAYBACK_PATH_SPK="SPK"
 DEVICE_HAS_TOUCHSCREEN="true"
 EOF

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353V/050-audio_path
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353V/050-audio_path
@@ -1,0 +1,10 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+cat <<EOF >/storage/.config/profile.d/002-audio_path
+ALSA_PRIMARY_CARD=1
+DEVICE_PLAYBACK_PATH_SPK="SPK"
+DEVICE_PLAYBACK_PATH_HP="HP"
+DEVICE_PLAYBACK_PATH="Playback Mux"
+EOF

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353VS/001-device_config
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353VS/001-device_config
@@ -5,5 +5,4 @@
 cat <<EOF >/storage/.config/profile.d/001-device_config
 DEVICE_FAKE_JACKSENSE="true"
 DEVICE_HEADPHONE_DEV="/dev/input/by-path/platform-rk817-sound-event"
-DEVICE_PLAYBACK_PATH_SPK="SPK"
 EOF

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353VS/050-audio_path
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG353VS/050-audio_path
@@ -1,0 +1,10 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+cat <<EOF >/storage/.config/profile.d/002-audio_path
+ALSA_PRIMARY_CARD=1
+DEVICE_PLAYBACK_PATH_SPK="SPK"
+DEVICE_PLAYBACK_PATH_HP="HP"
+DEVICE_PLAYBACK_PATH="Playback Mux"
+EOF


### PR DESCRIPTION
Prevents the audio path variables from being overwritten on boot for the RG353V/S by moving the variable set to the correct quirk (050-audio_path) for RG353V/S

Confirmed to work with a build and update, and remained working after two subsequent reboots