### PR TITLE
RG DS: Fix drastic-sa wake from sleep

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/post/99-drastic-cont
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/post/99-drastic-cont
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Resume DraStic if it's still there
+if pgrep drastic; then
+    kill -CONT $(pidof drastic)
+fi

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/pre/99-drastic-stop
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/pre/99-drastic-stop
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# DraStic specifically needs to be told to stop so it doesn't backlog dynarec
+# instructions while the cpu is clocking down before sleep fully completes
+if pgrep drastic; then
+    kill -STOP $(pidof drastic)
+fi


### PR DESCRIPTION
This PR adds explicit STOP and CONT calls to sleep.d quirks for drastic-sa on the RG DS, preventing drastic from potentially queueing a large number of emulation ticks in the moments between sleep start and the entrance to deep sleep states. Before, this would cause drastic-sa to have to "catch-up" to real-time before it continued execution. While this PR does add a short 1-2 second delay semi-consistently upon resume, drastic-sa has proven to always become responsive much quicker than before.

Tested working multiple times on the RG DS, including several short 10-15 minute long and two multi-hour long sleep/wake cycles.