### PR TITLE
gpudriver - handle Vulkan ICD files

### DIFF
--- a/projects/ROCKNIX/packages/graphics/gpudriver/sources/bin/gpudriver
+++ b/projects/ROCKNIX/packages/graphics/gpudriver/sources/bin/gpudriver
@@ -26,22 +26,33 @@ load_driver() {
       modprobe -r @PAN@
       modprobe mali_kbase
 
-      grep -q /usr/lib/libEGL.so /proc/mounts || find /usr/{lib,lib32}/mali -type f -exec bash -c 'lib={}; mount --bind $lib ${lib/\/mali\//\/}' ';'
+      # Bind-mount mali GLES libraries over mesa if not already done.
+      # Use mount output (not /proc/mounts) to avoid squashfs false positives.
+      mount | grep -q "on /usr/lib/libEGL.so" || find /usr/{lib,lib32}/mali -type f -exec bash -c 'lib={}; mount --bind $lib ${lib/\/mali\//\/}' ';'
       # Portmaster is not ready for SDL in glesonly subdir, so override libs the dirty way
       if [ -d /usr/lib/glesonly ]; then
-        grep -q /usr/lib/libSDL2-2.0.so /proc/mounts || find /usr/{lib,lib32}/glesonly -type f -exec bash -c 'lib={}; mount --bind $lib ${lib/\/glesonly\//\/}' ';'
+        mount | grep -q "on /usr/lib/libSDL2" || find /usr/{lib,lib32}/glesonly -type f -exec bash -c 'lib={}; mount --bind $lib ${lib/\/glesonly\//\/}' ';'
       fi
       mount --bind /dev/null /usr/lib/libGL.so
       mount --bind /dev/null /usr/lib32/libGL.so
+
+      # Mask panfrost Vulkan ICD so the loader only finds mali
+      for icd in /usr/share/vulkan/icd.d/panfrost_icd.*.json; do
+        [ -f "${icd}" ] && mount --bind /dev/null "${icd}"
+      done
       ;;
     "panfrost")
       modprobe -r mali_kbase
       modprobe @PAN@
 
-      grep -q /usr/lib/libEGL.so /proc/mounts && find /usr/lib/mali -type f -exec bash -c 'lib={}; umount ${lib/\/mali\//\/}' ';'
+      mount | grep -q "on /usr/lib/libEGL.so" && find /usr/lib/mali -type f -exec bash -c 'lib={}; umount ${lib/\/mali\//\/}' ';'
       if [ -d /usr/lib/glesonly ]; then
-        grep -q /usr/lib/libSDL2-2.0.so /proc/mounts && find /usr/lib/glesonly -type f -exec bash -c 'lib={}; umount ${lib/\/glesonly\//\/}' ';'
+        mount | grep -q "on /usr/lib/libSDL2" && find /usr/lib/glesonly -type f -exec bash -c 'lib={}; umount ${lib/\/glesonly\//\/}' ';'
       fi
+
+      # Mask mali Vulkan ICD so the loader only finds panfrost
+      [ -f /usr/share/vulkan/icd.d/mali.json ] && \
+        mount --bind /dev/null /usr/share/vulkan/icd.d/mali.json
       ;;
     *)
       exit 3


### PR DESCRIPTION
On devices with both Mali and Panfrost Vulkan ICDs installed (RK3566, RK3326), the Vulkan loader enumerates both but only one has a working kernel driver at any time. Emulators attempting Vulkan initialization fail silently and fall back to OpenGL.

Set VK_ICD_FILENAMES in runemu.sh based on the active GPU driver reported by gpudriver. This is inherited by all emulator subprocesses and fixes Vulkan for PPSSPP, Dolphin, AetherSX2, Duckstation, Flycast, RetroArch Vulkan cores, and all other Vulkan-capable emulators without requiring per-emulator launch script changes.