### PR TITLE
(package)f2fs-tools

### DIFF
--- a/projects/ROCKNIX/packages/sysutils/f2fs-tools/package.mk
+++ b/projects/ROCKNIX/packages/sysutils/f2fs-tools/package.mk
@@ -1,0 +1,48 @@
+PKG_NAME="f2fs-tools"
+PKG_VERSION="1.16.0"
+PKG_SHA256="208c7a07e95383fbd7b466b5681590789dcb41f41bf197369c41a95383b57c5e"
+PKG_LICENSE="GPL"
+PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git"
+PKG_URL="https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain util-linux:target lz4:target lzo:target"
+PKG_TOOLCHAIN="autotools"
+
+PKG_LONGDESC="Tools for Flash-Friendly File System (F2FS)"
+PKG_CONFIGURE_OPTS_TARGET="--prefix=/usr \
+                           --bindir=/usr/bin \
+                           --sbindir=/usr/sbin \
+                           --enable-shared \
+                           --disable-static \
+                           --without-selinux \
+                           --with-blkid \
+                           --with-lzo2 \
+                           --with-lz4"
+
+makeinstall_target() {
+  make install DESTDIR=${INSTALL}
+}
+
+post_makeinstall_target() {
+  rm -rf ${INSTALL}/usr/include
+  rm -rf ${INSTALL}/usr/share
+  rm -rf ${INSTALL}/usr/lib/pkgconfig
+  rm -f  ${INSTALL}/usr/lib/*.la
+  rm -f ${INSTALL}/usr/sbin/sload.f2fs
+  rm -f ${INSTALL}/usr/sbin/f2fs_io
+  rm -f ${INSTALL}/usr/sbin/parse.f2fs
+  rm -f ${INSTALL}/usr/sbin/defrag.f2fs
+  rm -f ${INSTALL}/usr/sbin/dump.f2fs
+  rm -f ${INSTALL}/usr/sbin/fibmap.f2fs
+  rm -f ${INSTALL}/usr/sbin/f2fslabel
+}
+
+makeinstall_init() {
+  mkdir -p ${INSTALL}/usr/sbin
+  cp ${PKG_BUILD}/fsck/fsck.f2fs ${INSTALL}/usr/sbin/
+
+  if [ "${INITRAMFS_PARTED_SUPPORT}" = "yes" ]; then
+    cp ${PKG_BUILD}/mkfs/mkfs.f2fs ${INSTALL}/usr/sbin/
+  fi
+  
+  ln -sf fsck.f2fs ${INSTALL}/usr/sbin/resize.f2fs
+}


### PR DESCRIPTION
This PR introduces the f2fs-tools package to ROCKNIX, providing userspace utilities for the Flash-Friendly File System (F2FS). This addition is intended to support future development and experimentation with F2FS as a root filesystem, taking advantage of its specific optimizations for the NAND/SD card storage common in retro handhelds.

Key Features & Configuration:
Version: 1.16.0
Compression Support: Explicitly enabled LZ4 and LZO2 support to ensure optimal performance on target SoCs (RK3326, RK3566, H700, and SM8250). Dependencies: Links dynamically against the system util-linux (for libblkid and libuuid), ensuring proper device probing and UUID generation without the overhead of static libraries.

Minimization:
Aligns with e2fsprogs packaging standards by aggressively stripping headers, man pages, pkgconfig data, and static archives (.a/.la). Removes non-essential developer tools (e.g., sload.f2fs, dump.f2fs, f2fs_io, fibmap.f2fs) to minimize the impact on the system image size. Retains only the core binaries required for operation: fsck.f2fs, mkfs.f2fs, and resize.f2fs.

Initramfs / Boot Support:
Implements makeinstall_init to stage binaries for the initial RAM filesystem. Includes resize.f2fs (symlinked to fsck.f2fs) to support the ROCKNIX first-boot partition expansion workflow on F2FS formatted cards. Conditionally includes mkfs.f2fs based on INITRAMFS_PARTED_SUPPORT.

Verification:
Package compiles successfully for AArch64 targets. Validated against configure --help to ensure no unrecognized flags are passed. Verified automatic detection and linking of lz4, lzo, and blkid during the configure stage.