### PR TITLE
ndsiware/RGDS/Thor: Set melondsds to default for ndsiware...

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/RK3566/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/RK3566/SUPPORTED_EMULATORS_AND_CORES.md
@@ -71,7 +71,7 @@
 |Nintendo|NES (Hacks) (nesh)|1985|`nesh`|.nes .unif .unf .zip .7z|**retroarch:** nestopia (default)<br>**retroarch:** fceumm<br>**retroarch:** quicknes<br>**retroarch:** mesen<br>**mednafen:** nesh<br>|
 |Nintendo|Nintendo 64 (n64)|1996|`n64`|.z64 .n64 .v64 .zip .7z|**retroarch:** mupen64plus_next (default)<br>**retroarch:** mupen64plus<br>**retroarch:** parallel_n64<br>**mupen64plus:** mupen64plus-sa<br>|
 |Nintendo|Nintendo DS (nds)|2005|`nds`|.nds .zip .7z|**drastic:** drastic-sa (default)<br>**retroarch:** melonds<br>**retroarch:** melondsds<br>**melonds:** melonds-sa<br>**retroarch:** desmume<br>|
-|Nintendo|Nintendo DSiWare (ndsiware)|2008|`ndsiware`|.nds .zip .7z|**melonds:** melonds-sa (default)<br>**retroarch:** melondsds<br>|
+|Nintendo|Nintendo DSiWare (ndsiware)|2008|`ndsiware`|.nds .zip .7z|**retroarch:** melondsds (default)<br>**melonds:** melonds-sa<br>|
 |Nintendo|Nintendo Entertainment System (nes)|1985|`nes`|.nes .unif .unf .zip .7z|**retroarch:** nestopia (default)<br>**retroarch:** fceumm<br>**retroarch:** quicknes<br>**retroarch:** mesen<br>**mednafen:** nes<br>|
 |Nintendo|Pokémon Mini (pokemini)|2001|`pokemini`|.min .zip .7z|**retroarch:** pokemini (default)<br>|
 |Nintendo|Satellaview (satellaview)|1995|`satellaview`|.smc .fig .bs .sfc .bsx .swc .zip .7z|**retroarch:** snes9x (default)<br>**retroarch:** snes9x2010<br>**retroarch:** snes9x2002<br>**retroarch:** snes9x2005_plus<br>|

--- a/projects/ROCKNIX/packages/emulators/libretro/desmume-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/desmume-lr/package.mk
@@ -10,7 +10,7 @@ PKG_DEPENDS_TARGET="toolchain libpcap"
 PKG_LONGDESC="DeSmuME - Nintendo DS libretro"
 PKG_TOOLCHAIN="make"
 
