### PR TITLE
RK3588 - Gameforce ACE - fix right analogue stick

### DIFF
--- a/projects/ROCKNIX/devices/RK3588/patches/linux/000-gameforce-ace.patch
+++ b/projects/ROCKNIX/devices/RK3588/patches/linux/000-gameforce-ace.patch
@@ -68,7 +68,7 @@ diff -rupbN linux.orig/arch/arm64/boot/dts/rockchip/rk3588s-gameforce-ace.dts li
 +		joypad-revision = <0x0100>;
 +
 +		/* Analog sticks */
-+		io-channels = <&saradc 2>, <&saradc 3>, <&saradc 4>, <&saradc 5>, <&ti_adc 7>, <&ti_adc 6>;
++		io-channels = <&saradc 3>, <&saradc 2>, <&saradc 4>, <&saradc 5>, <&ti_adc 7>, <&ti_adc 6>;
 +		io-channel-names = "key-RY", "key-RX", "key-X", "key-Y", "key-Z", "key-RZ";
 +		button-adc-scale = <4>;
 +		button-adc-deadzone = <150>;


### PR DESCRIPTION
Forgot this in https://github.com/ROCKNIX/distribution/pull/2254

Tested on my Gameforce ACE