### PR TITLE
input_sense / rocknix-screenshot - handle failure exit code for mako-notify

### DIFF
--- a/projects/ROCKNIX/packages/apps/rocknix-screenshot/sources/rocknix-screenshot
+++ b/projects/ROCKNIX/packages/apps/rocknix-screenshot/sources/rocknix-screenshot
@@ -15,6 +15,7 @@ if [ "${ROCKNIX_SCREENSHOT}" == "1" ]; then
   # Disable rocknix-screenshot while retroarch is running
   if pgrep -f "retroarch" > /dev/null; then
       echo "RetroArch is running, skipping screenshot."
+      # 'failure' (screenshot not taken) exit code
       exit 1
   fi
 
@@ -37,4 +38,11 @@ if [ "${ROCKNIX_SCREENSHOT}" == "1" ]; then
 
   # Take screenshot of the focused window
   grim -g "$GEOMETRY" "$FULL_PATH"
+
+  # 'success' (screenshot taken) exit code
+  exit 0
+else
+  echo "rocknix-screenshot is not enabled, skipping screenshot."
+  # 'failure' (screenshot not taken) exit code
+  exit 1
 fi

--- a/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -469,9 +469,11 @@ set +e
       ;;
       (${FUNCTION_HOTKEY_BTN_EAST_EVENT})
         if [ "${HOTKEY_A_PRESSED}" = true ]; then
-          ${DEBUG} && log $0 "${FUNCTION_HOTKEY_BTN_EAST_EVENT}: Screenshot Taken"
+          ${DEBUG} && log $0 "${FUNCTION_HOTKEY_BTN_EAST_EVENT}: Screenshot"
           /usr/bin/rocknix-screenshot
-          /usr/bin/mako-notify "Screenshot Saved" -no-ra
+          # Display notification if 'success' exit code
+          SCREENSHOT_SUCCESS=$?
+          [ "$SCREENSHOT_SUCCESS" -eq 0 ] && /usr/bin/mako-notify "Screenshot Saved" -no-ra
         fi
       ;;
      (${FUNCTION_HOTKEY_BTN_WEST_EVENT})


### PR DESCRIPTION
At the moment it triggers the 'Screenshot Saved' mako notification whether or not screenshots are enabled / actually have been taken. This change adds exit code handling before triggering the notification.

Tested on my OGU.