### PR TITLE
Fix dual screen touch keyboard in ports

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Will be called by PortMaster mod_ROCKNIX.txt
 
-. /etc/profile.d/001-functions
+. /etc/profile
 
 if echo "${UI_SERVICE}" | grep -q "sway"; then
     # Call the function to fullscreen the window for app_id asynchronously


### PR DESCRIPTION
This PR expands ports to use the full /etc/profile script in order to properly retrieve DEVICE_HAS_DUAL_SCREEN when needed, otherwise the variable may not populate as expected.

Tested on the RG DS