### PR TITLE
feat: re-implement volume control stepping

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
@@ -11,7 +11,13 @@
 VOLUME=$(get_setting "audio.volume")
 MAX_VOLUME=100
 MIN_VOLUME=0
-STEP=5
+STEP_CAP=5
+
+STEP=$(awk -v vol="$VOLUME" -v cap="$STEP_CAP" 'BEGIN {
+  step = cap - ((vol - 50) * (vol - 50) / 500)
+  if (step < 1) step = 1
+  printf "%.0f\n", step
+}')
 
 case ${1} in
   "+"|"up")

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
@@ -11,12 +11,13 @@
 VOLUME=$(get_setting "audio.volume")
 MAX_VOLUME=100
 MIN_VOLUME=0
-STEP_CAP=5
+MAX_STEP=5
+MIN_STEP=1
 
-STEP=$(awk -v vol="$VOLUME" -v cap="$STEP_CAP" 'BEGIN {
-  step = cap - ((vol - 50) * (vol - 50) / 500)
-  if (step < 1) step = 1
-  printf "%.0f\n", step
+STEP=$(awk -v v="$VOLUME" -v maxStep="$MAX_STEP" -v minStep="$MIN_STEP" 'BEGIN { 
+  step = (v^0.425)
+  minStep = 1
+  print int(step < maxStep ? (step < minStep ? minStep : step) : maxStep) 
 }')
 
 case ${1} in


### PR DESCRIPTION
Based on @porschemad911 's suggestion, implements volume control step calculation as a parabola.
Lower increments on low and high ends, with a max stepping (5) in mid.


