### PR TITLE
ppsspp-lr: Re-enable and fix Docker build error

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/ppsspp-lr/package.mk
@@ -94,6 +94,7 @@ pre_configure_target() {
 pre_make_target() {
   # This script should work on any board that has issues with system ffmpeg in ppsspp
   if [ "${TARGET_ARCH}" = "aarch64" ]; then
+    sed -i "s|aarch64-linux-gnu-|${TARGET_PREFIX}|g" ${PKG_BUILD}/ffmpeg/linux_arm64.sh
     (cd ${PKG_BUILD}/ffmpeg && ./linux_arm64.sh)
   fi
 

--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -21,7 +21,7 @@ LIBRETRO_CORES="81-lr a5200-lr arduous-lr atari800-lr b2-lr beetle-gba-lr beetle
                 gearboy-lr gearcoleco-lr gearsystem-lr genesis-plus-gx-lr genesis-plus-gx-wide-lr gw-lr handy-lr hatari-lr idtech-lr \
                 jaxe-lr mame-lr mame2003-plus-lr mame2010-lr mame2015-lr melonds-lr melonds-ds-lr mesen-lr mgba-lr minivmac-lr       \
                 mojozork-lr mu-lr mupen64plus-lr mupen64plus-nx-lr neocd_lr nestopia-lr np2kai-lr o2em-lr opera-lr parallel-n64-lr   \
-                pcsx_rearmed-lr picodrive-lr pokemini-lr potator-lr prosystem-lr puae-lr puae2021-lr px68k-lr quasi88-lr             \
+                pcsx_rearmed-lr picodrive-lr pokemini-lr potator-lr ppsspp-lr prosystem-lr puae-lr puae2021-lr px68k-lr quasi88-lr   \
                 quicknes-lr race-lr same_cdi-lr sameboy-lr sameduck-lr scummvm-lr smsplus-gx-lr snes9x-lr snes9x2002-lr              \
                 snes9x2005_plus-lr snes9x2010-lr stella-lr swanstation-lr tgbdual-lr theodore-lr tic80-lr uzem-lr vba-next-lr        \
                 vbam-lr vecx-lr vice-lr vircon32-lr virtualjaguar-lr xmil-lr wasm4-lr yabasanshiro-lr"
@@ -991,7 +991,7 @@ makeinstall_target() {
 
   ### Sony Playstation Portable
   add_emu_core psp ppsspp ppsspp-sa true
-  # add_emu_core psp retroarch ppsspp false
+  add_emu_core psp retroarch ppsspp false
   add_es_system psp
   install_script "Start PPSSPP.sh"
 


### PR DESCRIPTION
Host build worked fine, but I found and fixed an aarch64 toolchain issue during the bundled ffmpeg build for ppsspp-lr in the Docker environment.