### PR TITLE
Enable ppsspp-lr build

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/package.mk
@@ -20,11 +20,11 @@
 ################################################################################
 
 PKG_NAME="ppsspp-lr"
-PKG_VERSION="58e12acee4d7829ee675ce95f3d377c3aaa3ecc5"
+PKG_VERSION="e49c0bd8836a8a8f678565357773386f1174d3f5"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/hrydgard/ppsspp"
 PKG_URL="https://github.com/hrydgard/ppsspp.git"
-PKG_DEPENDS_TARGET="toolchain SDL2 ffmpeg libzip zstd"
+PKG_DEPENDS_TARGET="toolchain SDL2 libzip zstd"
 PKG_LONGDESC="A PSP emulator for Android, Windows, Mac, Linux and Blackberry 10, written in C++."
 GET_HANDLER_SUPPORT="git"
 
@@ -92,6 +92,11 @@ pre_configure_target() {
 }
 
 pre_make_target() {
+  # This script should work on any board that has issues with system ffmpeg in ppsspp
+  if [ "${TARGET_ARCH}" = "aarch64" ]; then
+    (cd ${PKG_BUILD}/ffmpeg && ./linux_arm64.sh)
+  fi
+
   # fix cross compiling
   find ${PKG_BUILD} -name flags.make -exec sed -i "s:isystem :I:g" \{} \;
   find ${PKG_BUILD} -name build.ninja -exec sed -i "s:isystem :I:g" \{} \;

--- a/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/patches/005-fix-atomics-arm64.patch
+++ b/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/patches/005-fix-atomics-arm64.patch
@@ -1,10 +1,10 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -395,6 +395,7 @@
- 	# NEON optimizations in libpng17 seem to cause PNG load errors, see #14485.
+@@ -396,6 +396,7 @@
  	add_compile_definitions(PNG_ARM_NEON_OPT=0)
  
-+	add_compile_options(-Ofast -fno-tree-slp-vectorize)
+ 	add_compile_options(-Ofast -fno-tree-slp-vectorize)
++	add_compile_options(-mno-outline-atomics)
  	add_compile_options(-Wall -Werror=return-type -Wno-unused-function -Wno-sign-compare -Wno-unused-but-set-variable "$<$<COMPILE_LANGUAGE:CXX>:-Wno-reorder>" -Wno-unknown-pragmas -Wno-unused-value -Wno-unused-variable)
  	if(NOT CLANG)
  		# This one is very useful but has many false positives.

--- a/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/patches/006-fix-ffmpeg-atomics.patch
+++ b/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/patches/006-fix-ffmpeg-atomics.patch
@@ -1,0 +1,11 @@
+--- a/ffmpeg/linux_arm64.sh
++++ b/ffmpeg/linux_arm64.sh
+@@ -86,7 +86,7 @@
+ ./configure --target-os=linux \
+     --prefix=./linux/aarch64 \
+     ${GENERAL} \
+-    --extra-cflags=" -O3 -fasm -Wno-psabi -fno-short-enums -fno-strict-aliasing -finline-limit=300 " \
++    --extra-cflags=" -O3 -fasm -Wno-psabi -mno-outline-atomics -fno-short-enums -fno-strict-aliasing -finline-limit=300 " \
+     --disable-shared \
+     --enable-static \
+     --enable-zlib \

--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -21,10 +21,10 @@ LIBRETRO_CORES="81-lr a5200-lr arduous-lr atari800-lr b2-lr beetle-gba-lr beetle
                 gearboy-lr gearcoleco-lr gearsystem-lr genesis-plus-gx-lr genesis-plus-gx-wide-lr gw-lr handy-lr hatari-lr idtech-lr \
                 jaxe-lr mame-lr mame2003-plus-lr mame2010-lr mame2015-lr melonds-lr melonds-ds-lr mesen-lr mgba-lr minivmac-lr       \
                 mojozork-lr mu-lr mupen64plus-lr mupen64plus-nx-lr neocd_lr nestopia-lr np2kai-lr o2em-lr opera-lr parallel-n64-lr   \
-                pcsx_rearmed-lr picodrive-lr pokemini-lr potator-lr prosystem-lr puae-lr puae2021-lr px68k-lr quasi88-lr quicknes-lr \
-                race-lr same_cdi-lr sameboy-lr sameduck-lr scummvm-lr smsplus-gx-lr snes9x-lr snes9x2002-lr snes9x2005_plus-lr       \
-                snes9x2010-lr stella-lr swanstation-lr tgbdual-lr theodore-lr tic80-lr uzem-lr vba-next-lr vbam-lr vecx-lr vice-lr   \
-                vircon32-lr virtualjaguar-lr xmil-lr wasm4-lr yabasanshiro-lr"
+                pcsx_rearmed-lr picodrive-lr pokemini-lr potator-lr ppsspp-lr prosystem-lr puae-lr puae2021-lr px68k-lr quasi88-lr   \
+                quicknes-lr race-lr same_cdi-lr sameboy-lr sameduck-lr scummvm-lr smsplus-gx-lr snes9x-lr snes9x2002-lr              \
+                snes9x2005_plus-lr snes9x2010-lr stella-lr swanstation-lr tgbdual-lr theodore-lr tic80-lr uzem-lr vba-next-lr        \
+                vbam-lr vecx-lr vice-lr vircon32-lr virtualjaguar-lr xmil-lr wasm4-lr yabasanshiro-lr"
 
 ### Emulators or cores for specific devices
 case "${DEVICE}" in
@@ -991,6 +991,7 @@ makeinstall_target() {
 
   ### Sony Playstation Portable
   add_emu_core psp ppsspp ppsspp-sa true
+  add_emu_core psp retroarch ppsspp false
   add_es_system psp
   install_script "Start PPSSPP.sh"
 


### PR DESCRIPTION
Enabled the `ppsspp-lr` build to provide a consistent user experience within RetroArch.

In this PR, I have:
- Bumped `ppsspp-lr` to the latest version.
- Resolved conflicts in the existing patch (004).
- Fixed the ffmpeg issue occurring on `aarch64` builds (005, 006).

<img width="671" height="556" alt="image" src="https://github.com/user-attachments/assets/d5e56d87-ec40-486c-8a32-5d9fdf54d92c" />

Tested and verified working on SM8250 (rpminiv2).


refer from:
https://github.com/libretro/Lakka-LibreELEC/tree/Lakka-v6.1/packages/lakka/libretro_cores/ppsspp
https://github.com/RetroGFX/UnofficialOS/tree/main/packages/emulators/libretro/ppsspp-lr
