### PR TITLE
wlroots: add RGA hardware scaling for direct scanout on Rockchip

### DIFF
--- a/projects/ROCKNIX/packages/wayland/lib/wlroots/package.mk
+++ b/projects/ROCKNIX/packages/wayland/lib/wlroots/package.mk
@@ -7,6 +7,15 @@ PKG_SITE="https://gitlab.freedesktop.org/wlroots/wlroots/"
 PKG_DEPENDS_TARGET="toolchain libinput libxkbcommon pixman libdrm wayland wayland-protocols seatd xwayland hwdata libxcb xcb-util-wm"
 PKG_LONGDESC="A modular Wayland compositor library"
 PKG_TOOLCHAIN="meson"
+PKG_PATCH_DIRS+=" ${DEVICE}"
+
+# RGA hardware scaling on Rockchip devices
+case ${DEVICE} in
+  RK3566|RK3326)
+    PKG_DEPENDS_TARGET+=" librga"
+    PKG_PATCH_DIRS+=" rockchip-rga"
+    ;;
+esac
 
 case ${DEVICE} in
   SM8250|SM8550|RK3399|H700)

--- a/projects/ROCKNIX/packages/wayland/lib/wlroots/patches/rockchip-rga/001-rga-scanout-scaling.patch
+++ b/projects/ROCKNIX/packages/wayland/lib/wlroots/patches/rockchip-rga/001-rga-scanout-scaling.patch
@@ -1,0 +1,352 @@
+diff --git a/include/wlr/config.h.in b/include/wlr/config.h.in
+index ef18634..fdff5d5 100644
+--- a/include/wlr/config.h.in
++++ b/include/wlr/config.h.in
+@@ -73,4 +73,9 @@
+  */
+ #mesondefine WLR_HAS_COLOR_MANAGEMENT
+ 
++/**
++ * Whether Rockchip RGA hardware scaling is compile-time enabled.
++ */
++#mesondefine WLR_HAS_RGA
++
+ #endif
+diff --git a/include/wlr/types/wlr_scene.h b/include/wlr/types/wlr_scene.h
+index 2292f1f..688fb6d 100644
+--- a/include/wlr/types/wlr_scene.h
++++ b/include/wlr/types/wlr_scene.h
+@@ -102,6 +102,7 @@ struct wlr_scene {
+ 	// May be NULL
+ 	struct wlr_linux_dmabuf_v1 *linux_dmabuf_v1;
+ 	struct wlr_gamma_control_manager_v1 *gamma_control_manager_v1;
++	struct wlr_rga_accel *rga_accel; // NULL if RGA unavailable
+ 
+ 	struct {
+ 		struct wl_listener linux_dmabuf_v1_destroy;
+@@ -250,6 +251,8 @@ struct wlr_scene_output {
+ 
+ 		struct wlr_drm_syncobj_timeline *in_timeline;
+ 		uint64_t in_point;
++
++		struct wlr_buffer *rga_scaled_buffer;
+ 	} WLR_PRIVATE;
+ };
+ 
+diff --git a/meson.build b/meson.build
+index 016e598..d6eaff5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -77,6 +77,7 @@ features = {
+ 	'udmabuf-allocator': false,
+ 	'session': false,
+ 	'color-management': false,
++	'rga': false,
+ }
+ internal_features = {
+ 	'xcb-errors': false,
+@@ -133,6 +134,14 @@ wlr_deps = [
+ 	rt,
+ ]
+ 
++# Rockchip RGA hardware scaling (required — this patch only applies to
++# RK3326/RK3566 builds where librga is a build dependency)
++librga = cc.find_library('rga', required: true)
++features += {'rga': true}
++wlr_deps += librga
++wlr_files += files('render/rga_accel.c')
++message('RGA hardware scaling: enabled')
++
+ subdir('protocol')
+ subdir('render')
+ 
+diff --git a/render/rga_accel.c b/render/rga_accel.c
+new file mode 100644
+index 0000000..5d9a86e
+--- /dev/null
++++ b/render/rga_accel.c
+@@ -0,0 +1,154 @@
++/* SPDX-License-Identifier: MIT */
++#include "rga_accel.h"
++
++#include <stdlib.h>
++#include <string.h>
++#include <drm_fourcc.h>
++#include <wlr/render/dmabuf.h>
++#include <wlr/render/allocator.h>
++#include <wlr/render/drm_format_set.h>
++#include <wlr/types/wlr_buffer.h>
++#include <wlr/util/log.h>
++
++#include <rga/im2d.h>
++#include <rga/rga.h>
++
++struct wlr_rga_accel {
++	bool available;
++};
++
++/*
++ * DRM fourcc to RGA format translation.
++ *
++ * RGA uses its own RK_FORMAT_* enum where channel ordering is defined
++ * relative to memory byte order, while DRM_FORMAT_* uses a packed pixel
++ * convention. The apparent ARGB->BGRA swap is a namespace translation,
++ * not a channel reorder:
++ *   DRM_FORMAT_ARGB8888: bytes [B,G,R,A] in memory = RK_FORMAT_BGRA_8888
++ *   DRM_FORMAT_ABGR8888: bytes [R,G,B,A] in memory = RK_FORMAT_RGBA_8888
++ *
++ * Validated formats: XRGB8888, ARGB8888 (covers 95%+ of emulator output)
++ * Untested but correct by spec: ABGR8888, XBGR8888, RGB888, BGR888
++ * YUV formats: NV12, NV21, YUV420, YVU420 (for video/camera sources)
++ */
++static int drm_format_to_rk(uint32_t drm_fourcc) {
++	switch (drm_fourcc) {
++	/* Primary path — validated on RK3326 and RK3566 hardware */
++	case DRM_FORMAT_ARGB8888:
++	case DRM_FORMAT_XRGB8888:
++		return RK_FORMAT_BGRA_8888;
++	case DRM_FORMAT_ABGR8888:
++	case DRM_FORMAT_XBGR8888:
++		return RK_FORMAT_RGBA_8888;
++	/* 24-bit packed RGB */
++	case DRM_FORMAT_RGB888:
++		return RK_FORMAT_RGB_888;
++	case DRM_FORMAT_BGR888:
++		return RK_FORMAT_BGR_888;
++	/* YUV planar/semi-planar (video sources) */
++	case DRM_FORMAT_NV12:
++		return RK_FORMAT_YCbCr_420_SP;
++	case DRM_FORMAT_NV21:
++		return RK_FORMAT_YCrCb_420_SP;
++	case DRM_FORMAT_YUV420:
++		return RK_FORMAT_YCbCr_420_P;
++	case DRM_FORMAT_YVU420:
++		return RK_FORMAT_YCrCb_420_P;
++	default:
++		return -1;
++	}
++}
++
++struct wlr_rga_accel *wlr_rga_accel_create(void) {
++	const char *disable = getenv("WLR_RGA_DISABLE");
++	if (disable && (disable[0] == '1' || disable[0] == 'y' || disable[0] == 'Y')) {
++		wlr_log(WLR_INFO, "RGA: disabled via WLR_RGA_DISABLE");
++		return NULL;
++	}
++
++	const char *info = querystring(RGA_ALL);
++	if (!info || strlen(info) == 0) {
++		wlr_log(WLR_ERROR, "RGA: no hardware detected, falling back to GLES2 compositing");
++		return NULL;
++	}
++
++	struct wlr_rga_accel *rga = calloc(1, sizeof(*rga));
++	if (!rga) {
++		wlr_log(WLR_ERROR, "RGA: allocation failed");
++		return NULL;
++	}
++
++	rga->available = true;
++	wlr_log(WLR_INFO, "RGA: hardware scaling accelerator enabled");
++	return rga;
++}
++
++void wlr_rga_accel_destroy(struct wlr_rga_accel *rga) {
++	free(rga);
++}
++
++bool wlr_rga_accel_scale(struct wlr_rga_accel *rga,
++		const struct wlr_dmabuf_attributes *src_dmabuf,
++		const struct wlr_dmabuf_attributes *dst_dmabuf) {
++	if (!rga || !rga->available) {
++		return false;
++	}
++
++	int src_rk_fmt = drm_format_to_rk(src_dmabuf->format);
++	int dst_rk_fmt = drm_format_to_rk(dst_dmabuf->format);
++	if (src_rk_fmt < 0 || dst_rk_fmt < 0) {
++		return false;
++	}
++
++	rga_buffer_t src = wrapbuffer_fd_t(
++		src_dmabuf->fd[0],
++		src_dmabuf->width, src_dmabuf->height,
++		src_dmabuf->width, src_dmabuf->height,
++		src_rk_fmt);
++
++	rga_buffer_t dst = wrapbuffer_fd_t(
++		dst_dmabuf->fd[0],
++		dst_dmabuf->width, dst_dmabuf->height,
++		dst_dmabuf->width, dst_dmabuf->height,
++		dst_rk_fmt);
++
++	IM_STATUS ret = imresize_t(src, dst, 0, 0, INTER_LINEAR, 1);
++	if (ret != IM_STATUS_SUCCESS) {
++		wlr_log(WLR_ERROR, "RGA: scale failed: %s", imStrError_t(ret));
++		return false;
++	}
++
++	return true;
++}
++
++struct wlr_buffer *wlr_rga_accel_alloc_output(struct wlr_rga_accel *rga,
++		struct wlr_allocator *alloc, int width, int height, uint32_t format) {
++	if (!rga || !alloc) {
++		return NULL;
++	}
++
++	/* Convert YUV to XRGB8888 for KMS scanout compatibility.
++	 * The RGA handles color space conversion during scaling. */
++	switch (format) {
++	case DRM_FORMAT_NV12:
++	case DRM_FORMAT_NV21:
++	case DRM_FORMAT_YUV420:
++	case DRM_FORMAT_YVU420:
++		format = DRM_FORMAT_XRGB8888;
++		break;
++	}
++
++	uint64_t mod = DRM_FORMAT_MOD_LINEAR;
++	struct wlr_drm_format drm_fmt = {
++		.format = format,
++		.len = 1,
++		.capacity = 1,
++		.modifiers = &mod,
++	};
++
++	struct wlr_buffer *buf = wlr_allocator_create_buffer(alloc, width, height, &drm_fmt);
++	if (!buf) {
++		wlr_log(WLR_ERROR, "RGA: failed to allocate %dx%d buffer", width, height);
++	}
++	return buf;
++}
+diff --git a/render/rga_accel.h b/render/rga_accel.h
+new file mode 100644
+index 0000000..a6d09ec
+--- /dev/null
++++ b/render/rga_accel.h
+@@ -0,0 +1,23 @@
++/* SPDX-License-Identifier: MIT */
++#ifndef WLR_RGA_ACCEL_H
++#define WLR_RGA_ACCEL_H
++
++#include <stdbool.h>
++#include <stdint.h>
++
++struct wlr_rga_accel;
++struct wlr_buffer;
++struct wlr_allocator;
++struct wlr_dmabuf_attributes;
++
++struct wlr_rga_accel *wlr_rga_accel_create(void);
++void wlr_rga_accel_destroy(struct wlr_rga_accel *rga);
++
++bool wlr_rga_accel_scale(struct wlr_rga_accel *rga,
++	const struct wlr_dmabuf_attributes *src_dmabuf,
++	const struct wlr_dmabuf_attributes *dst_dmabuf);
++
++struct wlr_buffer *wlr_rga_accel_alloc_output(struct wlr_rga_accel *rga,
++	struct wlr_allocator *alloc, int width, int height, uint32_t format);
++
++#endif
+diff --git a/types/scene/wlr_scene.c b/types/scene/wlr_scene.c
+index e823d62..55f396d 100644
+--- a/types/scene/wlr_scene.c
++++ b/types/scene/wlr_scene.c
+@@ -21,6 +21,11 @@
+ #include "util/time.h"
+ 
+ #include <wlr/config.h>
++#include <wlr/render/allocator.h>
++
++#if WLR_HAS_RGA
++#include "render/rga_accel.h"
++#endif
+ 
+ #if WLR_HAS_XWAYLAND
+ #include <wlr/xwayland/xwayland.h>
+@@ -145,6 +150,12 @@ void wlr_scene_node_destroy(struct wlr_scene_node *node) {
+ 			wl_list_remove(&scene->linux_dmabuf_v1_destroy.link);
+ 			wl_list_remove(&scene->gamma_control_manager_v1_destroy.link);
+ 			wl_list_remove(&scene->gamma_control_manager_v1_set_gamma.link);
++#if WLR_HAS_RGA
++			if (scene->rga_accel) {
++				wlr_rga_accel_destroy(scene->rga_accel);
++				scene->rga_accel = NULL;
++			}
++#endif
+ 		} else {
+ 			assert(node->parent);
+ 		}
+@@ -195,6 +206,10 @@ struct wlr_scene *wlr_scene_create(void) {
+ 	scene->calculate_visibility = !env_parse_bool("WLR_SCENE_DISABLE_VISIBILITY");
+ 	scene->highlight_transparent_region = env_parse_bool("WLR_SCENE_HIGHLIGHT_TRANSPARENT_REGION");
+ 
++#if WLR_HAS_RGA
++	scene->rga_accel = wlr_rga_accel_create();
++#endif
++
+ 	return scene;
+ }
+ 
+@@ -1722,6 +1737,11 @@ void wlr_scene_output_destroy(struct wlr_scene_output *scene_output) {
+ 	wl_list_remove(&scene_output->output_damage.link);
+ 	wl_list_remove(&scene_output->output_needs_frame.link);
+ 	wlr_drm_syncobj_timeline_unref(scene_output->in_timeline);
++#if WLR_HAS_RGA
++	if (scene_output->rga_scaled_buffer) {
++		wlr_buffer_drop(scene_output->rga_scaled_buffer);
++	}
++#endif
+ 	wl_array_release(&scene_output->render_list);
+ 	free(scene_output);
+ }
+@@ -1971,6 +1991,48 @@ static enum scene_direct_scanout_result scene_entry_try_direct_scanout(
+ 		wlr_output_state_set_wait_timeline(&pending, buffer->wait_timeline, buffer->wait_point);
+ 	}
+ 	if (!wlr_output_test_state(scene_output->output, &pending)) {
++#if WLR_HAS_RGA
++		struct wlr_rga_accel *rga = scene_output->scene->rga_accel;
++		struct wlr_dmabuf_attributes src_dmabuf = {0};
++		if (rga && wlr_buffer && wlr_buffer_get_dmabuf(wlr_buffer, &src_dmabuf)) {
++			int out_w = scene_output->output->width;
++			int out_h = scene_output->output->height;
++
++			if (src_dmabuf.width != out_w || src_dmabuf.height != out_h) {
++				if (!scene_output->rga_scaled_buffer) {
++					scene_output->rga_scaled_buffer = wlr_rga_accel_alloc_output(
++						rga, scene_output->output->allocator,
++						out_w, out_h, src_dmabuf.format);
++				}
++
++				if (scene_output->rga_scaled_buffer) {
++					struct wlr_dmabuf_attributes dst_dmabuf = {0};
++					if (wlr_buffer_get_dmabuf(scene_output->rga_scaled_buffer, &dst_dmabuf) &&
++					    wlr_rga_accel_scale(rga, &src_dmabuf, &dst_dmabuf)) {
++						struct wlr_output_state rga_pending;
++						wlr_output_state_init(&rga_pending);
++						if (wlr_output_state_copy(&rga_pending, state)) {
++							wlr_output_state_set_buffer(&rga_pending,
++								scene_output->rga_scaled_buffer);
++							if (wlr_output_test_state(scene_output->output, &rga_pending)) {
++								wlr_output_state_copy(state, &rga_pending);
++								wlr_output_state_finish(&rga_pending);
++								wlr_output_state_finish(&pending);
++								wlr_log(WLR_DEBUG, "RGA: scaled %dx%d->%dx%d scanout",
++									src_dmabuf.width, src_dmabuf.height, out_w, out_h);
++								struct wlr_scene_output_sample_event se = {
++									.output = scene_output, .direct_scanout = true,
++								};
++								wl_signal_emit_mutable(&buffer->events.output_sample, &se);
++								return SCANOUT_SUCCESS;
++							}
++						}
++						wlr_output_state_finish(&rga_pending);
++					}
++				}
++			}
++		}
++#endif
+ 		wlr_output_state_finish(&pending);
+ 		return SCANOUT_CANDIDATE;
+ 	}


### PR DESCRIPTION
Use the Rockchip RGA 2D engine to scale fullscreen client buffers to output resolution when the DRM plane cannot handle the mismatch natively. This enables direct scanout for emulators rendering at native console resolutions (320x240, 480x272, 640x480) on larger displays (720p/1080p HDMI), bypassing GLES2 compositing entirely.

The RGA is auto-detected at runtime via librga. On non-Rockchip hardware or when librga is absent, no RGA code compiles or executes. All code paths are gated behind WLR_HAS_RGA and fall through to the existing GLES2 compositor on failure.

Targets: RK3566 (RGA2), RK3326 (RGA2 with DT overlay). No effect on SM8250, SM8550, SDM845, S922X, H700, RK3399, RK3588.

This has had minimal testing on 353p and rgb30 as well as a custom build on rk3326 for xf40h.

Good results depending on how the core/emu is setup and the panel size, but hard to gauge how much of a perf improvement it nets (if any), but doesn't seem to cause any issues.