### PR TITLE
Add a module for launching melonds in dsi firmware mode

### DIFF
--- a/projects/ROCKNIX/packages/misc/modules/sources/gamelist.xml
+++ b/projects/ROCKNIX/packages/misc/modules/sources/gamelist.xml
@@ -205,6 +205,18 @@ and keyboard to modify settings.</desc>
         <players>1</players>
         <image>./images/melonds.svg</image>
     </game>
+	<game>
+		<path>./Start MelonDS (DSi Mode).sh</path>
+		<name>Start MelonDS (DSi Mode)</name>
+		<desc>Launches MelonDS in DSi mode and boots into NAND firmware. You must have dsi bios files in roms/bios.</desc>
+		<developer>ROCKNIX</developer>
+		<publisher>ROCKNIX</publisher>
+		<rating>5.0</rating>
+		<releasedate>2024</releasedate>
+		<genre>Emulator</genre>
+		<players>1</players>
+		<image>./images/melonds.svg</image>
+	</game>
     <game>
         <path>./Start Moonlight.sh</path>
         <name>Start Moonlight</name>

--- a/projects/ROCKNIX/packages/virtual/emulators/sources/Start MelonDS (DSi Mode).sh
+++ b/projects/ROCKNIX/packages/virtual/emulators/sources/Start MelonDS (DSi Mode).sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+. /etc/profile
+
+INI="$HOME/.config/melonDS/melonDS.ini"
+BACKUP="$(mktemp)"
+
+# Backup original config to restore on exit
+cp "$INI" "$BACKUP"
+
+set_ini() {
+  local key="$1"
+  local value="$2"
+  if grep -Eq "^[[:space:]]*$key[[:space:]]*=" "$INI"; then
+    sed -i "s|^[[:space:]]*$key[[:space:]]*=.*|$key=$value|" "$INI"
+  else
+    printf '\n%s=%s\n' "$key" "$value" >> "$INI"
+  fi
+}
+
+cleanup() {
+  cp "$BACKUP" "$INI"
+  rm -f "$BACKUP"
+}
+
+# Ensure settings are restored when the game closes
+trap cleanup EXIT INT TERM
+
+# ROM discovery
+ROM=$(find "$HOME/roms/nds/" -maxdepth 1 -name "*.nds" -print -quit)
+
+if [ -z "$ROM" ]; then
+    echo "No ROM found."
+    exit 1
+fi
+
+# DSi mode
+set_ini ConsoleType 1
+set_ini DirectBoot 0
+
+sway_fullscreen "net.kuribo64.melonDS" &
+/usr/bin/start_melonds.sh "$ROM" "nds"
+
+wait


### PR DESCRIPTION
Some dsiware titles are not standalone and can only be launched directly from nand. This module allows booting melonds into dsi nand to select such games. Bios files must be present for functionality.