### PR TITLE
Various DS fixes/improvements

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/desmume-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/desmume-lr/package.mk
@@ -10,7 +10,7 @@ PKG_DEPENDS_TARGET="toolchain libpcap"
 PKG_LONGDESC="DeSmuME - Nintendo DS libretro"
 PKG_TOOLCHAIN="make"
 
-if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+if [ "${OPENGL_SUPPORT}" = "yes" ] && [ ! "${PREFER_GLES}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL} glu libglvnd"
 
 elif [ "${OPENGLES_SUPPORT}" = yes ]; then

--- a/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
@@ -37,6 +37,8 @@ fi
 #Emulation Station Features
 GAME=$(echo "${1}" | sed "s#^/.*/##")
 PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+CONTYPE=$(get_setting console_type "${PLATFORM}" "${GAME}")
+DBOOT=$(get_setting direct_boot "${PLATFORM}" "${GAME}")
 GRENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
 IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
 SORIENTATION=$(get_setting screen_orientation "${PLATFORM}" "${GAME}")
@@ -50,6 +52,28 @@ CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
 unset EMUPERF
 [ "${CORES}" = "little" ] && EMUPERF="${SLOW_CORES}"
 [ "${CORES}" = "big" ] && EMUPERF="${FAST_CORES}"
+
+#Console Type
+if [ "$PLATFORM" = "ndsiware" ]
+then
+    sed -i '/^ConsoleType=/c\ConsoleType=1' /storage/.config/melonDS/melonDS.ini
+else if [ "$CONTYPE" > "0" ]
+then
+    sed -i '/^ConsoleType=/c\ConsoleType=1' /storage/.config/melonDS/melonDS.ini
+else
+    sed -i '/^ConsoleType=/c\ConsoleType=0' /storage/.config/melonDS/melonDS.ini
+fi
+
+#Direct Boot
+if [ "$PLATFORM" = "ndsiware" ]
+then
+    sed -i '/^ConsoleType=/c\DirectBoot=0' /storage/.config/melonDS/melonDS.ini
+else if [ "$DBOOT" > "0" ]
+then
+    sed -i '/^ConsoleType=/c\DirectBoot=1' /storage/.config/melonDS/melonDS.ini
+else
+    sed -i '/^ConsoleType=/c\DirectBoot=0' /storage/.config/melonDS/melonDS.ini
+fi
 
 #Graphics Backend
 if [ "$GRENDERER" > "0" ]; then

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/post/99-drastic-cont
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/post/99-drastic-cont
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Resume DraStic if it's still there
+if pgrep drastic; then
+    kill -CONT $(pidof drastic)
+fi

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/pre/99-drastic-stop
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/sleep.d/pre/99-drastic-stop
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# DraStic specifically needs to be told to stop so it doesn't backlog dynarec
+# instructions while the cpu is clocking down before sleep fully completes
+if pgrep drastic; then
+    kill -STOP $(pidof drastic)
+fi

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/setsettings.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/setsettings.sh
@@ -990,6 +990,41 @@ function set_dreamcastopts() {
     fi
 }
 
+function set_melondsdsopts() {
+    log "Set up melonDS DS..."
+    if [ "${CORE}" = "melondsds" ]
+    then
+        local MELONDSDSDIR="${RETROARCH_PATH}/config/melonDS DS"
+        if [ ! -d "${MELONDSDSDIR}" ]
+        then
+            mkdir -p "${MELONDSDSDIR}"
+        fi
+        
+        if [ ! -f "${MELONDSDSDIR}/melonDS DS.opt" ]
+        then
+            cat <<EOF >"${MELONDSDSDIR}/melonDS DS.opt"
+melonds_boot_mode = "direct"
+melonds_console_mode = "ds"
+melonds_show_cursor = "timeout"
+melonds_touch_mode = "auto"
+EOF
+        fi
+
+        if [ "${PLATFORM}" = "ndsiware" ]
+        then
+            sed -i '/melonds_console_mode = /c\melonds_console_mode = "dsi"' "${MELONDSDSDIR}/melonDS DS.opt"
+        else
+            sed -i '/melonds_console_mode = /c\melonds_console_mode = "ds"' "${MELONDSDSDIR}/melonDS DS.opt"
+        fi
+
+        if [ "${DEVICE_HAS_TOUCHSCREEN}" = "true" ]
+        then
+            sed -i '/melonds_show_cursor = /c\melonds_show_cursor = "disabled"' "${MELONDSDSDIR}/melonDS DS.opt"
+            sed -i '/melonds_touch_mode = /c\melonds_touch_mode = "touch"' "${MELONDSDSDIR}/melonDS DS.opt"
+        fi
+    fi
+}
+
 function set_atari() {
     log "Set up Atari (FIXME)..."
     if [ "${CORE}" = "atari800" ]
@@ -1252,6 +1287,7 @@ set_n64opts &
 set_saturnopts &
 set_snesopts &
 set_dreamcastopts &
+set_melondsdsopts &
 
 ### Sed operations are expensive, so they are staged and executed as
 ### a single process when all forks complete.

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -1068,6 +1068,14 @@
    <cores>
     <core name="melonds-sa">
      <features>
+      <feature name="console type">
+        <choice name="ds" value="0"/>
+        <choice name="dsi" value="1"/>
+      </feature>
+      <feature name="direct boot">
+        <choice name="on" value="1"/>
+        <choice name="off" value="0"/>
+      </feature>
       <feature name="graphics backend">
         <choice name="software" value="0"/>
         <choice name="opengl (classic)" value="1"/>

--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -842,8 +842,8 @@ makeinstall_target() {
       add_emu_core ndsiware retroarch melondsds true
     ;;
     *)
-      add_emu_core ndsiware melonds melonds-sa true
-      add_emu_core ndsiware retroarch melondsds false
+      add_emu_core ndsiware retroarch melondsds true
+      add_emu_core ndsiware melonds melonds-sa false
     ;;
   esac
   add_es_system ndsiware


### PR DESCRIPTION
Bugfix: Adds PREFER_GLES check to desmume-lr
- Prevents outright crashes on devices that technically have access to openGL

Bugfix: Prevent drastic from queueing a lot of cpu instructions via sleep.d scripts

Feature: Adds melonds-sa switches to EmulationStation for console type and direct boot

Improvement: Set melondsds-lr as default ndsiware emu, improves ease of use by not requiring virtual nand installs