### PR TITLE
`packages/linux-drivers: patch RTL8733BU for kernel 6.x and WPA3/iwd`

### DIFF
--- a/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/modprobe.d/8733bu.conf
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/modprobe.d/8733bu.conf
@@ -1,0 +1,1 @@
+options 8733bu rtw_ips_mode=1 rtw_power_mgnt=2 rtw_lps_level=1

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/package.mk
@@ -19,7 +19,10 @@ make_target() {
        ARCH=${TARGET_KERNEL_ARCH} \
        KSRC=$(kernel_path) \
        CROSS_COMPILE=${TARGET_KERNEL_PREFIX} \
-       CONFIG_POWER_SAVING=y
+       CONFIG_POWER_SAVING=y \
+       CONFIG_IPS_MODE=1 \
+       CONFIG_LPS_MODE=1 \
+       CONFIG_USB_AUTOSUSPEND=y
 }
 
 makeinstall_target() {

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/001-linux-6.19-compat.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/001-linux-6.19-compat.patch
@@ -1,0 +1,353 @@
+diff --git a/Makefile b/Makefile
+index 1111111..2222222 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2657,6 +2657,9 @@ ifeq ($(CONFIG_RTL8723B), y)
+ $(MODULE_NAME)-$(CONFIG_MP_INCLUDED)+= core/rtw_bt_mp.o
+ endif
+ 
++ccflags-y += $(EXTRA_CFLAGS)
++ldflags-y += $(EXTRA_LDFLAGS)
++
+ obj-$(CONFIG_RTL8733BU) := $(MODULE_NAME).o
+ 
+ else
+diff --git a/core/crypto/sha256-prf.c b/core/crypto/sha256-prf.c
+index 642b38f..976bc71 100644
+--- a/core/crypto/sha256-prf.c
++++ b/core/crypto/sha256-prf.c
+@@ -79,12 +79,12 @@ int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
+ 		plen = buf_len - pos;
+ 		WPA_PUT_LE16(counter_le, counter);
+ 		if (plen >= SHA256_MAC_LEN) {
+-			if (hmac_sha256_vector(key, key_len, 4, addr, len,
++			if (rtw_hmac_sha256_vector(key, key_len, 4, addr, len,
+ 					       &buf[pos]) < 0)
+ 				return -1;
+ 			pos += SHA256_MAC_LEN;
+ 		} else {
+-			if (hmac_sha256_vector(key, key_len, 4, addr, len,
++			if (rtw_hmac_sha256_vector(key, key_len, 4, addr, len,
+ 					       hash) < 0)
+ 				return -1;
+ 			os_memcpy(&buf[pos], hash, plen);
+diff --git a/core/crypto/sha256.c b/core/crypto/sha256.c
+index ea5d9e3..002b833 100644
+--- a/core/crypto/sha256.c
++++ b/core/crypto/sha256.c
+@@ -14,7 +14,7 @@
+ 
+ 
+ /**
+- * hmac_sha256_vector - HMAC-SHA256 over data vector (RFC 2104)
++ * rtw_hmac_sha256_vector - HMAC-SHA256 over data vector (RFC 2104)
+  * @key: Key for HMAC operations
+  * @key_len: Length of the key in bytes
+  * @num_elem: Number of elements in the data vector
+@@ -23,7 +23,7 @@
+  * @mac: Buffer for the hash (32 bytes)
+  * Returns: 0 on success, -1 on failure
+  */
+-int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
++int rtw_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+ 		       const u8 *addr[], const size_t *len, u8 *mac)
+ {
+ 	unsigned char k_pad[64]; /* padding - key XORd with ipad/opad */
+@@ -89,7 +89,7 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+ 
+ 
+ /**
+- * hmac_sha256 - HMAC-SHA256 over data buffer (RFC 2104)
++ * rtw_hmac_sha256 - HMAC-SHA256 over data buffer (RFC 2104)
+  * @key: Key for HMAC operations
+  * @key_len: Length of the key in bytes
+  * @data: Pointers to the data area
+@@ -97,8 +97,8 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+  * @mac: Buffer for the hash (32 bytes)
+  * Returns: 0 on success, -1 on failure
+  */
+-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
++int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+ 		size_t data_len, u8 *mac)
+ {
+-	return hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
++	return rtw_hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
+ }
+diff --git a/core/crypto/sha256.h b/core/crypto/sha256.h
+index 5219022..f579d12 100644
+--- a/core/crypto/sha256.h
++++ b/core/crypto/sha256.h
+@@ -11,9 +11,9 @@
+ 
+ #define SHA256_MAC_LEN 32
+ 
+-int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
++int rtw_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+ 		       const u8 *addr[], const size_t *len, u8 *mac);
+-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
++int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+ 		size_t data_len, u8 *mac);
+ int sha256_prf(const u8 *key, size_t key_len, const char *label,
+ 	       const u8 *data, size_t data_len, u8 *buf, size_t buf_len);
+@@ -23,7 +23,7 @@ int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
+ void tls_prf_sha256(const u8 *secret, size_t secret_len,
+ 		    const char *label, const u8 *seed, size_t seed_len,
+ 		    u8 *out, size_t outlen);
+-int hmac_sha256_kdf(const u8 *secret, size_t secret_len,
++int rtw_hmac_sha256_kdf(const u8 *secret, size_t secret_len,
+ 		    const char *label, const u8 *seed, size_t seed_len,
+ 		    u8 *out, size_t outlen);
+ 
+diff --git a/core/rtw_mlme.c b/core/rtw_mlme.c
+index 6393090..91408d4 100755
+--- a/core/rtw_mlme.c
++++ b/core/rtw_mlme.c
+@@ -89,6 +89,11 @@ sint	_rtw_init_mlme_priv(_adapter *padapter)
+ 		pmlmepriv->max_bss_cnt += is_supported_6g(padapter->registrypriv.wireless_mode) ? MAX_BSS_CNT : 0;
+ 	}
+ 
++	/* RTL8733BU FIX: force wireless_mode if zero (kernel 6.19 init order issue) */
++	if (padapter->registrypriv.wireless_mode == 0)
++		padapter->registrypriv.wireless_mode = WIRELESS_MODE_24G;
++	if (pmlmepriv->max_bss_cnt == 0)
++		pmlmepriv->max_bss_cnt = MAX_BSS_CNT;
+ 	pbuf = rtw_zvmalloc(pmlmepriv->max_bss_cnt * (sizeof(struct wlan_network)));
+ 
+ 	if (pbuf == NULL) {
+diff --git a/hal/halmac-rs/halmac_type.h b/hal/halmac-rs/halmac_type.h
+index c5a0d53..d148038 100644
+--- a/hal/halmac-rs/halmac_type.h
++++ b/hal/halmac-rs/halmac_type.h
+@@ -1298,6 +1298,9 @@ enum halmac_drv_rsvd_pg_num {
+ 	HALMAC_RSVD_PG_NUM64,   /* 8K */
+ 	HALMAC_RSVD_PG_NUM128,  /* 16K */
+ 	HALMAC_RSVD_PG_NUM256,  /* 32K */
++	HALMAC_RSVD_PG_NUM512,  /* 64K */
++	HALMAC_RSVD_PG_NUM1024, /* 128K */
++	HALMAC_RSVD_PG_NUM1460, /* ~183K */
+ };
+ 
+ enum halmac_pcie_cfg {
+diff --git a/hal/phydm/phydm_interface.c b/hal/phydm/phydm_interface.c
+index 26bb9c8..4c1a45e 100644
+--- a/hal/phydm/phydm_interface.c
++++ b/hal/phydm/phydm_interface.c
+@@ -763,11 +763,23 @@ void odm_initialize_timer(struct dm_struct *dm, struct phydm_timer_list *timer,
+ void odm_cancel_timer(struct dm_struct *dm, struct phydm_timer_list *timer)
+ {
+ #if (DM_ODM_SUPPORT_TYPE & ODM_AP)
+-	del_timer(timer);
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
++	timer_delete(timer);
++#else
++	del_timer(timer);
++#endif
+ #elif (DM_ODM_SUPPORT_TYPE & ODM_CE) && defined(DM_ODM_CE_MAC80211)
+-	del_timer(timer);
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
++	timer_delete(timer);
++#else
++	del_timer(timer);
++#endif
+ #elif (DM_ODM_SUPPORT_TYPE & ODM_CE) && defined(DM_ODM_CE_MAC80211_V2)
+-	del_timer(&timer->timer);
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
++	timer_delete(&timer->timer);
++#else
++	del_timer(&timer->timer);
++#endif
+ #elif (DM_ODM_SUPPORT_TYPE & ODM_CE)
+ 	_cancel_timer_ex(timer);
+ #elif (DM_ODM_SUPPORT_TYPE & ODM_WIN)
+diff --git a/hal/rtl8733b/hal8733b_fw.c b/hal/rtl8733b/hal8733b_fw.c
+index a05917e..4028038 100644
+--- a/hal/rtl8733b/hal8733b_fw.c
++++ b/hal/rtl8733b/hal8733b_fw.c
+@@ -64175,4 +64175,19 @@ u32 ccv_array_length_mp_8733b_fw_wowlan = 132112;
+ 
+ #endif /* end of LOAD_FW_HEADER_FROM_DRIVER */
+ 
++#ifndef LOAD_FW_HEADER_FROM_DRIVER
++/* Stub arrays for when firmware is loaded from filesystem (CONFIG_FILE_FWIMG).
++ * The code in rtl8733b_halinit.c / rtl8733b_mac.c references these symbols
++ * even when CONFIG_FILE_FWIMG is defined, so we provide zero-length stubs.
++ * WOWLAN stubs are always defined to satisfy the linker. */
++u8 array_mp_8733b_fw_nic[0];
++u32 array_length_mp_8733b_fw_nic = 0;
++u8 ccv_array_mp_8733b_fw_nic[0];
++u32 ccv_array_length_mp_8733b_fw_nic = 0;
++u8 array_mp_8733b_fw_wowlan[0];
++u32 array_length_mp_8733b_fw_wowlan = 0;
++u8 ccv_array_mp_8733b_fw_wowlan[0];
++u32 ccv_array_length_mp_8733b_fw_wowlan = 0;
++#endif /* !LOAD_FW_HEADER_FROM_DRIVER */
++
+ #endif
+diff --git a/hal/rtl8733b/hal8733b_fw.h b/hal/rtl8733b/hal8733b_fw.h
+index e03a2c9..01353fe 100644
+--- a/hal/rtl8733b/hal8733b_fw.h
++++ b/hal/rtl8733b/hal8733b_fw.h
+@@ -33,6 +33,15 @@ extern u8 ccv_array_mp_8733b_fw_wowlan[132112];
+ extern u32 ccv_array_length_mp_8733b_fw_wowlan;
+ #endif /*CONFIG_WOWLAN*/
+ #endif
++#else /* !LOAD_FW_HEADER_FROM_DRIVER -- file-based firmware stubs */
++extern u8 ccv_array_mp_8733b_fw_nic[];
++extern u32 ccv_array_length_mp_8733b_fw_nic;
++extern u8 array_mp_8733b_fw_nic[];
++extern u32 array_length_mp_8733b_fw_nic;
++extern u8 ccv_array_mp_8733b_fw_wowlan[];
++extern u32 ccv_array_length_mp_8733b_fw_wowlan;
++extern u8 array_mp_8733b_fw_wowlan[];
++extern u32 array_length_mp_8733b_fw_wowlan;
+ #endif /* end of LOAD_FW_HEADER_FROM_DRIVER */
+ 
+ #endif
+diff --git a/include/autoconf.h b/include/autoconf.h
+index 065389b..c1b9045 100755
+--- a/include/autoconf.h
++++ b/include/autoconf.h
+@@ -241,11 +241,14 @@
+ 
+ #define CONFIG_NEW_SIGNAL_STAT_PROCESS
+ 
++/* Embed firmware arrays in the driver module (3MB).
++ * Also enable file-based loading as first-try path;
++ * if file not found, driver falls back to embedded arrays. */
+ #define CONFIG_EMBEDDED_FWIMG
+ #ifdef CONFIG_EMBEDDED_FWIMG
+ 	#define	LOAD_FW_HEADER_FROM_DRIVER
+ #endif
+-/* #define CONFIG_FILE_FWIMG */
++#define CONFIG_FILE_FWIMG
+ #define CONFIG_LONG_DELAY_ISSUE
+ 
+ #define CONFIG_RX_PACKET_APPEND_FCS
+diff --git a/include/osdep_service_linux.h b/include/osdep_service_linux.h
+index 4351d76..ad6dd79 100755
+--- a/include/osdep_service_linux.h
++++ b/include/osdep_service_linux.h
+@@ -371,7 +371,9 @@ static inline void timer_hdl(struct timer_list *in_timer)
+ static inline void timer_hdl(unsigned long cntx)
+ #endif
+ {
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
++	_timer *ptimer = timer_container_of(ptimer, in_timer, timer);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+ 	_timer *ptimer = from_timer(ptimer, in_timer, timer);
+ #else
+ 	_timer *ptimer = (_timer *)cntx;
+@@ -406,12 +408,20 @@ __inline static void _set_timer(_timer *ptimer, u32 delay_time)
+ 
+ __inline static void _cancel_timer(_timer *ptimer, u8 *bcancelled)
+ {
+-	*bcancelled = del_timer_sync(&ptimer->timer) == 1 ? 1 : 0;
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
++	*bcancelled = timer_delete_sync(&ptimer->timer) == 1 ? 1 : 0;
++#else
++	*bcancelled = del_timer_sync(&ptimer->timer) == 1 ? 1 : 0;
++#endif
+ }
+ 
+ __inline static void _cancel_timer_async(_timer *ptimer)
+ {
+-	del_timer(&ptimer->timer);
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
++	timer_delete(&ptimer->timer);
++#else
++	del_timer(&ptimer->timer);
++#endif
+ }
+ 
+ static inline void _init_workitem(_workitem *pwork, void *pfunc, void *cntx)
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 8e160c7..11b57ee 100755
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -3513,7 +3513,11 @@ static void cfg80211_rtw_abort_scan(struct wiphy *wiphy,
+ }
+ #endif
+ 
+-static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, u32 changed)
++static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy,
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
++	int radio_idx,
++#endif
++	u32 changed)
+ {
+ #if 0
+ 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
+@@ -4561,6 +4565,9 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+ 	struct wireless_dev *wdev,
+ #endif
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
++	int radio_idx,
++#endif
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 36)) || defined(COMPAT_KERNEL_RELEASE)
+ 	enum nl80211_tx_power_setting type, int mbm)
+ #else
+@@ -4622,6 +4629,12 @@ exit:
+ static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+ 	struct wireless_dev *wdev,
++#endif
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
++	int radio_idx,
++#endif
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
++	unsigned int link_id,
+ #endif
+ 	int *dbm)
+ {
+@@ -6945,6 +6945,9 @@
+ #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++	, struct net_device *dev
++#endif
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+ 	, struct cfg80211_chan_def *chandef
+ #else
+@@ -10874,6 +10884,39 @@ int rtw_wiphy_register(struct wiphy *wiphy)
+ 	rtw_chset_hook_os_channels(chset, wiphy);
+ 	#endif
+ 
++	/* RTL8733BU FIX: ensure at least 2.4GHz band before wiphy_register (kernel 6.19) */
++	if (!wiphy->bands[NL80211_BAND_2GHZ] && !wiphy->bands[NL80211_BAND_5GHZ]) {
++		static struct ieee80211_channel rtw_2g_ch_fb[] = {
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2412, .hw_value = 1},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2417, .hw_value = 2},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2422, .hw_value = 3},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2427, .hw_value = 4},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2432, .hw_value = 5},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2437, .hw_value = 6},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2442, .hw_value = 7},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2447, .hw_value = 8},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2452, .hw_value = 9},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2457, .hw_value = 10},
++			{.band = NL80211_BAND_2GHZ, .center_freq = 2462, .hw_value = 11},
++		};
++		static struct ieee80211_rate rtw_2g_rt_fb[] = {
++			{.bitrate = 10, .hw_value = 0}, {.bitrate = 20, .hw_value = 1},
++			{.bitrate = 55, .hw_value = 2}, {.bitrate = 110, .hw_value = 3},
++			{.bitrate = 60, .hw_value = 4}, {.bitrate = 90, .hw_value = 5},
++			{.bitrate = 120, .hw_value = 6}, {.bitrate = 180, .hw_value = 7},
++			{.bitrate = 240, .hw_value = 8}, {.bitrate = 360, .hw_value = 9},
++			{.bitrate = 480, .hw_value = 10}, {.bitrate = 540, .hw_value = 11},
++		};
++		static struct ieee80211_supported_band rtw_band_2g_fb = {
++			.channels = rtw_2g_ch_fb,
++			.n_channels = ARRAY_SIZE(rtw_2g_ch_fb),
++			.bitrates = rtw_2g_rt_fb,
++			.n_bitrates = ARRAY_SIZE(rtw_2g_rt_fb),
++		};
++		wiphy->bands[NL80211_BAND_2GHZ] = &rtw_band_2g_fb;
++		/* Fallback 2.4GHz band injected for kernel 6.19 compatibility */
++	}
++
+ 	ret = wiphy_register(wiphy);
+ 	if (ret != 0) {
+ 		RTW_INFO(FUNC_WIPHY_FMT" wiphy_register() return %d\n", FUNC_WIPHY_ARG(wiphy), ret);

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/002-fix-dev-addr-set-kernel-6.x.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/002-fix-dev-addr-set-kernel-6.x.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ROCKNIX <rocknix@rocknix.org>
+Date: Mon, 17 Feb 2026 00:00:00 +0100
+Subject: [PATCH] net: rtl8733bu: use dev_addr_set() for kernel 6.x compat
+
+Since Linux 5.17, writing directly to netdev->dev_addr via memcpy is
+forbidden. The kernel validates the address through dev_addr_check()
+and triggers a WARNING when the address doesn't match the internal
+dev_addr_list, which also prevents cfg80211/ConnMan from recognizing
+the WiFi interface.
+
+Replace remaining _rtw_memcpy(ndev->dev_addr, ...) calls with
+dev_addr_set(). (ROCKNIX source 308919f already uses dev_addr_mod in
+rtw_net_set_mac_address and rtw_os_ndev_register; this patch fixes
+mlme_linux.c and the CONFIG_PLATFORM_INTEL_BYT paths in os_intfs.c.)
+
+Fixes: "WARNING: CPU: ... at net/core/dev_addr_lists.c:520 dev_addr_check"
+Fixes: "connmanctl enable wifi" returning "wifi is not available"
+
+Signed-off-by: ROCKNIX <rocknix@rocknix.org>
+---
+ os_dep/linux/mlme_linux.c | 2 +-
+ os_dep/linux/os_intfs.c   | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/os_dep/linux/mlme_linux.c b/os_dep/linux/mlme_linux.c
+index 1111111..2222222 100644
+--- a/os_dep/linux/mlme_linux.c
++++ b/os_dep/linux/mlme_linux.c
+@@ -412,7 +412,7 @@ void rtw_os_ndev_register_mgnt_frame(struct net_device *ndev)
+ 	mac[4] = 0x11;
+ 	mac[5] = 0x12;
+ 
+-	_rtw_memcpy(pnetdev->dev_addr, mac, ETH_ALEN);
++	dev_addr_set(pnetdev, mac);
+ 
+ 
+ 	rtw_netif_carrier_off(pnetdev);
+diff --git a/os_dep/linux/os_intfs.c b/os_dep/linux/os_intfs.c
+index 3333333..4444444 100644
+--- a/os_dep/linux/os_intfs.c
++++ b/os_dep/linux/os_intfs.c
+@@ -3269,7 +3269,7 @@ static int _netdev_open(struct net_device *pnetdev)
+ 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
+ #endif
+ 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
+-		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
++		dev_addr_set(pnetdev, adapter_mac_addr(padapter));
+ 	}
+ #endif /*CONFIG_PLATFORM_INTEL_BYT*/
+ 
+@@ -4025,7 +4025,7 @@ int _netdev_vir_if_open(struct net_device *pnetdev)
+ 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
+ #endif
+ 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
+-		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
++		dev_addr_set(pnetdev, adapter_mac_addr(padapter));
+ #endif /* CONFIG_PLATFORM_INTEL_BYT */
+ 
+ 		rtw_clr_surprise_removed(padapter);

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/003-fix-sae-wpa3-and-compat.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/003-fix-sae-wpa3-and-compat.patch
@@ -1,0 +1,182 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ROCKNIX <rocknix@rocknix.org>
+Date: Thu, 20 Feb 2026 00:00:00 +0100
+Subject: [PATCH] net: rtl8733bu: fix SAE/WPA3 authentication and compat
+
+Fix WPA3-Personal (SAE) connections with iwd on FullMAC drivers.
+Without these changes, SAE authentication either never starts, completes
+but never transitions to association, or silently self-disconnects
+within seconds due to a duplicate association storm.
+
+1. Fix SAE key_mgmt_suite endianness for kernel >= 6.9
+
+   Since kernel 6.9, nl80211 handles the big-endian conversion for
+   WLAN_AKM_SUITE_SAE inside cfg80211_external_auth_request(). The
+   driver was hardcoding cpu_to_be32(WLAN_AKM_SUITE_SAE) which breaks
+   the suite comparison in iwd. Pass the value in host byte order on
+   kernel >= 6.9.
+
+2. Fix cfg80211_external_auth_params struct layout mismatch
+
+   Kernel >= 5.1 changed pmkid from u8[16] to const u8* and added an
+   mld_addr field, making cfg80211_external_auth_params larger than the
+   driver's rtw_external_auth_params. The raw cast corrupted fields.
+   Copy fields individually instead.
+
+3. Fix mgmt_tx rejecting SAE frames when channel is NULL
+
+   iwd sends NL80211_CMD_FRAME for SAE authentication without a channel
+   frequency, causing the kernel to pass chan=NULL. The driver returned
+   -EINVAL, aborting SAE. Fall back to rtw_get_oper_ch() when chan is
+   NULL, and guard the DFS check against NULL dereference.
+
+4. Trigger association after SAE success in STA mode
+
+   The external_auth_status handler only stored the status but never
+   triggered the MLME association phase. Add start_clnt_assoc() call
+   on SAE success so the driver transitions from AUTH to ASSOC state.
+
+5. Remove duplicate start_clnt_assoc from set_pmksa
+
+   cfg80211_rtw_set_pmksa() called start_clnt_assoc() when SAE auth
+   was detected. Since iwd calls set_pmksa AFTER the 4-way handshake
+   (when association already succeeded), this sent a second association
+   request. The AP accepted it, but the driver's OnAssocRsp returned
+   early (ASSOC_SUCCESS already set), leaving the link timer running.
+   After REASSOC_LIMIT retries the driver reported join failure and
+   disconnected. Remove this redundant call.
+
+6. Add MODULE_IMPORT_NS for VFS access (CONFIG_FILE_FWIMG)
+
+   Kernel 6.13 changed MODULE_IMPORT_NS to require a string argument.
+
+7. Optimize _cancel_timer_ex for kernel >= 4.15
+
+   Bypass the _cancel_timer indirection and call timer_delete_sync /
+   del_timer_sync directly.
+
+Signed-off-by: ROCKNIX <rocknix@rocknix.org>
+---
+ include/osdep_service.h       |  8 +++++++-
+ os_dep/linux/ioctl_cfg80211.c | 36 +++++++++++++++++++++++++-----------
+ os_dep/linux/os_intfs.c       |  7 +++++++
+ 3 files changed, 39 insertions(+), 12 deletions(-)
+
+diff --git a/include/osdep_service.h b/include/osdep_service.h
+--- a/include/osdep_service.h
++++ b/include/osdep_service.h
+@@ -480,10 +480,14 @@
+ __inline static unsigned char _cancel_timer_ex(_timer *ptimer)
+ {
+ 	u8 bcancelled;
+-
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
++	return timer_delete_sync(&ptimer->timer);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
++	return del_timer_sync(&ptimer->timer);
++#else
+ 	_cancel_timer(ptimer, &bcancelled);
+-
+ 	return bcancelled;
++#endif
+ }
+ 
+ static __inline void thread_enter(char *name)
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -4738,12 +4738,6 @@
+ 
+ 	_rtw_set_pmksa(ndev, (u8 *)pmksa->bssid, (u8 *)pmksa->pmkid);
+ 
+-	if (sae_auth &&
+-		(psecuritypriv->extauth_status == WLAN_STATUS_SUCCESS)) {
+-		RTW_PRINT("SAE: auth success, start assoc\n");
+-		start_clnt_assoc(padapter);
+-	}
+-
+ 	return 0;
+ }
+ 
+@@ -7015,7 +7009,11 @@
+ 	params.ssid.ssid_len = pmlmeinfo->network.Ssid.SsidLength;
+ 	_rtw_memcpy(params.ssid.ssid, pmlmeinfo->network.Ssid.Ssid,
+ 		pmlmeinfo->network.Ssid.SsidLength);
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++	params.key_mgmt_suite = WLAN_AKM_SUITE_SAE;
++#else
+ 	params.key_mgmt_suite = 0x8ac0f00;
++#endif
+ 
+ 	RTW_INFO("external auth: use kernel API: cfg80211_external_auth_request()\n");
+ 	cfg80211_external_auth_request(netdev, &params, GFP_ATOMIC);
+@@ -8258,13 +8256,17 @@
+ #endif
+ 
+ 	if (chan == NULL) {
+-		ret = -EINVAL;
+-		goto exit;
++		tx_ch = rtw_get_oper_ch(padapter);
++		if (tx_ch == 0) {
++			ret = -EINVAL;
++			goto exit;
++		}
++	} else {
++		tx_ch = (u8)ieee80211_frequency_to_channel(chan->center_freq);
+ 	}
+ 
+ 	rfctl = adapter_to_rfctl(padapter);
+-	tx_ch = (u8)ieee80211_frequency_to_channel(chan->center_freq);
+-	if (IS_CH_WAITING(rfctl)) {
++	if (chan && IS_CH_WAITING(rfctl)) {
+ 		#ifdef CONFIG_DFS_MASTER
+ 		if (rtw_rfctl_overlap_radar_detect_ch(rfctl, nl80211_band_to_rtw_band(chan->band), tx_ch, CHANNEL_WIDTH_20, HAL_PRIME_CHNL_OFFSET_DONT_CARE)) {
+ 			ret = -EINVAL;
+@@ -10492,11 +10494,19 @@
+ 	struct cfg80211_external_auth_params *params)
+ {
+ 	PADAPTER padapter = (_adapter *)rtw_netdev_priv(dev);
++	struct rtw_external_auth_params rtw_params = {0};
+ 
+ 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(dev));
+ 
+-	rtw_cfg80211_external_auth_status(wiphy, dev,
+-		(struct rtw_external_auth_params *)params);
++	rtw_params.action = params->action;
++	_rtw_memcpy(rtw_params.bssid, params->bssid, ETH_ALEN);
++	rtw_params.ssid = params->ssid;
++	rtw_params.key_mgmt_suite = params->key_mgmt_suite;
++	rtw_params.status = params->status;
++	if (params->pmkid)
++		_rtw_memcpy(rtw_params.pmkid, params->pmkid, PMKID_LEN);
++
++	rtw_cfg80211_external_auth_status(wiphy, dev, &rtw_params);
+ 
+ 	return 0;
+ }
+@@ -10578,6 +10588,8 @@
+ 	} else {
+ 		/* STA mode */
+ 		psecuritypriv->extauth_status = params->status;
++		if (params->status == WLAN_STATUS_SUCCESS)
++			start_clnt_assoc(padapter);
+ 	}
+ }
+ 
+diff --git a/os_dep/linux/os_intfs.c b/os_dep/linux/os_intfs.c
+--- a/os_dep/linux/os_intfs.c
++++ b/os_dep/linux/os_intfs.c
+@@ -21,6 +21,13 @@
+ MODULE_DESCRIPTION("Realtek Wireless Lan Driver");
+ MODULE_AUTHOR("Realtek Semiconductor Corp.");
+ MODULE_VERSION(DRIVERVERSION);
++#ifdef CONFIG_FILE_FWIMG
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0))
++MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
++#endif
++#endif
+ 
+ /* module param defaults */
+ int rtw_chip_version = 0x00;

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/004-enable-usb-autosuspend.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8733BU/patches/004-enable-usb-autosuspend.patch
@@ -1,0 +1,75 @@
+--- a/os_dep/linux/usb_intf.c
++++ b/os_dep/linux/usb_intf.c
+@@ -355,6 +355,9 @@
+ #if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 22))
+ 	.usbdrv.reset_resume   = rtw_resume,
+ #endif
++#ifdef CONFIG_USB_AUTOSUSPEND
++	.usbdrv.supports_autosuspend = 1,
++#endif
+ 
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+     .usbdrv.drvwrap.driver.shutdown = rtw_dev_shutdown,
+@@ -1207,10 +1210,14 @@
+ #endif
+ 	/* 2012-07-11 Move here to prevent the 8723AS-VAU BT auto suspend influence */
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 33))
++#ifdef CONFIG_USB_AUTOSUSPEND
++	usb_enable_autosuspend(dvobj->pusbdev);
++#else
+ 	if (usb_autopm_get_interface(pusb_intf) < 0)
+ 		RTW_INFO("can't get autopm:\n");
+ #endif
+-#ifdef CONFIG_BT_COEXIST
++#endif
++#if defined(CONFIG_BT_COEXIST) && !defined(CONFIG_USB_AUTOSUSPEND)
+ 	dvobj_to_pwrctl(dvobj)->autopm_cnt = 1;
+ #endif
+ 
+--- a/os_dep/linux/os_intfs.c
++++ b/os_dep/linux/os_intfs.c
+@@ -4144,6 +4144,9 @@
+ {
+ 	int ret = _FALSE;
+ 	_adapter *padapter = (_adapter *)rtw_netdev_priv(pnetdev);
++#ifdef CONFIG_USB_AUTOSUSPEND
++	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
++#endif
+ 	struct pwrctrl_priv *pwrctrlpriv = adapter_to_pwrctl(padapter);
+ 
+ 	if (pwrctrlpriv->bInSuspend == _TRUE) {
+@@ -4151,6 +4154,11 @@
+ 		return 0;
+ 	}
+ 
++#ifdef CONFIG_USB_AUTOSUSPEND
++	if (dvobj->pusbintf && usb_autopm_get_interface(dvobj->pusbintf) < 0)
++		return -EIO;
++#endif
++
+ 	_enter_critical_mutex(&(adapter_to_dvobj(padapter)->hw_init_mutex), NULL);
+ #ifdef CONFIG_NEW_NETDEV_HDL
+ 	ret = _netdev_open(pnetdev);
+@@ -4400,6 +4408,9 @@
+ {
+ 	_adapter *padapter = (_adapter *)rtw_netdev_priv(pnetdev);
+ 	struct pwrctrl_priv *pwrctl = adapter_to_pwrctl(padapter);
++#ifdef CONFIG_USB_AUTOSUSPEND
++	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
++#endif
+ 	struct mlme_priv	*pmlmepriv = &padapter->mlmepriv;
+ 	struct mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
+ 	struct mlme_ext_info *pmlmeinfo = &(pmlmeext->mlmext_info);
+@@ -4501,6 +4512,12 @@
+ 
+ 	RTW_INFO("-871x_drv - drv_close, bup=%d\n", padapter->bup);
+ 
++#ifdef CONFIG_USB_AUTOSUSPEND
++	if (dvobj->pusbintf) {
++		usb_mark_last_busy(dvobj->pusbdev);
++		usb_autopm_put_interface(dvobj->pusbintf);
++	}
++#endif
+ 	return 0;
+ 
+ }


### PR DESCRIPTION
Patches the existing RTL8733BU package (WiFi + BT, USB). Scope: `projects/ROCKNIX/packages/linux-drivers/RTL8733BU/` only (patches + modprobe.d). No device options or DTS. Can cohexist with [this](https://github.com/ROCKNIX/distribution/pull/2354).

---

**001 – 6.19 / build**
- Makefile: `EXTRA_CFLAGS` / `EXTRA_LDFLAGS` for distro build.
- Rename `hmac_sha256_*` → `rtw_hmac_sha256_*` (kernel symbol clash).
- Force `wireless_mode` / `max_bss_cnt` when zero (6.19 init order) so wiphy registers.

**002 – MAC address**
- Use `dev_addr_set()` instead of writing `netdev->dev_addr` (required since 5.17). 

**003 – WPA3 (SAE) and iwd**
- SAE key_mgmt_suite host byte order on 6.9+; copy `cfg80211_external_auth_params` fields (layout changed); mgmt_tx accept NULL channel; trigger association after SAE success; remove duplicate `start_clnt_assoc` in set_pmksa; MODULE_IMPORT_NS and timer compat.

**004 – USB autosuspend**
- Enable autosuspend and wire autopm in open/close; fix bt-coexist when `CONFIG_USB_AUTOSUSPEND` is set.  
- **Note:** USB autosuspend may not be used in ROCKNIX (e.g. if devices rely on full power-down via a platform/rfkill driver). The patch is included for builds that enable it; behavior is correct when autosuspend is disabled.

**modprobe.d/8733bu.conf**  
`rtw_ips_mode=1`, `rtw_power_mgnt=2`, `rtw_lps_level=1` (IPS/LPS).