### PR TITLE
network: replace connman with rxnm, delegate IWD to L2-only

### DIFF
--- a/projects/ROCKNIX/packages/network/iwd/sources/main.conf
+++ b/projects/ROCKNIX/packages/network/iwd/sources/main.conf
@@ -1,14 +1,12 @@
-# use built-in dhcp client
+# L3 (DHCP/addressing) delegated to systemd-networkd
 [General]
-EnableNetworkConfiguration=true
+EnableNetworkConfiguration=false
 ControlPortOverNL80211=false
 
 [Network]
 RoutePriorityOffset=200
-
 NameResolvingService=systemd
 EnableIPv6=true
-
 
 [Scan]
 MaximumPeriodicScanInterval=30

--- a/projects/ROCKNIX/packages/network/iwd/system.d/iwd.service
+++ b/projects/ROCKNIX/packages/network/iwd/system.d/iwd.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Wireless service
 Documentation=man:iwd(8) man:iwd.config(5) man:iwd.network(5) man:iwd.ap(5)
-After=network-pre.target
+After=network-pre.target dbus.service
 Before=network.target
 Wants=network.target
+Requires=dbus.service
 
 [Service]
 Environment=STATE_DIRECTORY=/storage/.cache/iwd

--- a/projects/ROCKNIX/packages/network/rxnm/package.mk
+++ b/projects/ROCKNIX/packages/network/rxnm/package.mk
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="rxnm"
+PKG_VERSION="70eaf7c"
+PKG_LICENSE="GPLv2+"
+PKG_SITE="https://codeberg.org/aenertia/rxnm"
+PKG_URL="https://codeberg.org/aenertia/rxnm.git"
+PKG_DEPENDS_TARGET="toolchain jq systemd iwd"
+PKG_SECTION="network"
+PKG_SHORTDESC="ROCKNIX Network Manager"
+PKG_LONGDESC="rxnm — lightning-fast modular CLI suite for systemd-networkd, iwd, and bluez."
+PKG_TOOLCHAIN="make"
+
+make_target() {
+  cd ${PKG_BUILD}
+  mkdir -p bin build
+  bash scripts/sync-constants.sh
+  ${CC} ${CFLAGS} -std=c11 -Isrc -o bin/rxnm-agent src/rxnm-agent.c ${LDFLAGS}
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  mkdir -p ${INSTALL}/usr/lib/rocknix-network-manager/bin
+  mkdir -p ${INSTALL}/usr/lib/rocknix-network-manager/lib
+  mkdir -p ${INSTALL}/usr/lib/rocknix-network-manager/plugins
+
+  cp -f ${PKG_BUILD}/bin/* ${INSTALL}/usr/lib/rocknix-network-manager/bin/
+  cp -f ${PKG_BUILD}/lib/* ${INSTALL}/usr/lib/rocknix-network-manager/lib/
+  chmod 755 ${INSTALL}/usr/lib/rocknix-network-manager/bin/*
+  chmod 644 ${INSTALL}/usr/lib/rocknix-network-manager/lib/*
+
+  # Create correct symlink for target filesystem
+  ln -sf /usr/lib/rocknix-network-manager/bin/rxnm ${INSTALL}/usr/bin/rxnm
+
+  # Systemd service units
+  mkdir -p ${INSTALL}/usr/lib/systemd/system
+  cp ${PKG_BUILD}/systemd/rxnm-roaming.service    ${INSTALL}/usr/lib/systemd/system/
+  cp ${PKG_BUILD}/systemd/rxnm-api@.service       ${INSTALL}/usr/lib/systemd/system/
+  cp ${PKG_BUILD}/systemd/rxnm-api.socket         ${INSTALL}/usr/lib/systemd/system/
+  cp ${PKG_DIR}/system.d/rxnm.service             ${INSTALL}/usr/lib/systemd/system/
+
+  # Default network templates for systemd-networkd
+  mkdir -p ${INSTALL}/usr/lib/systemd/network
+  cp ${PKG_BUILD}/usr/lib/systemd/network/*.network ${INSTALL}/usr/lib/systemd/network/
+
+  # Suspend/resume hook
+  mkdir -p ${INSTALL}/usr/lib/systemd/system-sleep
+  cp ${PKG_BUILD}/usr/lib/systemd/system-sleep/rxnm-resume ${INSTALL}/usr/lib/systemd/system-sleep/
+
+  # Bash completion
+  mkdir -p ${INSTALL}/usr/share/bash-completion/completions
+  cp ${PKG_BUILD}/usr/share/bash-completion/completions/rxnm ${INSTALL}/usr/share/bash-completion/completions/
+
+  # ROCKNIX: iwd stores state in /storage/.cache/iwd (not FHS /var/lib/iwd)
+  # Patch STATE_DIR default so rxnm writes PSK files where iwd reads them
+  sed -i 's|STATE_DIR:=/var/lib|STATE_DIR:=/storage/.cache|' \
+    ${INSTALL}/usr/lib/rocknix-network-manager/lib/rxnm-constants.sh
+
+  # RAM-first architecture: /etc/systemd/network -> /run/systemd/network
+  mkdir -p ${INSTALL}/etc/systemd
+  ln -sf /run/systemd/network ${INSTALL}/etc/systemd/network
+}
+
+post_install() {
+  enable_service rxnm.service
+  # rxnm-roaming.service  — user-activated (WiFi roaming monitor)
+  # rxnm-api.socket        — user-activated (JSON API on port 29304)
+}

--- a/projects/ROCKNIX/packages/network/rxnm/system.d/rxnm.service
+++ b/projects/ROCKNIX/packages/network/rxnm/system.d/rxnm.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=ROCKNIX Network Manager
+DefaultDependencies=no
+After=local-fs.target network-base.service
+RequiresMountsFor=/storage
+Before=systemd-networkd.service systemd-resolved.service iwd.service network-online.target
+Wants=systemd-networkd.service systemd-resolved.service iwd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment="STATE_DIR=/storage/.cache"
+ExecStart=/usr/bin/rxnm system start
+ExecReload=/usr/bin/rxnm system reload
+ExecStop=/usr/bin/rxnm system stop
+PrivateTmp=yes
+TimeoutStopSec=1s
+
+[Install]
+WantedBy=multi-user.target

--- a/projects/ROCKNIX/packages/sysutils/systemd/config/networkd.conf.d/README
+++ b/projects/ROCKNIX/packages/sysutils/systemd/config/networkd.conf.d/README
@@ -1,0 +1,3 @@
+# systemd-networkd drop-in configuration overrides
+# Place .conf files here to customize networkd behaviour
+# See: man systemd-networkd.conf

--- a/projects/ROCKNIX/packages/sysutils/systemd/package.mk
+++ b/projects/ROCKNIX/packages/sysutils/systemd/package.mk
@@ -65,7 +65,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dportabled=false \
                        -Duserdb=false \
                        -Dhomed=false \
-                       -Dnetworkd=false \
+                       -Dnetworkd=true \
                        -Dtimedated=false \
                        -Dtimesyncd=true \
                        -Dfirstboot=false \
@@ -92,7 +92,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dhtml=false \
                        -Dlink-udev-shared=true \
                        -Dlink-systemctl-shared=true \
-                       -Dlink-networkd-shared=false \
+                       -Dlink-networkd-shared=true \
                        -Dbashcompletiondir=no \
                        -Dzshcompletiondir=no \
                        -Dkmod-path=/usr/bin/kmod \
@@ -190,8 +190,10 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/lib/systemd/user-preset/*
   echo "disable *" > ${INSTALL}/usr/lib/systemd/user-preset/90-systemd.preset
 
-  # remove networkd
-  safe_remove ${INSTALL}/usr/lib/systemd/network
+  # networkd: keep /usr/lib/systemd/network/ for rxnm templates, strip wait-online
+  safe_remove ${INSTALL}/usr/lib/systemd/systemd-networkd-wait-online
+  safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-networkd-wait-online.service
+  safe_remove ${INSTALL}/usr/lib/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
 
   # remove systemd-time-wait-sync (not detecting slew time updates, using package wait-time-sync)
   safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-time-wait-sync.service
@@ -257,6 +259,7 @@ post_makeinstall_target() {
   ln -sf /storage/.config/resolved.conf.d ${INSTALL}/etc/systemd/resolved.conf.d
   ln -sf /storage/.config/sleep.conf.d ${INSTALL}/etc/systemd/sleep.conf.d
   ln -sf /storage/.config/timesyncd.conf.d ${INSTALL}/etc/systemd/timesyncd.conf.d
+  ln -sf /storage/.config/networkd.conf.d ${INSTALL}/etc/systemd/networkd.conf.d
   safe_remove ${INSTALL}/etc/sysctl.d
   ln -sf /storage/.config/sysctl.d ${INSTALL}/etc/sysctl.d
   safe_remove ${INSTALL}/etc/tmpfiles.d
@@ -314,5 +317,6 @@ post_install() {
   enable_service systemd-timesyncd.service
   enable_service systemd-timesyncd-setup.service
   enable_service systemd-resolved.service
+  enable_service systemd-networkd.service
   enable_service debug-shell.service
 }

--- a/projects/ROCKNIX/packages/sysutils/systemd/scripts/network-base-setup
+++ b/projects/ROCKNIX/packages/sysutils/systemd/scripts/network-base-setup
@@ -10,6 +10,10 @@ if [ -f /storage/.config/hosts.conf ]; then
   cat /storage/.config/hosts.conf > /run/rocknix/hosts
 fi
 
+# Ensure rxnm runtime directories exist before networkd starts
+mkdir -p /run/systemd/network
+mkdir -p /run/rocknix
+
 # RESOLUTION ORDER:
 # 1. USER OVERRIDE: /storage/.config/resolv.conf exists -> Use it directly.
 # 2. DYNAMIC/STUB:  No override -> Symlink to systemd-resolved stub.

--- a/projects/ROCKNIX/packages/sysutils/systemd/system.d/systemd-networkd.service.d/override.conf
+++ b/projects/ROCKNIX/packages/sysutils/systemd/system.d/systemd-networkd.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStopSec=1s

--- a/projects/ROCKNIX/packages/virtual/network/package.mk
+++ b/projects/ROCKNIX/packages/virtual/network/package.mk
@@ -7,7 +7,7 @@ PKG_VERSION=""
 PKG_LICENSE="various"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain connman iwd netbase ethtool openssh iw wireless-regdb rsync tailscale avahi miniupnpc nss-mdns speedtest-cli"
+PKG_DEPENDS_TARGET="toolchain rxnm iwd netbase ethtool openssh iw wireless-regdb rsync tailscale avahi miniupnpc nss-mdns speedtest-cli"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Metapackage for various packages to install network support"
 


### PR DESCRIPTION
Replace ConnMan with rxnm v1.1.1 + systemd-networkd as the network management stack. This is a minimal introduction for full replacement — all user and low-level networking functionality works exactly as it does pre-rxnm (and in several cases, better).

rxnm delegates L3 (DHCP, addressing, routing) to systemd-networkd and keeps IWD in L2-only mode for WiFi authentication. Standard networkd .network templates handle all interface types — WiFi station, ethernet, USB gadget, Bluetooth PAN, AP/hotspot — automatically via template matching, without user interaction. Zero-touch unless the user wants to customize, in which case it is standard networkd config overrides.

This eliminates ConnMan's 7MB daemon and glib/ncurses/readline deps, replacing them with ~150KB of shell libraries and a 50KB native C agent. Measured on RK3566 hardware: 7.8 MiB RSS saved, 5 MiB less system memory used, 23 fewer CPU jiffies at idle — lighter across every dimension.

Changes:
- systemd: enable networkd (-Dnetworkd=true, -Dlink-networkd-shared=true)
- systemd: strip networkd-wait-online (boot must not block on network)
- systemd: preserve /usr/lib/systemd/network/ for rxnm templates
- systemd: add networkd.conf.d override symlink
- iwd: set EnableNetworkConfiguration=false (L2-only, networkd does DHCP)
- iwd: add explicit dbus.service dependency
- virtual/network: swap connman for rxnm (connman package left in-tree)
- rxnm: add v1.1.1 package with systemd units, network templates, suspend/resume hook, bash completion
- network-base-setup: ensure runtime directories exist

Hardware validated on RK3566 across multiple boot cycles: WiFi station (WPA3), USB ethernet hotplug, local-play AP mode, dual-homed routing, profile save/load, DNS via systemd-resolved, nullify enable/disable. EmulationStation WiFi UI works unchanged — no ES modifications needed.

make world passes for all 9 targets (RK3588, RK3566, RK3326, RK3399, S922X, SM8250, SM8550, H700, SM8650).

Note: XDP/eBPF kernel module support for nullify power management modes will come in a separate patchset. This change focuses solely on the ConnMan-to-rxnm network stack replacement.

rxnm upstream: https://codeberg.org/aenertia/rxnm (v1.1.1 tagged) CI: https://github.com/aenertia/rxnm/actions (unit, POSIX, shellcheck,
    wired/bridge integration, virtual WiFi hwsim, bundle interop) 

Extensive benchmarks and docs at the codeburg.

Rocknix CI kicked off and building here : https://github.com/aenertia/distribution/actions/runs/22613457258