### PR TITLE
MelonDS-SA: show cheevos toasts on OpenGL renderer

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/patches/000-retro-achievements.patch
+++ b/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/patches/000-retro-achievements.patch
@@ -1,12 +1,6 @@
-#############################
-This patch is based on the work from the following repo https://github.com/PanMenel/melonDS-Menel-Forks/tree/Retro-Achievements-Implementation
-
-All credit goes to PanMenel
-############################
-
 diff -rupbN melonDS.orig/src/CMakeLists.txt melonDS.ra/src/CMakeLists.txt
---- melonDS.orig/src/CMakeLists.txt	2026-02-19 15:13:54.655526163 +0000
-+++ melonDS.ra/src/CMakeLists.txt	2026-02-19 15:16:12.436947885 +0000
+--- melonDS.orig/src/CMakeLists.txt	2026-03-06 21:36:14.522056951 +0000
++++ melonDS.ra/src/CMakeLists.txt	2026-03-06 21:37:07.046799886 +0000
 @@ -226,6 +226,65 @@ if (ENABLE_JIT_PROFILING)
      target_link_libraries(core PRIVATE "${VTUNE_LIBRARY}")
  endif()
@@ -74,8 +68,8 @@ diff -rupbN melonDS.orig/src/CMakeLists.txt melonDS.ra/src/CMakeLists.txt
  #  set(
  #    CMAKE_C_FLAGS
 diff -rupbN melonDS.orig/src/NDS.cpp melonDS.ra/src/NDS.cpp
---- melonDS.orig/src/NDS.cpp	2026-02-19 15:14:21.435802414 +0000
-+++ melonDS.ra/src/NDS.cpp	2026-02-19 15:16:12.436947885 +0000
+--- melonDS.orig/src/NDS.cpp	2026-03-06 21:36:14.530057064 +0000
++++ melonDS.ra/src/NDS.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -44,6 +44,11 @@
  #include "DSi_DSP.h"
  #include "ARMJIT.h"
@@ -88,7 +82,7 @@ diff -rupbN melonDS.orig/src/NDS.cpp melonDS.ra/src/NDS.cpp
  
  namespace melonDS
  {
-@@ -547,6 +552,9 @@ void NDS::Reset()
+@@ -539,6 +544,9 @@ void NDS::Reset()
      SPI.Reset();
      RTC.Reset();
      Wifi.Reset();
@@ -98,7 +92,7 @@ diff -rupbN melonDS.orig/src/NDS.cpp melonDS.ra/src/NDS.cpp
  }
  
  void NDS::Start()
-@@ -769,6 +777,16 @@ bool NDS::DoSavestate(Savestate* file)
+@@ -761,6 +769,16 @@ bool NDS::DoSavestate(Savestate* file)
  #endif
      }
  
@@ -115,7 +109,7 @@ diff -rupbN melonDS.orig/src/NDS.cpp melonDS.ra/src/NDS.cpp
      file->Finish();
  
      return true;
-@@ -780,6 +798,16 @@ void NDS::SetNDSCart(std::unique_ptr<NDS
+@@ -772,6 +790,16 @@ void NDS::SetNDSCart(std::unique_ptr<NDS
      // The existing cart will always be ejected;
      // if cart is null, then that's equivalent to ejecting a cart
      // without inserting a new one.
@@ -132,7 +126,7 @@ diff -rupbN melonDS.orig/src/NDS.cpp melonDS.ra/src/NDS.cpp
  }
  
  void NDS::SetNDSSave(const u8* savedata, u32 savelen)
-@@ -926,6 +954,11 @@ void NDS::RunSystemSleep(u64 timestamp)
+@@ -918,6 +946,11 @@ void NDS::RunSystemSleep(u64 timestamp)
  template <CPUExecuteMode cpuMode>
  u32 NDS::RunFrame()
  {
@@ -144,7 +138,7 @@ diff -rupbN melonDS.orig/src/NDS.cpp melonDS.ra/src/NDS.cpp
      Current = this;
  
      FrameStartTimestamp = SysTimestamp;
-@@ -1601,6 +1634,11 @@ void NDS::MonitorARM9Jump(u32 addr)
+@@ -1593,6 +1626,11 @@ void NDS::MonitorARM9Jump(u32 addr)
          {
              Log(LogLevel::Info, "Game is now booting\n");
              RunningGame = true;
@@ -157,8 +151,8 @@ diff -rupbN melonDS.orig/src/NDS.cpp melonDS.ra/src/NDS.cpp
      }
  }
 diff -rupbN melonDS.orig/src/NDS.h melonDS.ra/src/NDS.h
---- melonDS.orig/src/NDS.h	2026-02-19 15:14:21.435802414 +0000
-+++ melonDS.ra/src/NDS.h	2026-02-19 15:16:12.436947885 +0000
+--- melonDS.orig/src/NDS.h	2026-03-06 21:36:14.530057064 +0000
++++ melonDS.ra/src/NDS.h	2026-03-06 21:37:07.046799886 +0000
 @@ -44,6 +44,9 @@
  #include "DMA.h"
  #include "FreeBIOS.h"
@@ -182,8 +176,8 @@ diff -rupbN melonDS.orig/src/NDS.h melonDS.ra/src/NDS.h
  
      int ConsoleType;
 diff -rupbN melonDS.orig/src/NDSCart.cpp melonDS.ra/src/NDSCart.cpp
---- melonDS.orig/src/NDSCart.cpp	2026-02-19 15:14:21.435802414 +0000
-+++ melonDS.ra/src/NDSCart.cpp	2026-02-19 15:16:12.436947885 +0000
+--- melonDS.orig/src/NDSCart.cpp	2026-03-06 21:36:14.530057064 +0000
++++ melonDS.ra/src/NDSCart.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -27,6 +27,11 @@
  #include "FATStorage.h"
  #include "Utils.h"
@@ -223,8 +217,8 @@ diff -rupbN melonDS.orig/src/NDSCart.cpp melonDS.ra/src/NDSCart.cpp
      IsDSi = Header.IsDSi() && !badDSiDump;
      DSiBase = Header.DSiRegionStart << 19;
 diff -rupbN melonDS.orig/src/NDSCart.h melonDS.ra/src/NDSCart.h
---- melonDS.orig/src/NDSCart.h	2026-02-19 15:14:21.435802414 +0000
-+++ melonDS.ra/src/NDSCart.h	2026-02-19 15:16:12.436947885 +0000
+--- melonDS.orig/src/NDSCart.h	2026-03-06 21:36:14.530057064 +0000
++++ melonDS.ra/src/NDSCart.h	2026-03-06 21:37:07.046799886 +0000
 @@ -30,6 +30,10 @@
  #include "FATStorage.h"
  #include "ROMList.h"
@@ -250,7 +244,7 @@ diff -rupbN melonDS.orig/src/NDSCart.h melonDS.ra/src/NDSCart.h
      virtual ~CartCommon();
 diff -rupbN melonDS.orig/src/RetroAchievements/RAClient.cpp melonDS.ra/src/RetroAchievements/RAClient.cpp
 --- melonDS.orig/src/RetroAchievements/RAClient.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/RetroAchievements/RAClient.cpp	2026-02-19 20:25:21.500583861 +0000
++++ melonDS.ra/src/RetroAchievements/RAClient.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,1119 @@
 +#include "RAClient.h"
 +#include "../NDS.h"
@@ -1373,7 +1367,7 @@ diff -rupbN melonDS.orig/src/RetroAchievements/RAClient.cpp melonDS.ra/src/Retro
 +}
 diff -rupbN melonDS.orig/src/RetroAchievements/RAClient.h melonDS.ra/src/RetroAchievements/RAClient.h
 --- melonDS.orig/src/RetroAchievements/RAClient.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/RetroAchievements/RAClient.h	2026-02-19 15:16:12.436947885 +0000
