### PR TITLE
feat: use repo variable for cache repo name

### DIFF
--- a/.github/workflows/build-aarch64-emu-libretro.yml
+++ b/.github/workflows/build-aarch64-emu-libretro.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-emu-libretro.tar"
+          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-emu-libretro.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."  
 
       - name: Download aarch64 (${{ inputs.DEVICE }})
@@ -164,7 +164,7 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repo: distribution-cache
+          repo: ${{ vars.CACHE_REPO || 'distribution-cache' }}
         continue-on-error: true
 
       - name: Print space

--- a/.github/workflows/build-aarch64-emu-standalone.yml
+++ b/.github/workflows/build-aarch64-emu-standalone.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          BASE="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache"
+          BASE="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache"
           PREFIX="ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar.part-"
           found_any=0
           for suffix in $(printf "%s\n" {a..z}{a..z}); do
@@ -192,7 +192,7 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repo: distribution-cache
+          repo: ${{ vars.CACHE_REPO || 'distribution-cache' }}
         continue-on-error: true
 
       - name: Print space

--- a/.github/workflows/build-aarch64-mame-lr.yml
+++ b/.github/workflows/build-aarch64-mame-lr.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-mame.tar"
+          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-mame.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."
 
       - name: Download aarch64-toolchain (${{ inputs.DEVICE }})
@@ -112,7 +112,7 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repo: distribution-cache
+          repo: ${{ vars.CACHE_REPO || 'distribution-cache' }}
         continue-on-error: true
 
       - name: Compress directory

--- a/.github/workflows/build-aarch64-qt6.yml
+++ b/.github/workflows/build-aarch64-qt6.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-qt6.tar"
+          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-qt6.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping." 
 
       - name: Download aarch64 (${{ inputs.DEVICE }})
@@ -118,7 +118,7 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repo: distribution-cache
+          repo: ${{ vars.CACHE_REPO || 'distribution-cache' }}
         continue-on-error: true
 
       - name: Compress directory

--- a/.github/workflows/build-aarch64-toolchain.yml
+++ b/.github/workflows/build-aarch64-toolchain.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar"
+          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."            
 
       - name: Build
@@ -98,7 +98,7 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repo: distribution-cache
+          repo: ${{ vars.CACHE_REPO || 'distribution-cache' }}
         continue-on-error: true
 
       - name: Compress directory

--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}.tar"
+          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."     
 
       - name: Download aarch64-toolchain (${{ inputs.DEVICE }})
@@ -145,7 +145,7 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repo: distribution-cache
+          repo: ${{ vars.CACHE_REPO || 'distribution-cache' }}
         continue-on-error: true
 
       - name: Print space

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-arm-${{ inputs.DEVICE }}.tar"
+          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-arm-${{ inputs.DEVICE }}.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."       
 
       - name: build
@@ -95,7 +95,7 @@ jobs:
           prerelease: true
           body: cache
           token: ${{ secrets.GH_PAT }}
-          repo: distribution-cache
+          repo: ${{ vars.CACHE_REPO || 'distribution-cache' }}
         continue-on-error: true
 
       - name: Compress directory

--- a/.github/workflows/update-kernel-configs-docs.yml
+++ b/.github/workflows/update-kernel-configs-docs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Retrieve ccache
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/distribution-cache/releases/download/ccache/ccache-aarch64-${{ matrix.device }}-toolchain.tar"
+          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ matrix.device }}-toolchain.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."      
 
       - name: Get deps


### PR DESCRIPTION
- Allows to set the cache repo name via environment variables. Defaults back to `distribution-cache`  if not set.