### PR TITLE
RK3566: Enable touchscreen keyboard

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -11,7 +11,7 @@ if echo "${UI_SERVICE}" | grep -q "sway"; then
     swaymsg 'seat seat1 attach "*"'
     swaymsg 'seat * keyboard_grouping smart'
 
-    if [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true"]]; then
+    if [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true" ]]; then
         TSKEY=$(get_setting "rocknix.touchscreen-keyboard.enabled")
         if [[ "${TSKEY}" == "1" ]]; then
             swaymsg 'output DSI-1 power on, seat seat1 fallback no'

--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -7,14 +7,15 @@ if echo "${UI_SERVICE}" | grep -q "sway"; then
     # Call the function to fullscreen the window for app_id asynchronously
     sway_fullscreen "${1}" &
 
-    # Explicitly map all input devices to the active game seat to prevent wayland focus revocation, and unify virtual input nodes.
-    swaymsg 'seat seat1 attach "*"'
-    swaymsg 'seat * keyboard_grouping smart'
-
+    # Create a virtual touch keyboard device if there are two displays
     if [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true" ]]; then
         TSKEY=$(get_setting "rocknix.touchscreen-keyboard.enabled")
         if [[ "${TSKEY}" == "1" ]]; then
             swaymsg 'output DSI-1 power on, seat seat1 fallback no'
         fi
     fi
+    
+    # Explicitly map all input devices to the active game seat to prevent wayland focus revocation.
+    swaymsg 'seat seat1 attach "*"'
+    swaymsg 'seat * keyboard_grouping none'
 fi

--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -10,4 +10,11 @@ if echo "${UI_SERVICE}" | grep -q "sway"; then
     # Explicitly map all input devices to the active game seat to prevent wayland focus revocation, and unify virtual input nodes.
     swaymsg 'seat seat1 attach "*"'
     swaymsg 'seat * keyboard_grouping smart'
+
+    if [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true"]]; then
+        TSKEY=$(get_setting "rocknix.touchscreen-keyboard.enabled")
+        if [[ "${TSKEY}" == "1" ]]; then
+            swaymsg 'output DSI-1 power on, seat seat1 fallback no'
+        fi
+    fi
 fi

--- a/projects/ROCKNIX/packages/apps/rocknix-touchscreen-keyboard/sources/rocknix-touchscreen-keyboard
+++ b/projects/ROCKNIX/packages/apps/rocknix-touchscreen-keyboard/sources/rocknix-touchscreen-keyboard
@@ -22,6 +22,7 @@ while true; do
       killall wvkbd-mobintl
     elif [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true" ]]; then
       secondary_output=$(swaymsg -t get_outputs -r | jq -r '.[] | select(.focused == false) | .name')
+      swaymsg output ${secondary_output} power on
       if [[ ! "${QUIRK_DEVICE}" == "Anbernic RG DS" ]]; then
         tskb_height=720
         tskb_legend_size=35

--- a/projects/ROCKNIX/packages/apps/rocknix-touchscreen-keyboard/sources/rocknix-touchscreen-keyboard
+++ b/projects/ROCKNIX/packages/apps/rocknix-touchscreen-keyboard/sources/rocknix-touchscreen-keyboard
@@ -22,8 +22,14 @@ while true; do
       killall wvkbd-mobintl
     elif [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true" ]]; then
       secondary_output=$(swaymsg -t get_outputs -r | jq -r '.[] | select(.focused == false) | .name')
-       swaymsg output ${secondary_output} power on
-      /usr/bin/wvkbd-mobintl -L 720 -fg 6b6b75 -fg-sp 6b6b75 -bg 1d1d1d --text ffffff --text-sp ffffff -fn 35 -l simple --hidden --output ${secondary_output}
+      if [[ ! "${QUIRK_DEVICE}" == "Anbernic RG DS" ]]; then
+        tskb_height=720
+        tskb_legend_size=35
+      else
+        tskb_height=350
+        tskb_legend_size=18
+      fi
+      /usr/bin/wvkbd-mobintl -L ${tskb_height} -fg 6b6b75 -fg-sp 6b6b75 -bg 1d1d1d --text ffffff --text-sp ffffff -fn ${tskb_legend_size} -l simple --hidden --output ${secondary_output}
     else
       /usr/bin/wvkbd-mobintl -L 350 -fg 6b6b75 -fg-sp 6b6b75 -bg 1d1d1d --text ffffff --text-sp ffffff -fn 50 -l simple --hidden
     fi

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/065-Touchscreen-events
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/RK3566/065-Touchscreen-events
@@ -1,0 +1,12 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+TOUCHSCREEN_EVENTS=$(get_setting key.touchscreen.events)
+if [ -z "${TOUCHSCREEN_EVENTS}" ]
+then
+  set_setting key.touchscreen.events 1
+fi

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -138,7 +138,7 @@ fi
 if [ "${QUIRK_DEVICE}" = "Anbernic RG DS" ]; then
   echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' power on' >> $SWAY_HOME/config
   echo 'for_window [title="RetroArch\s(melonDS|DeSmuME|VecX|MAME|FinalBurn|FB Alpha).*"] exec /usr/lib/autostart/quirks/devices/"Anbernic RG DS"/bin/vertical-check' >> $SWAY_HOME/config
-  echo 'for_window [app_id="drastic"] output '"${second_con}"' power on, seat seat1 fallback no' >> $SWAY_HOME/config
+  echo 'for_window [app_id="drastic"] output '"${second_con}"' power on, input "1046:911:Goodix_Capacitive_TouchScreen" map_to_output '"${con}" >> $SWAY_HOME/config
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} power off" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"1046:911:Goodix_Capacitive_TouchScreen\"" >> $SWAY_HOME/config

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -138,7 +138,7 @@ fi
 if [ "${QUIRK_DEVICE}" = "Anbernic RG DS" ]; then
   echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' power on' >> $SWAY_HOME/config
   echo 'for_window [title="RetroArch\s(melonDS|DeSmuME|VecX|MAME|FinalBurn|FB Alpha).*"] exec /usr/lib/autostart/quirks/devices/"Anbernic RG DS"/bin/vertical-check' >> $SWAY_HOME/config
-  echo 'for_window [app_id="drastic"] output '"${second_con}"' power on, input "1046:911:Goodix_Capacitive_TouchScreen" map_to_output '"${con}" >> $SWAY_HOME/config
+  echo 'for_window [app_id="drastic"] output '"${second_con}"' power on, seat seat1 fallback no' >> $SWAY_HOME/config
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} power off" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"1046:911:Goodix_Capacitive_TouchScreen\"" >> $SWAY_HOME/config


### PR DESCRIPTION
This PR enables usage of the rocknix-touchscreen-keyboard for RK3566 as it has a few devices with touchscreens. Additionally has tuning for the RG DS, and allows touchscreen keyboard usage in portmaster games/apps for dual screen devices.