### PR TITLE
mali-bifrost: use devicetree platform instead of meson

### DIFF
--- a/projects/ROCKNIX/packages/linux-drivers/mali-bifrost/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/mali-bifrost/package.mk
@@ -21,8 +21,21 @@ case ${DEVICE} in
 esac
 
 make_target() {
+  # S922X is an actual Amlogic Meson SoC — it requires the meson platform
+  # backend for correct GPU clock and power domain handling.
+  # Rockchip devices use the devicetree backend which properly coordinates
+  # with kernel power domain drivers during runtime PM suspend/resume cycles.
+  case ${DEVICE} in
+    S922X)
+      MALI_PLATFORM="meson"
+      ;;
+    *)
+      MALI_PLATFORM="devicetree"
+      ;;
+  esac
+
   kernel_make KDIR=$(kernel_path) -C ${PKG_BUILD} \
-       CONFIG_MALI_MIDGARD=m CONFIG_MALI_PLATFORM_NAME=meson CONFIG_MALI_REAL_HW=y CONFIG_MALI_DEVFREQ=y CONFIG_MALI_GATOR_SUPPORT=y
+       CONFIG_MALI_MIDGARD=m CONFIG_MALI_PLATFORM_NAME=${MALI_PLATFORM} CONFIG_MALI_REAL_HW=y CONFIG_MALI_DEVFREQ=y CONFIG_MALI_GATOR_SUPPORT=y
 }
 
 makeinstall_target() {


### PR DESCRIPTION
Switch CONFIG_MALI_PLATFORM_NAME from meson to devicetree. The meson platform backend calls clk_disable_unprepare() during runtime PM suspend without a matching clk_prepare_enable() on resume. On Rockchip SoCs (RK3566, RK3326), this leaves GPU clocks unprepared when the power domain re-enables them, triggering repeated warnings:

  WARNING: Enabling unprepared clk 'gpu'
  rockchip-pm-domain: failed to enable clocks

The devicetree platform backend uses the standard DT power domain and clock framework correctly, coordinating with the kernel power domain driver on all SoCs (Rockchip, Amlogic S922X).