### PR TITLE
Resolve AYN Thor touchscreens reporting as keyboards

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -11,20 +11,7 @@ if echo "${UI_SERVICE}" | grep -q "sway"; then
     if [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true" ]]; then
         TSKEY=$(get_setting "rocknix.touchscreen-keyboard.enabled")
         if [[ "${TSKEY}" == "1" ]]; then
-            swaymsg 'output DSI-1 power on, seat seat1 fallback no'
+            swaymsg 'output DSI-1 power on'
         fi
-    fi
-    
-    # The following conditionals deal with focus revocation quirks on specific devices
-    
-    # Force all inputs into seat1 to bypass the Thor's 0:0 input ID collisions
-    if [[ "${QUIRK_DEVICE}" == "AYN Thor" ]]; then
-        swaymsg 'seat seat1 attach "*"'
-        swaymsg 'seat * keyboard_grouping none'
-    fi
-
-    # Put touchscreen into seat0 for Anbernic RG DS
-    if [[ "${QUIRK_DEVICE}" == "Anbernic RG DS" ]]; then
-        swaymsg seat seat0 attach "1046:911:Goodix_Capacitive_TouchScreen"
     fi
 fi

--- a/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
+++ b/projects/ROCKNIX/packages/apps/portmaster/scripts/portmaster_sway_fullscreen.sh
@@ -12,6 +12,10 @@ if echo "${UI_SERVICE}" | grep -q "sway"; then
         TSKEY=$(get_setting "rocknix.touchscreen-keyboard.enabled")
         if [[ "${TSKEY}" == "1" ]]; then
             swaymsg 'output DSI-1 power on'
+            (
+              sleep 2
+              swaymsg 'seat seat1 fallback yes'
+            ) &
         fi
     fi
 fi

--- a/projects/ROCKNIX/packages/sysutils/systemd/hwdb.d/61-thor-ft5x06.hwdb
+++ b/projects/ROCKNIX/packages/sysutils/systemd/hwdb.d/61-thor-ft5x06.hwdb
@@ -1,0 +1,7 @@
+# AYN Thor dual-screen ft5x06 touch panels
+# Touchscreens expose BTN_TOUCH (EV_KEY) which inflates wlroots seat capabilities.
+# Explicitly mark as touchscreen-only to prevent seat capability 4 (Keyboard) hijacking.
+
+evdev:name:*ft5x06*:*
+ ID_INPUT_KEYBOARD=0
+ ID_INPUT_TOUCHSCREEN=1

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -130,7 +130,7 @@ if [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ]; then
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
 fi
 
-#disable switch focus to secondary screen
+# AYN Thor touchscreen setup
 if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}" >> $SWAY_HOME/config

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -125,6 +125,9 @@ if [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ]; then
   second_con=$([[ "${connected_cons[0]}" == "$con" ]] && echo "${connected_cons[1]}" || echo "${connected_cons[0]}")
   echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] move window to output '"${second_con}" >> $SWAY_HOME/config
   echo 'for_window [title="RetroArch\s(melonDS|DeSmuME|VecX|MAME|FinalBurn|FB Alpha).*"] exec /usr/bin/vertical-check' >> $SWAY_HOME/config
+  # Required for the touch keyboard to both accept inputs on bottom screen and sent those events to the top screen
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat0 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
 fi
 
 #disable switch focus to secondary screen
@@ -132,9 +135,6 @@ if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:generic_ft5x06_(8d)\"" >> $SWAY_HOME/config
-  # These two lines may belong elsewhere; needed for wvkbd to respond to touch input on bottom but be able to interact with top
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat0 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
 fi
 
 # Anbernic RG DS touchscreen setup

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -130,10 +130,11 @@ fi
 #disable switch focus to secondary screen
 if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
-  echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] seat seat0 attach "*"' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:generic_ft5x06_(8d)\"" >> $SWAY_HOME/config
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 fallback yes" >> $SWAY_HOME/config
+  # These two lines may belong elsewhere; needed for wvkbd to respond to touch input on bottom but be able to interact with top
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat0 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
 fi
 
 # Anbernic RG DS touchscreen setup


### PR DESCRIPTION
I hope I put everything in the right spot. This is a follow-up to #2281. After the hwdb.d entry was created a full shutdown was issued. Afterwards, the modified sway config was created and sway was reloaded.
```
THOR:~ # swaymsg -t get_seats
Seat: seat1
  Capabilities: 6
  Devices:
    wlr_virtual_keyboard_v1
    generic ft5x06 (8d)
    generic ft5x06 (8d)

Seat: seat0
  Capabilities: 2
  Devices:
    AYN-Odin2 Headset Jack
    wlr_virtual_keyboard_v1
    pmic_resin
    pmic_pwrkey
    AYN Odin2 Gamepad
    gpio-keys
    gpio-keys
```

Input works in the frontend and the touch keyboard works as expected. A game is launched.
```
THOR:~ # swaymsg -t get_seats
Seat: seat1
  Capabilities: 6
  Devices:
    wlr_virtual_keyboard_v1
    generic ft5x06 (8d)
    generic ft5x06 (8d)

Seat: seat0
  Capabilities: 3
  Devices:
    Fake Keyboard
    Fake Keyboard
    AYN-Odin2 Headset Jack
    wlr_virtual_keyboard_v1
    pmic_resin
    pmic_pwrkey
    AYN Odin2 Gamepad
    gpio-keys
    gpio-keys
```

GPTOKEYB is still given to seat0 which allows its inputs to function. The touch keyboard still opens on the bottom screen but while a game is running the bottom screen does not respond to input to wvkbd. Other touch systems, NDS, 3DS, DSiWare, all respond to touch input. @beebono may have to take a look.

Please review thoroughly to ensure this is the correct path forward. I attempted a udev rule for the touchscreens and it did not work, so I resorted to sway config to attach them.