-if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+if [ "${OPENGL_SUPPORT}" = "yes" ] && [ ! "${PREFER_GLES}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL} glu libglvnd"
 
 elif [ "${OPENGLES_SUPPORT}" = yes ]; then

--- a/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
@@ -37,6 +37,8 @@ fi
 #Emulation Station Features
 GAME=$(echo "${1}" | sed "s#^/.*/##")
 PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+CONTYPE=$(get_setting console_type "${PLATFORM}" "${GAME}")
+DBOOT=$(get_setting direct_boot "${PLATFORM}" "${GAME}")
 GRENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
 IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
 SORIENTATION=$(get_setting screen_orientation "${PLATFORM}" "${GAME}")
@@ -50,6 +52,28 @@ CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 unset EMUPERF
 [ "${CORES}" = "little" ] && EMUPERF="${SLOW_CORES}"
 [ "${CORES}" = "big" ] && EMUPERF="${FAST_CORES}"
+
+#Console Type
+if [ "$PLATFORM" = "ndsiware" ]
+then
+    sed -i '/^ConsoleType=/c\ConsoleType=1' /storage/.config/melonDS/melonDS.ini
+else if [ "$CONTYPE" > "0" ]
+then
+    sed -i '/^ConsoleType=/c\ConsoleType=1' /storage/.config/melonDS/melonDS.ini
+else
+    sed -i '/^ConsoleType=/c\ConsoleType=0' /storage/.config/melonDS/melonDS.ini
+fi
+
+#Direct Boot
+if [ "$PLATFORM" = "ndsiware" ]
+then
+    sed -i '/^ConsoleType=/c\DirectBoot=0' /storage/.config/melonDS/melonDS.ini
+else if [ "$DBOOT" > "0" ]
+then
+    sed -i '/^ConsoleType=/c\DirectBoot=1' /storage/.config/melonDS/melonDS.ini
+else
+    sed -i '/^ConsoleType=/c\DirectBoot=0' /storage/.config/melonDS/melonDS.ini
+fi
 
 #Graphics Backend
 if [ "$GRENDERER" > "0" ]; then

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/vertical-check
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/vertical-check
@@ -35,8 +35,9 @@ esac
 
 if [ "${IS_VERTICAL}" = true ]; then
     # Needs two separate swaymsg calls. Screen cannot move and have windows moved to it in the same line.
-    swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 dpms on pos 0 480'
-    swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 640 960, move to output DSI-2, move absolute position 0 0'
+    swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 pos 340 1080'
+    swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 1240 2160, move to output DSI-2, move absolute position 340 0'
     # Additionally fix touch mapping for vertical stack
-    swaymsg 'input "1046:911:Goodix_Capacitive_TouchScreen" calibration_matrix 1 0 0 0 0.5 0.5'
+    swaymsg input "0:0:generic_ft5x06_(8d)" map_to_output DSI-1
+    swaymsg -- input "0:0:generic_ft5x06_(8d)" calibration_matrix 0 -1 1 1 0 0
 fi

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/setsettings.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/setsettings.sh
@@ -990,6 +990,41 @@ function set_dreamcastopts() {
     fi
 }
 
+function set_melondsdsopts() {
+    log "Set up melonDS DS..."
+    if [ "${CORE}" = "melondsds" ]
+    then
+        local MELONDSDSDIR="${RETROARCH_PATH}/config/melonDS DS"
+        if [ ! -d "${MELONDSDSDIR}" ]
+        then
+            mkdir -p "${MELONDSDSDIR}"
+        fi
+        
+        if [ ! -f "${MELONDSDSDIR}/melonDS DS.opt" ]
+        then
+            cat <<EOF >"${MELONDSDSDIR}/melonDS DS.opt"
+melonds_boot_mode = "direct"
+melonds_console_mode = "ds"
+melonds_show_cursor = "timeout"
+melonds_touch_mode = "auto"
+EOF
+        fi
+
+        if [ "${PLATFORM}" = "ndsiware" ]
+        then
+            sed -i '/melonds_console_mode = /c\melonds_console_mode = "dsi"' "${MELONDSDSDIR}/melonDS DS.opt"
+        else
+            sed -i '/melonds_console_mode = /c\melonds_console_mode = "ds"' "${MELONDSDSDIR}/melonDS DS.opt"
+        fi
+
+        if [ "${DEVICE_HAS_TOUCHSCREEN}" = "true" ]
+        then
+            sed -i '/melonds_show_cursor = /c\melonds_show_cursor = "disabled"' "${MELONDSDSDIR}/melonDS DS.opt"
+            sed -i '/melonds_touch_mode = /c\melonds_touch_mode = "touch"' "${MELONDSDSDIR}/melonDS DS.opt"
+        fi
+    fi
+}
+
 function set_atari() {
     log "Set up Atari (FIXME)..."
     if [ "${CORE}" = "atari800" ]
@@ -1252,6 +1287,7 @@ set_n64opts &
 set_saturnopts &
 set_snesopts &
 set_dreamcastopts &
+set_melondsdsopts &
 
 ### Sed operations are expensive, so they are staged and executed as
 ### a single process when all forks complete.

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -1068,6 +1068,14 @@
    <cores>
     <core name="melonds-sa">
      <features>
+      <feature name="console type">
+        <choice name="ds" value="0"/>
+        <choice name="dsi" value="1"/>
+      </feature>
+      <feature name="direct boot">
+        <choice name="on" value="1"/>
+        <choice name="off" value="0"/>
+      </feature>
       <feature name="graphics backend">
         <choice name="software" value="0"/>
         <choice name="opengl (classic)" value="1"/>

--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -842,8 +842,8 @@ makeinstall_target() {
       add_emu_core ndsiware retroarch melondsds true
     ;;
     *)
-      add_emu_core ndsiware melonds melonds-sa true
-      add_emu_core ndsiware retroarch melondsds false
+      add_emu_core ndsiware retroarch melondsds true
+      add_emu_core ndsiware melonds melonds-sa false
     ;;
   esac
   add_es_system ndsiware

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -128,6 +128,7 @@ fi
 if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] seat seat0 attach "*"' >> $SWAY_HOME/config
+  echo 'for_window [title="RetroArch\s(melonDS|DeSmuME|VecX|MAME|FinalBurn|FB Alpha).*"] exec /usr/lib/autostart/quirks/devices/"AYN Thor"/bin/vertical-check' >> $SWAY_HOME/config 
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:generic_ft5x06_(8d)\"" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 fallback yes" >> $SWAY_HOME/config


### PR DESCRIPTION
This PR sets the RetroArch melondsds core as the default for ndsiware, and additionally allows functioning touch calibration and usage of dual screens in RetroArch for the Anbernic RG DS and AYN Thor.

Currently a draft, pending additional testing on the AYN Thor