### PR TITLE
rocknix-joypad - temp fix for Gameforce ACE (RK3588)

### DIFF
--- a/projects/ROCKNIX/packages/linux-drivers/rocknix-joypad/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/rocknix-joypad/package.mk
@@ -10,6 +10,9 @@ PKG_LONGDESC="rocknix-joypad: ROCKNIX joypad driver"
 PKG_TOOLCHAIN="manual"
 PKG_IS_KERNEL_PKG="yes"
 
+# Temp fix for Gameforce ACE (RK3588) - axis / trigger mappings broken by https://github.com/ROCKNIX/rocknix-joypad/pull/12
+[[ ${DEVICE} == "RK3588" ]] && PKG_VERSION="d95d0372a907607d6795e02e5bba24856f4d412c"
+
 pre_make_target() {
   unset LDFLAGS
 }


### PR DESCRIPTION
PR https://github.com/ROCKNIX/rocknix-joypad/pull/12 somehow breaks axis / trigger mappings on my Gameforce ACE

Temp fix by downgrading the package version for RK3588. Tested on my Gameforce ACE.