### PR TITLE
post-update - inputplumber - ES input / RA / standalone emulator config

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -114,7 +114,7 @@ if echo ${HW_DEVICE}  | grep -E 'H700'; then
   rsync -a /usr/config/flycast /storage/.config/
 fi
 
-# Update PPSSPP & PS2 configs on Retroid Devices
+# SM8250 / SM8550 - disable RA threaded video
 if echo ${HW_DEVICE}  | grep -E 'SM8250|SM8550'; then
   sed -i '/video_threaded =/c\video_threaded = "false"' /storage/.config/retroarch/retroarch.cfg
 fi
@@ -254,4 +254,26 @@ rm -f /storage/.cache/swapfile
 if [[ -d "/storage/.config/azahar/states" && ! -d "/storage/roms/savestates/3ds" ]]; then
   mkdir -p /storage/roms/savestates/3ds
   cp -rf /storage/.config/azahar/states/* /storage/roms/savestates/3ds/
+fi
+
+# Clean input config for platforms migrated to inputplumber, with migration flag check
+if [[ "${HW_DEVICE}" =~ SM8550|SM8650 && ! -e "/storage/.inputplumber_migration_complete" ]]; then
+  # Reset ES input / RA config
+  cp -f /usr/config/emulationstation/es_input.cfg /storage/.config/emulationstation/
+  cp -f /usr/config/retroarch/retroarch.cfg /storage/.config/retroarch/
+  
+  # Wipe standalone emulator config - it will be recreated from /usr/config on emulator launch
+  rm -rf /storage/.config/aethersx2
+  rm -rf /storage/.config/dolphin-emu
+  rm -rf /storage/.config/azahar
+  rm -rf /storage/.config/duckstation
+  rm -rf /storage/.config/flycast
+  rm -rf /storage/.config/ppsspp
+  rm -rf /storage/.config/rpcs3
+  rm -rf /storage/.config/Cemu
+  rm -rf /storage/.config/melonDS
+  rm -rf /storage/.config/mupen64plus
+
+  # Mark migration as complete
+  touch /storage/.inputplumber_migration_complete
 fi


### PR DESCRIPTION
Tested on my Odin 2, multiple times for migration flag check.