### PR TITLE
gzip: use bash for wrappers. Default was dash, and we don't have it

### DIFF
--- a/projects/ROCKNIX/packages/compress/gzip/package.mk
+++ b/projects/ROCKNIX/packages/compress/gzip/package.mk
@@ -10,3 +10,6 @@ PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="gcc:host"
 PKG_LONGDESC="GNU Gzip is a popular data compression program originally written by Jean-loup Gailly for the GNU project."
 
+# For some weird reason gzip wrappers default to /bin/dash which we don't have
+CONFIG_SHELL=/bin/bash
+PKG_CONFIGURE_OPTS_TARGET=" CONFIG_SHELL=/bin/bash"


### PR DESCRIPTION
Was:
```
RK3326:~ # /usr/bin/zcat --help
-sh: /usr/bin/zcat: /bin/dash: bad interpreter: No such file or directory
```

Now:
```
RK3326:~ # zcat --help
Usage: /usr/bin/zcat [OPTION]... [FILE]...
Uncompress FILEs to standard output.

  -f, --force       force; read compressed data even from a terminal
  -l, --list        list compressed file contents
  -q, --quiet       suppress all warnings
  -r, --recursive   operate recursively on directories
  -S, --suffix=SUF  use suffix SUF on compressed files
      --synchronous synchronous output (safer if system crashes, but slower)
  -t, --test        test compressed file integrity
  -v, --verbose     verbose mode
      --help        display this help and exit
      --version     display version information and exit

With no FILE, or when FILE is -, read standard input.

Report bugs to <bug-gzip@gnu.org>.
RK3326:~ # zcat test.txt.gz 
hello
```