### PR TITLE
Fix Thor/RGDS seat attachments in sway_fullscreen.sh

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -15,7 +15,16 @@ if echo "${UI_SERVICE}" | grep -q "sway"; then
         fi
     fi
     
-    # Explicitly map all input devices to the active game seat to prevent wayland focus revocation.
-    swaymsg 'seat seat1 attach "*"'
-    swaymsg 'seat * keyboard_grouping none'
+    # The following conditionals deal with focus revocation quirks on specific devices
+    
+    # Force all inputs into seat1 to bypass the Thor's 0:0 input ID collisions
+    if [[ "${QUIRK_DEVICE}" == "AYN Thor" ]]; then
+        swaymsg 'seat seat1 attach "*"'
+        swaymsg 'seat * keyboard_grouping none'
+    fi
+
+    # Put touchscreen into seat0 for Anbernic RG DS
+    if [[ "${QUIRK_DEVICE}" == "Anbernic RG DS" ]]; then
+        swaymsg seat seat0 attach "1046:911:Goodix_Capacitive_TouchScreen"
+    fi
 fi


### PR DESCRIPTION
#2150 added a blanket seat attach wildcard which resolved an input bug for the AYN Thor. It unknowingly caused an input bug in the RG DS. Put the specific needs behind $QUIRK_DEVICE conditionals.