### PR TITLE
Retroid Pocket: Add dual-screen vertical support for RP5, Flip 2 and Mini series

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
@@ -405,6 +405,15 @@ performance
 
 clear_screen
 
+### Disable touch on the secondary screen for dual screen devices
+if [[ "${DEVICE_HAS_DUAL_SCREEN}" == "true" ]]; then
+  # Disable touch events for Retroid Pocket devices to prevent focus loss
+  if [[ "${QUIRK_DEVICE}" == "Retroid Pocket 5" || "${QUIRK_DEVICE}" == "Retroid Pocket Flip2" || "${QUIRK_DEVICE}" == "Retroid Pocket Mini" || "${QUIRK_DEVICE}" == "Retroid Pocket Mini V2" ]]; then
+    swaymsg input "0:0:generic_ft5x06_(a0)" events disabled
+    swaymsg input "0:0:generic_ft5x06_(8d)" events disabled
+  fi
+fi
+
 ### Go back to system display mode , if we had specialized mode defined
 DISPLAY_MODE=$(get_setting "display_mode" "${PLATFORM}" "${ROMNAME##*/}")
 if [ ! -z "${DISPLAY_MODE}" ] && [ "${DISPLAY_MODE}" != "default" ]

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
@@ -52,6 +52,32 @@ if [ "${IS_VERTICAL}" = "true" ]; then
         swaymsg output DSI-1 scale 1.41
         swaymsg '[title="RetroArch.*"] output DSI-1 pos 0 0, output DSI-2 pos 160 768'
         swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 1024 1536, move to output DSI-1, move absolute position 160 0'
+    elif [[ "${QUIRK_DEVICE}" == "Retroid Pocket 5" || "${QUIRK_DEVICE}" == "Retroid Pocket Flip2" || "${QUIRK_DEVICE}" == "Retroid Pocket Mini" || "${QUIRK_DEVICE}" == "Retroid Pocket Mini V2" ]]; then
+        case "${QUIRK_DEVICE}" in
+            "Retroid Pocket 5" | "Retroid Pocket Flip2")
+                DSI_X="0"
+                RA_WIDTH="1920"
+                RA_HEIGHT="2160" # 1080 + 1080
+                ;;
+            "Retroid Pocket Mini")
+                DSI_X="340"
+                RA_WIDTH="1240"
+                RA_HEIGHT="2010" # 1080 + 930
+                ;;
+            "Retroid Pocket Mini V2")
+                DSI_X="340"
+                RA_WIDTH="1240"
+                RA_HEIGHT="2160" # 1080 + 1080
+                ;;
+        esac
 
+        # Setup vertical stack using external DP-1 as the top screen.
+        swaymsg "[title=\"RetroArch.*\"] output DP-1 pos 0 0, output DSI-1 pos ${DSI_X} 1080"
+        swaymsg "[title=\"RetroArch.*\"] floating enable, fullscreen disable, resize set ${RA_WIDTH} ${RA_HEIGHT}, move to output DP-1, move absolute position ${DSI_X} 0"
+
+        swaymsg input "0:0:generic_ft5x06_(a0)" map_to_output DSI-1
+        swaymsg input "0:0:generic_ft5x06_(a0)" events enabled
+        swaymsg input "0:0:generic_ft5x06_(8d)" map_to_output DSI-1
+        swaymsg input "0:0:generic_ft5x06_(8d)" events enabled
     fi
 fi

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -102,8 +102,12 @@ if hexdump -C /sys/class/drm/card0-DP-1/edid | grep -q "Lontium"; then
   echo "output DP-1 scale 1" >> $SWAY_HOME/config
   echo "output DP-1 position 0 0" >> $SWAY_HOME/config
   echo "input \"0:0:generic_ft5x06_(a0)\" map_to_output DSI-1" >> $SWAY_HOME/config
+  echo "input \"0:0:generic_ft5x06_(a0)\" events disabled" >> $SWAY_HOME/config
+  echo "input \"0:0:generic_ft5x06_(8d)\" map_to_output DSI-1" >> $SWAY_HOME/config
+  echo "input \"0:0:generic_ft5x06_(8d)\" events disabled" >> $SWAY_HOME/config
   echo "input \"8746:1:RetroidPocket_RDS_Touchscreen\" map_to_output DP-1" >> $SWAY_HOME/config
   echo "input \"8746:1:RetroidPocket_RDS_Touchscreen\" calibration_matrix 0 1 0 -1 0 1" >> $SWAY_HOME/config
+  echo 'for_window [app_id="emulationstation"] focus output DP-1' >> $SWAY_HOME/config
   con="DP-1"
 fi
 


### PR DESCRIPTION
Since RDS recognition is already present, I have implemented the `vertical-check` logic for Retroid devices.

To overcome the issue where controls/buttons become frozen after exiting a game, I applied an aggressive retry loop to reliably regain focus for ES. While there might be a more refined architectural approach, this method successfully handles the unpredictable timing of display re-rendering and ES wake-up.

Please note that I have only tested this on the Retroid Pocket Mini V2, so further verification on other listed devices (RP5, Flip 2, Mini) might be necessary.