### PR TITLE
linux: bump RK3566 to kernel 6.19.5

### DIFF
--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -32,11 +32,11 @@ case ${DEVICE} in
     ;;
   *)
     case ${DEVICE} in
-      SM8250|SM8650|H700)
+      SM8250|SM8650|H700|RK3566)
         PKG_VERSION="6.19.5"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
-      S922X|RK3399|RK3566|SM8550)
+      S922X|RK3399|SM8550)
         PKG_VERSION="6.18.13"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;


### PR DESCRIPTION
Move RK3566 from 6.18.13 to 6.19.5, aligning with SM8250/SM8650/H700. All existing RK3566 device patches apply cleanly against 6.19.5. Secondary PR inbound for mali-kbase.