++++ melonDS.ra/src/RetroAchievements/RAClient.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,250 @@
 +#pragma once
 +
@@ -1628,7 +1622,7 @@ diff -rupbN melonDS.orig/src/RetroAchievements/RAClient.h melonDS.ra/src/RetroAc
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/RetroAchievements/cacert.c melonDS.ra/src/RetroAchievements/cacert.c
 --- melonDS.orig/src/RetroAchievements/cacert.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/RetroAchievements/cacert.c	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/RetroAchievements/cacert.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,5642 @@
 +/*
 +  C-file generated by Bin2C
@@ -7274,7 +7268,7 @@ diff -rupbN melonDS.orig/src/RetroAchievements/cacert.c melonDS.ra/src/RetroAchi
 +/*************************** End of file ****************************/
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/AchievementItemWidget.cpp melonDS.ra/src/frontend/qt_sdl/AchievementItemWidget.cpp
 --- melonDS.orig/src/frontend/qt_sdl/AchievementItemWidget.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/AchievementItemWidget.cpp	2026-02-19 16:25:30.567536754 +0000
++++ melonDS.ra/src/frontend/qt_sdl/AchievementItemWidget.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,125 @@
 +#include "AchievementItemWidget.h"
 +#include <QLabel>
@@ -7403,7 +7397,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/AchievementItemWidget.cpp melonDS.r
 +}
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/AchievementItemWidget.h melonDS.ra/src/frontend/qt_sdl/AchievementItemWidget.h
 --- melonDS.orig/src/frontend/qt_sdl/AchievementItemWidget.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/AchievementItemWidget.h	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/AchievementItemWidget.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,34 @@
 +#pragma once
 +#include <QWidget>
@@ -7441,8 +7435,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/AchievementItemWidget.h melonDS.ra/
 +};
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/CMakeLists.txt melonDS.ra/src/frontend/qt_sdl/CMakeLists.txt
---- melonDS.orig/src/frontend/qt_sdl/CMakeLists.txt	2026-02-19 15:13:54.675526370 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/CMakeLists.txt	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/CMakeLists.txt	2026-03-06 21:36:14.554057405 +0000
++++ melonDS.ra/src/frontend/qt_sdl/CMakeLists.txt	2026-03-06 21:37:07.046799886 +0000
 @@ -62,6 +62,22 @@ set(SOURCES_QT_SDL
      NetplayDialog.cpp
  )
@@ -7467,8 +7461,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/CMakeLists.txt melonDS.ra/src/front
  
  if (USE_QT6)
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/Config.cpp melonDS.ra/src/frontend/qt_sdl/Config.cpp
---- melonDS.orig/src/frontend/qt_sdl/Config.cpp	2026-02-19 15:14:21.439802455 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/Config.cpp	2026-02-20 05:15:24.994484236 +0000
+--- melonDS.orig/src/frontend/qt_sdl/Config.cpp	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/Config.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -103,6 +103,10 @@ DefaultList<bool> DefaultBools =
      {"Emu.DirectBoot", true},
      {"Instance*.DS.Battery.LevelOkay", true},
@@ -7512,7 +7506,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Config.cpp melonDS.ra/src/frontend/
      {"HKJoy_SwapScreens",         0, "Joystick.HK_SwapScreens", true},
      {"HKJoy_SwapScreenEmphasis",  0, "Joystick.HK_SwapScreenEmphasis", true},
      {"HKJoy_SolarSensorDecrease", 0, "Joystick.HK_SolarSensorDecrease", true},
-@@ -334,7 +349,19 @@ LegacyEntry LegacyFile[] =
+@@ -332,7 +347,19 @@ LegacyEntry LegacyFile[] =
      {"Camera1_ImagePath", 2, "DSi.Camera1.ImagePath", false},
      {"Camera1_CamDeviceName", 2, "DSi.Camera1.DeviceName", false},
      {"Camera1_XFlip", 1, "DSi.Camera1.XFlip", false},
@@ -7533,7 +7527,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Config.cpp melonDS.ra/src/frontend/
      {"", -1, "", false}
  };
  
-@@ -833,4 +860,17 @@ Table GetLocalTable(int instance)
+@@ -831,4 +858,17 @@ Table GetLocalTable(int instance)
      return Table(tbl, key);
  }
  
@@ -7552,8 +7546,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Config.cpp melonDS.ra/src/frontend/
 +
  }
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/Config.h melonDS.ra/src/frontend/qt_sdl/Config.h
---- melonDS.orig/src/frontend/qt_sdl/Config.h	2026-02-19 15:14:21.439802455 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/Config.h	2026-02-19 23:33:44.314355502 +0000
+--- melonDS.orig/src/frontend/qt_sdl/Config.h	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/Config.h	2026-03-06 21:37:07.046799886 +0000
 @@ -92,6 +92,13 @@ public:
      Table(toml::value& data, const std::string& path);
      ~Table() {}
@@ -7579,8 +7573,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Config.h melonDS.ra/src/frontend/qt
  
  }
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstance.cpp melonDS.ra/src/frontend/qt_sdl/EmuInstance.cpp
---- melonDS.orig/src/frontend/qt_sdl/EmuInstance.cpp	2026-02-19 15:14:21.439802455 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/EmuInstance.cpp	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/EmuInstance.cpp	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/EmuInstance.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -48,6 +48,10 @@
  #include "FreeBIOS.h"
  #include "main.h"
@@ -7627,7 +7621,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstance.cpp melonDS.ra/src/fron
  }
  
  void EmuInstance::deleteWindow(int id, bool close)
-@@ -1370,6 +1388,13 @@ bool EmuInstance::updateConsole() noexce
+@@ -1335,6 +1353,13 @@ bool EmuInstance::updateConsole() noexce
          else
              nds = new NDS(std::move(ndsargs), this);
  
@@ -7641,7 +7635,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstance.cpp melonDS.ra/src/fron
          nds->Reset();
          loadRTCData();
          emuThread->updateVideoRenderer();
-@@ -2274,3 +2299,30 @@ void EmuInstance::animatedROMIcon(const
+@@ -2256,3 +2281,30 @@ void EmuInstance::animatedROMIcon(const
              animatedSequenceRef.push_back(i);
      }
  }
@@ -7674,8 +7668,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstance.cpp melonDS.ra/src/fron
 +#endif
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstance.h melonDS.ra/src/frontend/qt_sdl/EmuInstance.h
---- melonDS.orig/src/frontend/qt_sdl/EmuInstance.h	2026-02-19 15:14:21.439802455 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/EmuInstance.h	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/EmuInstance.h	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/EmuInstance.h	2026-03-06 21:37:07.046799886 +0000
 @@ -29,6 +29,10 @@
  #include "Config.h"
  #include "SaveManager.h"
@@ -7715,7 +7709,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstance.h melonDS.ra/src/fronte
      EmuInstance(int inst);
      ~EmuInstance();
  
-@@ -380,6 +398,9 @@ private:
+@@ -379,6 +397,9 @@ private:
  
      friend class EmuThread;
      friend class MainWindow;
