### PR TITLE
S922X - post-update - disable fake suspend DPMS

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -240,3 +240,6 @@ if [[ "${HW_DEVICE}" == "S922X" ]]; then
   grep -q "^psp\.rocknix\.mangohud\.enabled=" /storage/.config/system/configs/system.cfg ||
     sed -i '$ a\psp.rocknix.mangohud.enabled=0' /storage/.config/system/configs/system.cfg
 fi
+
+# S922X - disable fake suspend DPMS as it causes crash / reboot on resume
+[[ "${HW_DEVICE}" == "S922X" ]] && sed -i '/system.suspend.dpms/c\system.suspend.dpms=0' /storage/.config/system/configs/system.cfg


### PR DESCRIPTION
S922X - disable fake suspend DPMS by default as it can cause crashes / reboots on resume

Tested on my OGU