### PR TITLE
Add gpio-keys to the input whitelist to prevent self-lockout in fake sleep

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -25,13 +25,16 @@ check_hardware_suspend_enabled() {
 }
 
 check_hdmi_connected() {
-  local HDMI_STATUS=$(cat /sys/class/drm/card*/card*-HDMI-A-[0-9]/status)
+  for status_file in /sys/class/drm/card*-HDMI-A-[0-9]/status; do
+    if [[ -f "$status_file" ]]; then
+      local HDMI_STATUS=$(cat "$status_file")
+      if [[ "${HDMI_STATUS}" = "connected" ]]; then
+        return 0
+      fi
+    fi
+  done
 
-  if [[ "${HDMI_STATUS}" = "connected" ]]; then
-    return 0
-  else
-    return 1
-  fi
+  return 1
 }
 
 check_charging() {
@@ -345,7 +348,8 @@ INPUT_WHITELIST=(
   # S922X
   "rk805 pwrkey" \
   # SM8550
-  "pmic_pwrkey"
+  "pmic_pwrkey" \
+  "gpio-keys"
 )
 
 # Backlight power devices

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -348,9 +348,11 @@ INPUT_WHITELIST=(
   # S922X
   "rk805 pwrkey" \
   # SM8550
-  "pmic_pwrkey" \
-  "gpio-keys"
+  "pmic_pwrkey"
 )
+
+# Ayn Thor gpio-keys contains lid events
+[[ "${QUIRK_DEVICE}" == "AYN Thor" ]] && INPUT_WHITELIST+=("gpio-keys")
 
 # Backlight power devices
 declare -a BL_POWER_DEVICES=()


### PR DESCRIPTION
On the AYN Thor, the lid sensor is a part of `gpio-keys`. By blocking it, the lid sensor is never detected as open. Thus a hard reboot is required, and the `unmute_audio` function never runs, giving the illusion that a hard crash has broken the audio driver.

Add `gpio-keys` to the whitelist. Also make `check_hdmi_connected()` safer by ensuring file exists before we cat it.

https://discord.com/channels/948029830325235753/1341661999372832828/1465862806812491929