### PR TITLE
Fix small build bug

### DIFF
--- a/scripts/get_env
+++ b/scripts/get_env
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-for var in $(compgen -e); do echo "$var=${!var}"; done
+for var in $(compgen -e); do 
+  [[ "$var" == PATH  ]] && continue
+  echo "$var=${!var}"
+done


### PR DESCRIPTION
So what had happened was I tried to build Rocknix on a machine running NixOS, and because NixOS has a very different file structure than Ubuntu, the build failed because this `set_env` function was overwriting the docker image's `PATH` with my system `PATH`, which was not at all the same `PATH`, so I did some quick `MATH` and figured this might be a good **path** forward.