### PR TITLE
Adjustable volume and brightness steps

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/brightness
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/brightness
@@ -79,8 +79,9 @@ _write_brightness() {
 stepUp() {
   local current_percent
   current_percent="$(get_setting "${CURRENT_SETTING_KEY}")"
+  brightness_step="$(getBrightnessStep)"
 
-  local next_percent=$((current_percent + 5))
+  local next_percent=$((current_percent + ${brightness_step}))
   if (("${next_percent}" > 100)); then
     next_percent=100
   fi
@@ -103,8 +104,9 @@ stepUp() {
 stepDown() {
   local current_percent
   current_percent="$(get_setting "${CURRENT_SETTING_KEY}")"
+  brightness_step="$(getBrightnessStep)"
 
-  local next_percent=$((current_percent - 5))
+  local next_percent=$((current_percent - ${brightness_step}))
 
   if (("${next_percent}" < 5)); then
     next_percent=5
@@ -137,6 +139,19 @@ setBrightnessValue() {
 
 getBrightnessValue() {
   cat "${CURRENT_DEV_PATH}"
+}
+
+getBrightnessStep() {
+  local step="$(get_setting display.brightness_step)"
+  if [ -z "${step}" ]
+  then
+    step=5
+  fi
+  if (( ${step} <= 0 ))
+  then
+    step=5
+  fi
+  echo "$step"
 }
 
 # Helper: apply an action to all detected screens

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/volume
@@ -11,7 +11,15 @@
 VOLUME=$(get_setting "audio.volume")
 MAX_VOLUME=100
 MIN_VOLUME=0
-STEP=5
+STEP=$(get_setting "audio.volume_step")
+if [ -z "${STEP}" ]
+then
+ STEP=5
+fi
+if (( ${STEP} <= 0 ))
+then
+ STEP=5
+fi
 
 case ${1} in
   "+"|"up")


### PR DESCRIPTION
Make it so that the settings keys 'audio.volume_step' and 'display.brightness_step' specify the percentage by which the volume and display brightness should be stepped. If those keys are not set, the percentage step defaults to 5% as before.

I'm suggesting this change because I found that the previous default step of 5% gave me a choice between "almost inaudible" and "way too loud", both through headphones and through the speaker. The brightness step of 5% wasn't very comfortable either. Thanks for reviewing.