@@ -7726,8 +7720,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstance.h melonDS.ra/src/fronte
  
  #endif //EMUINSTANCE_H
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstanceInput.cpp melonDS.ra/src/frontend/qt_sdl/EmuInstanceInput.cpp
---- melonDS.orig/src/frontend/qt_sdl/EmuInstanceInput.cpp	2026-02-19 15:14:21.439802455 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/EmuInstanceInput.cpp	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/EmuInstanceInput.cpp	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/EmuInstanceInput.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -52,6 +52,9 @@ const char* EmuInstance::hotkeyNames[HK_
      "HK_FastForward",
      "HK_FrameLimitToggle",
@@ -7762,8 +7756,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuInstanceInput.cpp melonDS.ra/src
  
      joyHotkeyMask = 0;
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuThread.cpp melonDS.ra/src/frontend/qt_sdl/EmuThread.cpp
---- melonDS.orig/src/frontend/qt_sdl/EmuThread.cpp	2026-02-19 15:14:21.443802497 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/EmuThread.cpp	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/EmuThread.cpp	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/EmuThread.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -51,6 +51,10 @@
  #include "GPU_Soft.h"
  #include "GPU_OpenGL.h"
@@ -7951,8 +7945,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuThread.cpp melonDS.ra/src/fronte
          sendMessage(msg_EmuPause);
      sendMessage(msg_EmuFrameStep);
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuThread.h melonDS.ra/src/frontend/qt_sdl/EmuThread.h
---- melonDS.orig/src/frontend/qt_sdl/EmuThread.h	2026-02-19 15:14:21.443802497 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/EmuThread.h	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/EmuThread.h	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/EmuThread.h	2026-03-06 21:37:07.046799886 +0000
 @@ -155,6 +155,9 @@ signals:
  
      void windowFullscreenToggle();
@@ -7964,8 +7958,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/EmuThread.h melonDS.ra/src/frontend
      void screenEmphasisToggle();
  
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h melonDS.ra/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
---- melonDS.orig/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h	2026-02-19 15:14:21.443802497 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h	2026-03-06 21:36:14.558057462 +0000
++++ melonDS.ra/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h	2026-03-06 21:37:07.046799886 +0000
 @@ -61,6 +61,9 @@ static constexpr std::initializer_list<i
      HK_SlowMoToggle,
      HK_FrameLimitToggle,
@@ -7988,7 +7982,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h mel
      "Swap screens",
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/RAOverlayWidget.cpp melonDS.ra/src/frontend/qt_sdl/RAOverlayWidget.cpp
 --- melonDS.orig/src/frontend/qt_sdl/RAOverlayWidget.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/RAOverlayWidget.cpp	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/RAOverlayWidget.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,570 @@
 +#include "RAOverlayWidget.h"
 +#include "AchievementItemWidget.h"
@@ -8563,7 +8557,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/RAOverlayWidget.cpp melonDS.ra/src/
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/RAOverlayWidget.h melonDS.ra/src/frontend/qt_sdl/RAOverlayWidget.h
 --- melonDS.orig/src/frontend/qt_sdl/RAOverlayWidget.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/RAOverlayWidget.h	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/RAOverlayWidget.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,74 @@
 +#pragma once
 +
@@ -8642,7 +8636,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/RAOverlayWidget.h melonDS.ra/src/fr
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.cpp melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.cpp
 --- melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.cpp	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,214 @@
 +#include "RASettingsDialog.h"
 +#include "ui_RASettingsDialog.h"
@@ -8861,7 +8855,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.cpp melonDS.ra/src
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.h melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.h
 --- melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.h	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,42 @@
 +#pragma once
 +
@@ -8908,7 +8902,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.h melonDS.ra/src/f
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.ui melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.ui
 --- melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.ui	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.ui	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/RASettingsDialog.ui	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,187 @@
 +<?xml version="1.0" encoding="UTF-8"?>
 +<ui version="4.0">
@@ -9099,8 +9093,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/RASettingsDialog.ui melonDS.ra/src/
 +</ui>
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/qt_sdl/Window.cpp
---- melonDS.orig/src/frontend/qt_sdl/Window.cpp	2026-02-19 15:14:21.443802497 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/Window.cpp	2026-02-19 19:24:59.921026086 +0000
+--- melonDS.orig/src/frontend/qt_sdl/Window.cpp	2026-03-06 21:36:14.566057575 +0000
++++ melonDS.ra/src/frontend/qt_sdl/Window.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -82,6 +82,14 @@
  #include "Window.h"
  #include "AboutDialog.h"
@@ -9139,7 +9133,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
              actWifiSettings = menu->addAction("Wifi settings");
              connect(actWifiSettings, &QAction::triggered, this, &MainWindow::onOpenWifiSettings);
  
-@@ -794,6 +811,132 @@ MainWindow::MainWindow(int id, EmuInstan
+@@ -784,6 +801,132 @@ MainWindow::MainWindow(int id, EmuInstan
  #endif // __APPLE__
          }
  
@@ -9272,7 +9266,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
          if (emuThread->emuIsActive())
              onEmuStart();
      }
-@@ -1564,6 +1707,17 @@ void MainWindow::onEjectGBACart()
+@@ -1554,6 +1697,17 @@ void MainWindow::onEjectGBACart()
  
  void MainWindow::onSaveState()
  {
@@ -9290,7 +9284,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      int slot = ((QAction*)sender())->data().toInt();
  
      QString filename;
-@@ -1599,6 +1753,17 @@ void MainWindow::onSaveState()
+@@ -1589,6 +1743,17 @@ void MainWindow::onSaveState()
  
  void MainWindow::onLoadState()
  {
@@ -9308,7 +9302,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      int slot = ((QAction*)sender())->data().toInt();
  
      QString filename;
-@@ -1649,6 +1814,17 @@ void MainWindow::onUndoStateLoad()
+@@ -1639,6 +1804,17 @@ void MainWindow::onUndoStateLoad()
  
  void MainWindow::onImportSavefile()
  {
@@ -9326,7 +9320,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      QString path = QFileDialog::getOpenFileName(this,
                                              "Select savefile",
                                              globalCfg.GetQString("LastROMFolder"),
-@@ -1709,6 +1885,9 @@ void MainWindow::onPause(bool checked)
+@@ -1699,6 +1875,9 @@ void MainWindow::onPause(bool checked)
  
  void MainWindow::onReset()
  {
@@ -9336,7 +9330,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      if (!emuThread->emuIsActive()) return;
  
      emuThread->emuReset();
-@@ -1716,6 +1895,9 @@ void MainWindow::onReset()
+@@ -1706,6 +1885,9 @@ void MainWindow::onReset()
  
  void MainWindow::onStop()
  {
@@ -9346,7 +9340,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      if (!emuThread->emuIsActive()) return;
  
      emuThread->emuStop(true);
-@@ -1740,6 +1922,18 @@ void MainWindow::onOpenPowerManagement()
+@@ -1730,6 +1912,18 @@ void MainWindow::onOpenPowerManagement()
  
  void MainWindow::onEnableCheats(bool checked)
  {
@@ -9365,7 +9359,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      localCfg.SetBool("EnableCheats", checked);
      emuThread->enableCheats(checked);
  
-@@ -1751,6 +1945,17 @@ void MainWindow::onEnableCheats(bool che
+@@ -1741,6 +1935,17 @@ void MainWindow::onEnableCheats(bool che
  
  void MainWindow::onSetupCheats()
  {
@@ -9383,7 +9377,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      emuThread->emuPause();
  
      CheatsDialog* dlg = CheatsDialog::openDlg(this);
-@@ -1880,6 +2085,52 @@ void MainWindow::onEmuSettingsDialogFini
+@@ -1870,6 +2075,52 @@ void MainWindow::onEmuSettingsDialogFini
      if (!emuThread->emuIsActive())
          actTitleManager->setEnabled(!globalCfg.GetString("DSi.NANDPath").empty());
  
@@ -9436,7 +9430,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      emuThread->emuUnpause();
  }
  
-@@ -2007,6 +2258,35 @@ void MainWindow::onMPSettingsFinished(in
+@@ -1997,6 +2248,35 @@ void MainWindow::onMPSettingsFinished(in
  
      emuThread->emuUnpause();
  }
@@ -9472,7 +9466,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
  
  void MainWindow::onOpenWifiSettings()
  {
-@@ -2175,6 +2455,13 @@ void MainWindow::onChangeAudioSync(bool
+@@ -2160,6 +2440,13 @@ void MainWindow::onChangeAudioSync(bool
  
  void MainWindow::onTitleUpdate(QString title)
  {
@@ -9486,7 +9480,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
      if (!emuInstance) return;
  
      int numinst = numEmuInstances();
-@@ -2225,6 +2512,38 @@ void MainWindow::onFullscreenToggled()
+@@ -2210,6 +2497,38 @@ void MainWindow::onFullscreenToggled()
      toggleFullscreen();
  }
  
@@ -9525,7 +9519,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
  void MainWindow::onScreenEmphasisToggled()
  {
      int currentSizing = windowCfg.GetInt("ScreenSizing");
-@@ -2308,6 +2627,229 @@ void MainWindow::onEmuReset()
+@@ -2293,6 +2612,229 @@ void MainWindow::onEmuReset()
      actUndoStateLoad->setEnabled(false);
  }
  
@@ -9756,8 +9750,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.cpp melonDS.ra/src/frontend/
  {
      if (!emuInstance) return;
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.h melonDS.ra/src/frontend/qt_sdl/Window.h
---- melonDS.orig/src/frontend/qt_sdl/Window.h	2026-02-19 15:14:21.443802497 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/Window.h	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/Window.h	2026-03-06 21:36:14.566057575 +0000
++++ melonDS.ra/src/frontend/qt_sdl/Window.h	2026-03-06 21:37:07.046799886 +0000
 @@ -37,6 +37,13 @@
  #include "Config.h"
  #include "MPInterface.h"
@@ -9810,7 +9804,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.h melonDS.ra/src/frontend/qt
      void onOpenWifiSettings();
      void onWifiSettingsFinished(int res);
      void onOpenFirmwareSettings();
-@@ -183,6 +214,9 @@ private slots:
+@@ -182,6 +213,9 @@ private slots:
      void onUpdateVideoSettings(bool glchange);
  
      void onFullscreenToggled();
@@ -9820,7 +9814,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.h melonDS.ra/src/frontend/qt
      void onScreenEmphasisToggled();
  
  private:
-@@ -270,6 +304,9 @@ public:
+@@ -269,6 +303,9 @@ public:
      QAction* actCameraSettings;
      QAction* actAudioSettings;
      QAction* actMPSettings;
@@ -9831,8 +9825,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/Window.h melonDS.ra/src/frontend/qt
      QAction* actFirmwareSettings;
      QAction* actPathSettings;
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/main.cpp melonDS.ra/src/frontend/qt_sdl/main.cpp
---- melonDS.orig/src/frontend/qt_sdl/main.cpp	2026-02-19 15:14:21.443802497 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/main.cpp	2026-02-19 15:16:12.440947926 +0000
+--- melonDS.orig/src/frontend/qt_sdl/main.cpp	2026-03-06 21:36:14.566057575 +0000
++++ melonDS.ra/src/frontend/qt_sdl/main.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -65,6 +65,11 @@
  #include "Net_PCap.h"
  #include "Net_Slirp.h"
@@ -9913,11 +9907,9 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/main.cpp melonDS.ra/src/frontend/qt
      int ret = melon.exec();
  
      delete options;
-Binary files melonDS.orig/src/frontend/qt_sdl/retroachievements/resources/icons/placeholder.png and melonDS.ra/src/frontend/qt_sdl/retroachievements/resources/icons/placeholder.png differ
-Binary files melonDS.orig/src/frontend/qt_sdl/retroachievements/resources/icons/ra-icon.png and melonDS.ra/src/frontend/qt_sdl/retroachievements/resources/icons/ra-icon.png differ
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/retroachievements/resources/ra.qrc melonDS.ra/src/frontend/qt_sdl/retroachievements/resources/ra.qrc
 --- melonDS.orig/src/frontend/qt_sdl/retroachievements/resources/ra.qrc	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/retroachievements/resources/ra.qrc	2026-02-19 15:16:12.440947926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/retroachievements/resources/ra.qrc	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,10 @@
 +<RCC>
 +    <qresource prefix="/ra">
@@ -9930,10 +9922,9 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/retroachievements/resources/ra.qrc 
 +    </qresource>
 +</RCC>
 \ No newline at end of file
-Binary files melonDS.orig/src/frontend/qt_sdl/retroachievements/resources/sounds/unlock.wav and melonDS.ra/src/frontend/qt_sdl/retroachievements/resources/sounds/unlock.wav differ
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/BadgeCache.cpp melonDS.ra/src/frontend/qt_sdl/toast/BadgeCache.cpp
 --- melonDS.orig/src/frontend/qt_sdl/toast/BadgeCache.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/toast/BadgeCache.cpp	2026-02-19 19:28:42.802590593 +0000
++++ melonDS.ra/src/frontend/qt_sdl/toast/BadgeCache.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,50 @@
 +#include "BadgeCache.h"
 +#include <QNetworkReply>
@@ -9987,7 +9978,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/BadgeCache.cpp melonDS.ra/src
 +}
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/BadgeCache.h melonDS.ra/src/frontend/qt_sdl/toast/BadgeCache.h
 --- melonDS.orig/src/frontend/qt_sdl/toast/BadgeCache.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/toast/BadgeCache.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/frontend/qt_sdl/toast/BadgeCache.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,21 @@
 +#pragma once
 +#include <QPixmap>
@@ -10013,7 +10004,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/BadgeCache.h melonDS.ra/src/f
 \ No newline at end of file
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastManager.cpp melonDS.ra/src/frontend/qt_sdl/toast/ToastManager.cpp
 --- melonDS.orig/src/frontend/qt_sdl/toast/ToastManager.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/toast/ToastManager.cpp	2026-02-19 18:44:28.177386238 +0000
++++ melonDS.ra/src/frontend/qt_sdl/toast/ToastManager.cpp	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,149 @@
 +#include "ToastManager.h"
 +#include "toast/ToastOverlay.h"
@@ -10166,7 +10157,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastManager.cpp melonDS.ra/s
 +}
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastManager.h melonDS.ra/src/frontend/qt_sdl/toast/ToastManager.h
 --- melonDS.orig/src/frontend/qt_sdl/toast/ToastManager.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/toast/ToastManager.h	2026-02-19 18:46:35.895046926 +0000
++++ melonDS.ra/src/frontend/qt_sdl/toast/ToastManager.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,26 @@
 +#pragma once
 +#include <QObject>
@@ -10196,8 +10187,8 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastManager.h melonDS.ra/src
 +};
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/src/frontend/qt_sdl/toast/ToastOverlay.cpp
 --- melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/toast/ToastOverlay.cpp	2026-02-19 20:04:55.094259041 +0000
-@@ -0,0 +1,362 @@
++++ melonDS.ra/src/frontend/qt_sdl/toast/ToastOverlay.cpp	2026-03-06 21:38:33.640023242 +0000
+@@ -0,0 +1,377 @@
 +#include "ToastOverlay.h"
 +#include <QPainter>
 +#include <QEvent>
@@ -10288,7 +10279,6 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +
 +        if (!title.isEmpty()) {
 +            auto* titleLabel = new QLabel;
-+            //titleLabel->setStyleSheet("font-weight: bold; color: white; background: transparent; padding-left: 2px;");
 +            titleLabel->setStyleSheet(QString("font-weight: bold; color: white; background: transparent; padding-left: 2px; font-size: %1pt;").arg(titlePt));
 +            actualTitleW = ConfigureLabelAutoFit(titleLabel, title, maxTextWidth);
 +            titleLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
@@ -10298,7 +10288,6 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +
 +        if (!description.isEmpty()) {
 +            auto* descLabel = new QLabel;
-+            //descLabel->setStyleSheet("color: #bbb; background: transparent; padding-left: 2px;");
 +            descLabel->setStyleSheet(QString("color: #bbb; background: transparent; padding-left: 2px; font-size: %1pt;").arg(descPt));
 +            actualDescW = ConfigureLabelAutoFit(descLabel, description, maxTextWidth);
 +            descLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
@@ -10337,10 +10326,17 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +}
 +
 +ToastOverlay::ToastOverlay(QWidget* parent)
-+    : QGraphicsView(parent)
++    : QGraphicsView(static_cast<QWidget*>(nullptr))
++    , m_anchor(parent)
 +{
 +    m_scene = new QGraphicsScene(this);
 +    setScene(m_scene);
++    setWindowFlags(Qt::Tool | Qt::FramelessWindowHint |
++                   Qt::WindowStaysOnTopHint | Qt::WindowDoesNotAcceptFocus |
++                   Qt::WindowTransparentForInput);
++    setAttribute(Qt::WA_ShowWithoutActivating);
++    setAttribute(Qt::WA_NoSystemBackground);
++    setWindowFlag(Qt::X11BypassWindowManagerHint);
 +    setFrameShape(QFrame::NoFrame);
 +    setBackgroundRole(QPalette::NoRole);
 +    setStyleSheet("background: transparent; border: none;");
@@ -10356,15 +10352,15 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +
 +void ToastOverlay::ShowToast(const QString& title, const QString& description, const QPixmap& icon, bool playSound)
 +{
-+    MainWindow* mainWin = qobject_cast<MainWindow*>(parentWidget());
++    MainWindow* mainWin = qobject_cast<MainWindow*>(m_anchor);
 +    if (mainWin) {
 +        if (mainWin->getEmuInstance()->getLocalConfig().GetBool("RetroAchievements.HideToasts")) {
 +            return;
 +        }
 +    }
-+    if (!parentWidget()) return;
-+    float scale = ComputeToastScale(parentWidget()->size());
-+    const int maxToastWidth = int(parentWidget()->width() * 0.825f);
++    if (!m_anchor) return;
++    float scale = ComputeToastScale(m_anchor->size());
++    const int maxToastWidth = int(m_anchor->width() * 0.825f);
 +
 +    auto* toast = new ToastWidget(title, description, icon, scale, maxToastWidth);
 +    QGraphicsProxyWidget* proxy = m_scene->addWidget(toast);
@@ -10386,17 +10382,17 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +
 +void ToastOverlay::ShowChallenge(const QPixmap& icon, const QString& badgeName)
 +{
-+    MainWindow* mainWin = qobject_cast<MainWindow*>(parentWidget());
++    MainWindow* mainWin = qobject_cast<MainWindow*>(m_anchor);
 +    if (mainWin) {
 +        if (mainWin->getEmuInstance()->getLocalConfig().GetBool("RetroAchievements.HideChallengeIndicators")) {
 +            return;
 +        }
 +    }
 +
-+    if (!parentWidget() || icon.isNull()) return;
++    if (!m_anchor || icon.isNull()) return;
 +
-+    float scale = ComputeToastScale(parentWidget()->size());
-+    int scaledSize = int(48 * scale); 
++    float scale = ComputeToastScale(m_anchor->size());
++    int scaledSize = int(48 * scale);
 +
 +    QLabel* label = new QLabel();
 +    label->setPixmap(icon.scaled(scaledSize, scaledSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
@@ -10405,8 +10401,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +    label->adjustSize();
 +
 +    QGraphicsProxyWidget* proxy = m_scene->addWidget(label);
-+
-+    proxy->setProperty("badgeName", badgeName); 
++    proxy->setProperty("badgeName", badgeName);
 +
 +    m_challengeProxies.append(proxy);
 +    RepositionChallenge();
@@ -10419,7 +10414,7 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +    bool playSound
 +)
 +{
-+    MainWindow* mainWin = qobject_cast<MainWindow*>(parentWidget());
++    MainWindow* mainWin = qobject_cast<MainWindow*>(m_anchor);
 +    if (mainWin)
 +    {
 +        if (mainWin->getEmuInstance()->getLocalConfig().GetBool("RetroAchievements.HideLeaderboardToasts")) {
@@ -10455,10 +10450,10 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +
 +void ToastOverlay::RepositionToasts()
 +{
-+    if (!parentWidget()) return;
++    if (!m_anchor) return;
 +    int rotMode = Config::GetLocalTable(0).GetInt("Window0.ScreenRotation");
 +    int angle = rotMode * 90;
-+    QRect pRect = parentWidget()->rect();
++    QRect pRect = m_anchor->rect();
 +    m_scene->setSceneRect(0, 0, pRect.width(), pRect.height());
 +
 +    const int margin = 20;
@@ -10476,7 +10471,6 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +        int centerX, centerY;
 +
 +        if (rotMode == 0) {
-+            //centerX = pRect.width() - margin - finalW / 2;
 +            centerX = margin + finalW / 2;
 +            centerY = offset + finalH / 2;
 +        } else if (rotMode == 1) {
@@ -10497,11 +10491,11 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +
 +void ToastOverlay::RepositionChallenge()
 +{
-+    if (m_challengeProxies.isEmpty() || !parentWidget()) return;
++    if (m_challengeProxies.isEmpty() || !m_anchor) return;
 +
 +    int rotMode = Config::GetLocalTable(0).GetInt("Window0.ScreenRotation");
 +    int angle = rotMode * 90;
-+    QRect pRect = parentWidget()->rect();
++    QRect pRect = m_anchor->rect();
 +
 +    const int margin = 20;
 +    const int spacing = 8;
@@ -10534,14 +10528,17 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +        }
 +
 +        proxy->setPos(centerX - s.width() / 2.0, centerY - s.height() / 2.0);
-+
 +        currentOffset += (rotMode % 2 == 0 ? finalW : finalH) + spacing;
 +    }
 +}
 +
 +void ToastOverlay::resizeEvent(QResizeEvent* event)
 +{
-+    if (parentWidget()) setGeometry(parentWidget()->rect());
++    if (m_anchor)
++    {
++        QPoint globalPos = m_anchor->mapToGlobal(QPoint(0, 0));
++        setGeometry(globalPos.x(), globalPos.y(), m_anchor->width(), m_anchor->height());
++    }
 +    RepositionToasts();
 +    RepositionChallenge();
 +    QGraphicsView::resizeEvent(event);
@@ -10549,21 +10546,30 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.cpp melonDS.ra/s
 +
 +bool ToastOverlay::eventFilter(QObject* obj, QEvent* event)
 +{
-+    if (obj == parentWidget())
++    if (obj == m_anchor || obj == m_anchor->window())
 +    {
-+        if (event->type() == QEvent::Resize || event->type() == QEvent::WindowStateChange)
++        if (event->type() == QEvent::Resize ||
++            event->type() == QEvent::Move ||
++            event->type() == QEvent::WindowStateChange)
 +        {
-+            setGeometry(parentWidget()->rect());
-+            RepositionToasts();
-+            RepositionChallenge();
++            if (m_anchor)
++            {
++            if (!m_anchor->window()->isMinimized())
++            {
++                QPoint globalPos = m_anchor->mapToGlobal(QPoint(0, 0));
++                setGeometry(globalPos.x(), globalPos.y(), m_anchor->width(), m_anchor->height());
++                RepositionToasts();
++                RepositionChallenge();
++            }
++            }
 +        }
 +    }
 +    return QGraphicsView::eventFilter(obj, event);
 +}
 diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.h melonDS.ra/src/frontend/qt_sdl/toast/ToastOverlay.h
 --- melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/frontend/qt_sdl/toast/ToastOverlay.h	2026-02-19 15:16:12.444947968 +0000
-@@ -0,0 +1,51 @@
++++ melonDS.ra/src/frontend/qt_sdl/toast/ToastOverlay.h	2026-03-06 21:39:48.805083859 +0000
+@@ -0,0 +1,52 @@
 +#pragma once
 +
 +#include <QWidget>
@@ -10614,11 +10620,11 @@ diff -rupbN melonDS.orig/src/frontend/qt_sdl/toast/ToastOverlay.h melonDS.ra/src
 +    QList<QGraphicsProxyWidget*> m_toastProxies;
 +    QList<QGraphicsProxyWidget*> m_challengeProxies;
 +    QSoundEffect m_soundEffect;
++    QWidget* m_anchor = nullptr;
 +};
-\ No newline at end of file
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_editor.h melonDS.ra/src/rcheevos/include/rc_api_editor.h
 --- melonDS.orig/src/rcheevos/include/rc_api_editor.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_api_editor.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_api_editor.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,296 @@
 +#ifndef RC_API_EDITOR_H
 +#define RC_API_EDITOR_H
@@ -10918,7 +10924,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_editor.h melonDS.ra/src/rch
 +#endif /* RC_EDITOR_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_info.h melonDS.ra/src/rcheevos/include/rc_api_info.h
 --- melonDS.orig/src/rcheevos/include/rc_api_info.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_api_info.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_api_info.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,278 @@
 +#ifndef RC_API_INFO_H
 +#define RC_API_INFO_H
@@ -11200,7 +11206,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_info.h melonDS.ra/src/rchee
 +#endif /* RC_API_INFO_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_request.h melonDS.ra/src/rcheevos/include/rc_api_request.h
 --- melonDS.orig/src/rcheevos/include/rc_api_request.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_api_request.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_api_request.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,77 @@
 +#ifndef RC_API_REQUEST_H
 +#define RC_API_REQUEST_H
@@ -11281,7 +11287,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_request.h melonDS.ra/src/rc
 +#endif /* RC_API_REQUEST_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_runtime.h melonDS.ra/src/rcheevos/include/rc_api_runtime.h
 --- melonDS.orig/src/rcheevos/include/rc_api_runtime.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_api_runtime.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_api_runtime.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,417 @@
 +#ifndef RC_API_RUNTIME_H
 +#define RC_API_RUNTIME_H
@@ -11702,7 +11708,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_runtime.h melonDS.ra/src/rc
 +#endif /* RC_API_RUNTIME_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_user.h melonDS.ra/src/rcheevos/include/rc_api_user.h
 --- melonDS.orig/src/rcheevos/include/rc_api_user.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_api_user.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_api_user.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,262 @@
 +#ifndef RC_API_USER_H
 +#define RC_API_USER_H
@@ -11968,7 +11974,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_api_user.h melonDS.ra/src/rchee
 +#endif /* RC_API_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_client.h melonDS.ra/src/rcheevos/include/rc_client.h
 --- melonDS.orig/src/rcheevos/include/rc_client.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_client.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_client.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,871 @@
 +#ifndef RC_CLIENT_H
 +#define RC_CLIENT_H
@@ -12843,7 +12849,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_client.h melonDS.ra/src/rcheevo
 +#endif /* RC_RUNTIME_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_client_raintegration.h melonDS.ra/src/rcheevos/include/rc_client_raintegration.h
 --- melonDS.orig/src/rcheevos/include/rc_client_raintegration.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_client_raintegration.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_client_raintegration.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,101 @@
 +#ifndef RC_CLIENT_RAINTEGRATION_H
 +#define RC_CLIENT_RAINTEGRATION_H
@@ -12948,7 +12954,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_client_raintegration.h melonDS.
 +#endif /* RC_CLIENT_RAINTEGRATION_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_consoles.h melonDS.ra/src/rcheevos/include/rc_consoles.h
 --- melonDS.orig/src/rcheevos/include/rc_consoles.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_consoles.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_consoles.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,138 @@
 +#ifndef RC_CONSOLES_H
 +#define RC_CONSOLES_H
@@ -13090,7 +13096,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_consoles.h melonDS.ra/src/rchee
 +#endif /* RC_CONSOLES_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_error.h melonDS.ra/src/rcheevos/include/rc_error.h
 --- melonDS.orig/src/rcheevos/include/rc_error.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_error.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_error.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,59 @@
 +#ifndef RC_ERROR_H
 +#define RC_ERROR_H
@@ -13153,7 +13159,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_error.h melonDS.ra/src/rcheevos
 +#endif /* RC_ERROR_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_export.h melonDS.ra/src/rcheevos/include/rc_export.h
 --- melonDS.orig/src/rcheevos/include/rc_export.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_export.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_export.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,100 @@
 +#ifndef RC_EXPORT_H
 +#define RC_EXPORT_H
@@ -13257,7 +13263,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_export.h melonDS.ra/src/rcheevo
 +#endif /* RC_EXPORT_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_hash.h melonDS.ra/src/rcheevos/include/rc_hash.h
 --- melonDS.orig/src/rcheevos/include/rc_hash.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_hash.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_hash.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,200 @@
 +#ifndef RC_HASH_H
 +#define RC_HASH_H
@@ -13461,7 +13467,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_hash.h melonDS.ra/src/rcheevos/
 +#endif /* RC_HASH_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_runtime.h melonDS.ra/src/rcheevos/include/rc_runtime.h
 --- melonDS.orig/src/rcheevos/include/rc_runtime.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_runtime.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_runtime.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,148 @@
 +#ifndef RC_RUNTIME_H
 +#define RC_RUNTIME_H
@@ -13613,7 +13619,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_runtime.h melonDS.ra/src/rcheev
 +#endif /* RC_RUNTIME_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_runtime_types.h melonDS.ra/src/rcheevos/include/rc_runtime_types.h
 --- melonDS.orig/src/rcheevos/include/rc_runtime_types.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_runtime_types.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_runtime_types.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,452 @@
 +#ifndef RC_RUNTIME_TYPES_H
 +#define RC_RUNTIME_TYPES_H
@@ -14069,7 +14075,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_runtime_types.h melonDS.ra/src/
 +#endif /* RC_RUNTIME_TYPES_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rc_util.h melonDS.ra/src/rcheevos/include/rc_util.h
 --- melonDS.orig/src/rcheevos/include/rc_util.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rc_util.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rc_util.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,51 @@
 +#ifndef RC_UTIL_H
 +#define RC_UTIL_H
@@ -14124,7 +14130,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rc_util.h melonDS.ra/src/rcheevos/
 +#endif /* RC_UTIL_H */
 diff -rupbN melonDS.orig/src/rcheevos/include/rcheevos.h melonDS.ra/src/rcheevos/include/rcheevos.h
 --- melonDS.orig/src/rcheevos/include/rcheevos.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/include/rcheevos.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/include/rcheevos.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,8 @@
 +#ifndef RCHEEVOS_H
 +#define RCHEEVOS_H
@@ -14136,7 +14142,7 @@ diff -rupbN melonDS.orig/src/rcheevos/include/rcheevos.h melonDS.ra/src/rcheevos
 +#endif /* RCHEEVOS_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_common.c melonDS.ra/src/rcheevos/src/rapi/rc_api_common.c
 --- melonDS.orig/src/rcheevos/src/rapi/rc_api_common.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rapi/rc_api_common.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rapi/rc_api_common.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,1379 @@
 +#include "rc_api_common.h"
 +#include "rc_api_request.h"
@@ -15519,7 +15525,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_common.c melonDS.ra/src/rc
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_common.h melonDS.ra/src/rcheevos/src/rapi/rc_api_common.h
 --- melonDS.orig/src/rcheevos/src/rapi/rc_api_common.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rapi/rc_api_common.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rapi/rc_api_common.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,88 @@
 +#ifndef RC_API_COMMON_H
 +#define RC_API_COMMON_H
@@ -15611,7 +15617,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_common.h melonDS.ra/src/rc
 +#endif /* RC_API_COMMON_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_editor.c melonDS.ra/src/rcheevos/src/rapi/rc_api_editor.c
 --- melonDS.orig/src/rcheevos/src/rapi/rc_api_editor.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rapi/rc_api_editor.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rapi/rc_api_editor.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,625 @@
 +#include "rc_api_editor.h"
 +#include "rc_api_common.h"
@@ -16240,7 +16246,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_editor.c melonDS.ra/src/rc
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_info.c melonDS.ra/src/rcheevos/src/rapi/rc_api_info.c
 --- melonDS.orig/src/rcheevos/src/rapi/rc_api_info.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rapi/rc_api_info.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rapi/rc_api_info.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,582 @@
 +#include "rc_api_info.h"
 +#include "rc_api_common.h"
@@ -16826,7 +16832,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_info.c melonDS.ra/src/rche
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_runtime.c melonDS.ra/src/rcheevos/src/rapi/rc_api_runtime.c
 --- melonDS.orig/src/rcheevos/src/rapi/rc_api_runtime.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rapi/rc_api_runtime.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rapi/rc_api_runtime.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,901 @@
 +#include "rc_api_runtime.h"
 +#include "rc_api_common.h"
@@ -17731,7 +17737,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_runtime.c melonDS.ra/src/r
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_user.c melonDS.ra/src/rcheevos/src/rapi/rc_api_user.c
 --- melonDS.orig/src/rcheevos/src/rapi/rc_api_user.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rapi/rc_api_user.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rapi/rc_api_user.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,483 @@
 +#include "rc_api_user.h"
 +#include "rc_api_common.h"
@@ -18218,7 +18224,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rapi/rc_api_user.c melonDS.ra/src/rche
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rc_client.c melonDS.ra/src/rcheevos/src/rc_client.c
 --- melonDS.orig/src/rcheevos/src/rc_client.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rc_client.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rc_client.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,6775 @@
 +#include "rc_client_internal.h"
 +
@@ -24997,7 +25003,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rc_client.c melonDS.ra/src/rcheevos/sr
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rc_client_internal.h melonDS.ra/src/rcheevos/src/rc_client_internal.h
 --- melonDS.orig/src/rcheevos/src/rc_client_internal.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rc_client_internal.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rc_client_internal.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,409 @@
 +#ifndef RC_CLIENT_INTERNAL_H
 +#define RC_CLIENT_INTERNAL_H
@@ -25410,7 +25416,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rc_client_internal.h melonDS.ra/src/rc
 +#endif /* RC_CLIENT_INTERNAL_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rc_compat.c melonDS.ra/src/rcheevos/src/rc_compat.c
 --- melonDS.orig/src/rcheevos/src/rc_compat.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rc_compat.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rc_compat.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,251 @@
 +#if !defined(RC_NO_THREADS) && !defined(_WIN32) && !defined(GEKKO) && !defined(_3DS) && (!defined(_XOPEN_SOURCE) || (_XOPEN_SOURCE - 0) < 500)
 +/* We'll want to use pthread_mutexattr_settype/PTHREAD_MUTEX_RECURSIVE, but glibc only conditionally exposes pthread_mutexattr_settype and PTHREAD_MUTEX_RECURSIVE depending on feature flags
@@ -25665,7 +25671,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rc_compat.c melonDS.ra/src/rcheevos/sr
 +#endif /* RC_NO_THREADS */
 diff -rupbN melonDS.orig/src/rcheevos/src/rc_compat.h melonDS.ra/src/rcheevos/src/rc_compat.h
 --- melonDS.orig/src/rcheevos/src/rc_compat.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rc_compat.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rc_compat.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,121 @@
 +#ifndef RC_COMPAT_H
 +#define RC_COMPAT_H
@@ -25790,7 +25796,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rc_compat.h melonDS.ra/src/rcheevos/sr
 +#endif /* RC_COMPAT_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rc_util.c melonDS.ra/src/rcheevos/src/rc_util.c
 --- melonDS.orig/src/rcheevos/src/rc_util.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rc_util.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rc_util.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,199 @@
 +#include "rc_util.h"
 +
@@ -25993,7 +25999,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rc_util.c melonDS.ra/src/rcheevos/src/
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rc_version.c melonDS.ra/src/rcheevos/src/rc_version.c
 --- melonDS.orig/src/rcheevos/src/rc_version.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rc_version.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rc_version.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,11 @@
 +#include "rc_version.h"
 +
@@ -26008,7 +26014,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rc_version.c melonDS.ra/src/rcheevos/s
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rc_version.h melonDS.ra/src/rcheevos/src/rc_version.h
 --- melonDS.orig/src/rcheevos/src/rc_version.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rc_version.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rc_version.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,32 @@
 +#ifndef RC_VERSION_H
 +#define RC_VERSION_H
@@ -26044,7 +26050,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rc_version.h melonDS.ra/src/rcheevos/s
 +#endif /* RC_VERSION_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/alloc.c melonDS.ra/src/rcheevos/src/rcheevos/alloc.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/alloc.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/alloc.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/alloc.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,312 @@
 +#include "rc_internal.h"
 +
@@ -26360,7 +26366,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/alloc.c melonDS.ra/src/rcheev
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/condition.c melonDS.ra/src/rcheevos/src/rcheevos/condition.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/condition.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/condition.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/condition.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,754 @@
 +#include "rc_internal.h"
 +
@@ -27118,7 +27124,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/condition.c melonDS.ra/src/rc
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/condset.c melonDS.ra/src/rcheevos/src/rcheevos/condset.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/condset.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/condset.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/condset.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,770 @@
 +#include "rc_internal.h"
 +
@@ -27892,7 +27898,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/condset.c melonDS.ra/src/rche
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/consoleinfo.c melonDS.ra/src/rcheevos/src/rcheevos/consoleinfo.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/consoleinfo.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/consoleinfo.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/consoleinfo.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,1215 @@
 +#include "rc_consoles.h"
 +
@@ -29111,7 +29117,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/consoleinfo.c melonDS.ra/src/
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/format.c melonDS.ra/src/rcheevos/src/rcheevos/format.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/format.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/format.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/format.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,330 @@
 +#include "rc_internal.h"
 +
@@ -29445,7 +29451,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/format.c melonDS.ra/src/rchee
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/lboard.c melonDS.ra/src/rcheevos/src/rcheevos/lboard.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/lboard.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/lboard.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/lboard.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,287 @@
 +#include "rc_internal.h"
 +
@@ -29736,7 +29742,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/lboard.c melonDS.ra/src/rchee
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/memref.c melonDS.ra/src/rcheevos/src/rcheevos/memref.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/memref.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/memref.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/memref.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,805 @@
 +#include "rc_internal.h"
 +
@@ -30545,7 +30551,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/memref.c melonDS.ra/src/rchee
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/operand.c melonDS.ra/src/rcheevos/src/rcheevos/operand.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/operand.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/operand.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/operand.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,607 @@
 +#include "rc_internal.h"
 +
@@ -31156,7 +31162,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/operand.c melonDS.ra/src/rche
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/rc_internal.h melonDS.ra/src/rcheevos/src/rcheevos/rc_internal.h
 --- melonDS.orig/src/rcheevos/src/rcheevos/rc_internal.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/rc_internal.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/rc_internal.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,390 @@
 +#ifndef RC_INTERNAL_H
 +#define RC_INTERNAL_H
@@ -31550,7 +31556,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/rc_internal.h melonDS.ra/src/
 +#endif /* RC_INTERNAL_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/rc_validate.c melonDS.ra/src/rcheevos/src/rcheevos/rc_validate.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/rc_validate.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/rc_validate.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/rc_validate.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,1370 @@
 +#include "rc_validate.h"
 +
@@ -32924,7 +32930,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/rc_validate.c melonDS.ra/src/
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/rc_validate.h melonDS.ra/src/rcheevos/src/rcheevos/rc_validate.h
 --- melonDS.orig/src/rcheevos/src/rcheevos/rc_validate.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/rc_validate.h	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/rc_validate.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,18 @@
 +#ifndef RC_VALIDATE_H
 +#define RC_VALIDATE_H
@@ -32946,7 +32952,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/rc_validate.h melonDS.ra/src/
 +#endif /* RC_VALIDATE_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/richpresence.c melonDS.ra/src/rcheevos/src/rcheevos/richpresence.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/richpresence.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/richpresence.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/richpresence.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,922 @@
 +#include "rc_internal.h"
 +
@@ -33872,7 +33878,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/richpresence.c melonDS.ra/src
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/runtime.c melonDS.ra/src/rcheevos/src/rcheevos/runtime.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/runtime.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/runtime.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/runtime.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,852 @@
 +#include "rc_runtime.h"
 +#include "rc_internal.h"
@@ -34728,7 +34734,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/runtime.c melonDS.ra/src/rche
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/runtime_progress.c melonDS.ra/src/rcheevos/src/rcheevos/runtime_progress.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/runtime_progress.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/runtime_progress.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/runtime_progress.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,1073 @@
 +#include "rc_runtime.h"
 +#include "rc_internal.h"
@@ -35805,7 +35811,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/runtime_progress.c melonDS.ra
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/trigger.c melonDS.ra/src/rcheevos/src/rcheevos/trigger.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/trigger.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/trigger.c	2026-02-19 15:16:12.444947968 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/trigger.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,344 @@
 +#include "rc_internal.h"
 +
@@ -36153,7 +36159,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/trigger.c melonDS.ra/src/rche
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/value.c melonDS.ra/src/rcheevos/src/rcheevos/value.c
 --- melonDS.orig/src/rcheevos/src/rcheevos/value.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rcheevos/value.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rcheevos/value.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,933 @@
 +#include "rc_internal.h"
 +
@@ -37090,7 +37096,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rcheevos/value.c melonDS.ra/src/rcheev
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/aes.h melonDS.ra/src/rcheevos/src/rhash/aes.h
 --- melonDS.orig/src/rcheevos/src/rhash/aes.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/aes.h	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/aes.h	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,49 @@
 +#ifndef AES_H
 +#define AES_H
@@ -37143,7 +37149,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/aes.h melonDS.ra/src/rcheevos/sr
 +#endif /* AES_H */
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/cdreader.c melonDS.ra/src/rcheevos/src/rhash/cdreader.c
 --- melonDS.orig/src/rcheevos/src/rhash/cdreader.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/cdreader.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/cdreader.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,838 @@
 +#include "rc_hash_internal.h"
 +
@@ -37985,7 +37991,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/cdreader.c melonDS.ra/src/rcheev
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash.c melonDS.ra/src/rcheevos/src/rhash/hash.c
 --- melonDS.orig/src/rcheevos/src/rhash/hash.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/hash.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/hash.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,1402 @@
 +#include "rc_hash.h"
 +
@@ -39391,7 +39397,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash.c melonDS.ra/src/rcheevos/s
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_disc.c melonDS.ra/src/rcheevos/src/rhash/hash_disc.c
 --- melonDS.orig/src/rcheevos/src/rhash/hash_disc.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/hash_disc.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/hash_disc.c	2026-03-06 21:37:07.046799886 +0000
 @@ -0,0 +1,1340 @@
 +#include "rc_hash.h"
 +
@@ -40735,7 +40741,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_disc.c melonDS.ra/src/rchee
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_encrypted.c melonDS.ra/src/rcheevos/src/rhash/hash_encrypted.c
 --- melonDS.orig/src/rcheevos/src/rhash/hash_encrypted.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/hash_encrypted.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/hash_encrypted.c	2026-03-06 21:37:07.050799942 +0000
 @@ -0,0 +1,566 @@
 +#include "rc_hash_internal.h"
 +
@@ -41305,7 +41311,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_encrypted.c melonDS.ra/src/
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_rom.c melonDS.ra/src/rcheevos/src/rhash/hash_rom.c
 --- melonDS.orig/src/rcheevos/src/rhash/hash_rom.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/hash_rom.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/hash_rom.c	2026-03-06 21:37:07.050799942 +0000
 @@ -0,0 +1,426 @@
 +#include "rc_hash_internal.h"
 +
@@ -41735,7 +41741,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_rom.c melonDS.ra/src/rcheev
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_zip.c melonDS.ra/src/rcheevos/src/rhash/hash_zip.c
 --- melonDS.orig/src/rcheevos/src/rhash/hash_zip.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/hash_zip.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/hash_zip.c	2026-03-06 21:37:07.050799942 +0000
 @@ -0,0 +1,460 @@
 +#include "rc_hash_internal.h"
 +
@@ -42199,7 +42205,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/hash_zip.c melonDS.ra/src/rcheev
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/md5.c melonDS.ra/src/rcheevos/src/rhash/md5.c
 --- melonDS.orig/src/rcheevos/src/rhash/md5.c	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/md5.c	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/md5.c	2026-03-06 21:37:07.050799942 +0000
 @@ -0,0 +1,382 @@
 +/*
 +  Copyright (C) 1999, 2000, 2002 Aladdin Enterprises.  All rights reserved.
@@ -42585,7 +42591,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/md5.c melonDS.ra/src/rcheevos/sr
 +}
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/md5.h melonDS.ra/src/rcheevos/src/rhash/md5.h
 --- melonDS.orig/src/rcheevos/src/rhash/md5.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/md5.h	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/md5.h	2026-03-06 21:37:07.050799942 +0000
 @@ -0,0 +1,91 @@
 +/*
 +  Copyright (C) 1999, 2002 Aladdin Enterprises.  All rights reserved.
@@ -42680,7 +42686,7 @@ diff -rupbN melonDS.orig/src/rcheevos/src/rhash/md5.h melonDS.ra/src/rcheevos/sr
 +#endif /* md5_INCLUDED */
 diff -rupbN melonDS.orig/src/rcheevos/src/rhash/rc_hash_internal.h melonDS.ra/src/rcheevos/src/rhash/rc_hash_internal.h
 --- melonDS.orig/src/rcheevos/src/rhash/rc_hash_internal.h	1970-01-01 00:00:00.000000000 +0000
-+++ melonDS.ra/src/rcheevos/src/rhash/rc_hash_internal.h	2026-02-19 15:16:12.448948008 +0000
++++ melonDS.ra/src/rcheevos/src/rhash/rc_hash_internal.h	2026-03-06 21:37:07.050799942 +0000
 @@ -0,0 +1,116 @@
 +#ifndef RC_HASH_INTERNAL_H
 +#define RC_HASH_INTERNAL_H


### PR DESCRIPTION
Still experimental and hardcore achievements not supported. 

But before only software renderer would chow retro achievements, not but now work on both OpenGL backends. 