### PR TITLE
mali-bifrost: 6.19 compat and MGLRU/madvise support

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/patches/mali-bifrost/003-mali-bifrost-madvise-mglru.patch
+++ b/projects/ROCKNIX/devices/RK3566/patches/mali-bifrost/003-mali-bifrost-madvise-mglru.patch
@@ -1,0 +1,60 @@
+From: Joel Wirāmu Pauling <aenertia@aenertia.net>
+Date: Thu, 26 Feb 2026 20:00:00 +1300
+Subject: [PATCH] mali: bifrost: Enable madvise and MGLRU reclaim for native kbase mem
+
+Strip VM_IO and VM_PFNMAP from CPU VMAs backed by KBASE_MEM_TYPE_NATIVE
+allocations so that:
+
+  1. madvise(MADV_DONTNEED) works correctly from libmali/libmali-vulkan,
+     allowing userspace to hint purgeable GPU buffers back to the kernel.
+
+  2. Linux MGLRU (CONFIG_LRU_GEN + LRU_GEN_WALKS_MMU) can age and reclaim
+     these pages via hardware pgtable walks, improving memory pressure
+     handling on constrained RK3566 devices.
+
+VM_IO and VM_PFNMAP are intentionally preserved on KBASE_MEM_TYPE_IMPORTED_UMM
+(dma-buf/scanout) mappings, which may back non-RAM memory and require the
+original pfn-mapping semantics for correct operation.
+
+VM_MIXEDMAP is not applied: native allocations are homogeneous struct-page
+mappings and do not require mixed pfn/page handling. Setting it here would
+confuse follow_page() and page migration.
+
+VM_NOHUGEPAGE is added to prevent spurious THP promotion races. The RK3566
+kernel is built with CONFIG_TRANSPARENT_HUGEPAGE_MADVISE and the ROCKNIX
+memory manager triggers vm.compact_memory at runtime; without this flag,
+compaction could attempt to collapse 4K GPU buffer pages into a hugepage
+during a concurrent fault-in, causing blank screen hangs on the compositor.
+
+Kernel config confirmed: LRU_GEN=y, LRU_GEN_ENABLED=y, LRU_GEN_WALKS_MMU=y,
+TRANSPARENT_HUGEPAGE_MADVISE=y (Linux 6.18, aarch64, ROCKNIX RK3566).
+
+---
+ product/kernel/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/product/kernel/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c b/product/kernel/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c
+--- a/product/kernel/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c
++++ b/product/kernel/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c
+@@ -1240,6 +1240,21 @@ static int kbase_cpu_mmap(struct kbase_context *kctx, struct kbase_va_region *re
+ 
+ 	__vm_flags_mod(vma, VM_DONTCOPY | VM_DONTDUMP | VM_DONTEXPAND | VM_IO, 0);
+ 
++	/*
++	 * ROCKNIX/MGLRU: For native struct-page-backed GPU allocations, strip
++	 * VM_IO and VM_PFNMAP so that madvise(MADV_DONTNEED) is honoured by the
++	 * kernel and MGLRU (LRU_GEN_WALKS_MMU) can age and reclaim these pages.
++	 *
++	 * KBASE_MEM_TYPE_IMPORTED_UMM (dma-buf/scanout) is deliberately excluded:
++	 * those mappings may cover non-RAM pfns and must retain VM_IO/VM_PFNMAP.
++	 *
++	 * VM_NOHUGEPAGE guards against THP promotion races during vm.compact_memory
++	 * triggered by the ROCKNIX memory manager (TRANSPARENT_HUGEPAGE_MADVISE).
++	 */
++	if (reg->cpu_alloc->type == KBASE_MEM_TYPE_NATIVE) {
++		vm_flags_clear(vma, VM_IO | VM_PFNMAP);
++		vm_flags_set(vma, VM_NOHUGEPAGE);
++	}
+ 	vma->vm_ops = &kbase_vm_ops;
+ 	vma->vm_private_data = map;
+ 

--- a/projects/ROCKNIX/packages/linux-drivers/mali-bifrost/patches/001-fix-mm_get_unmapped_area-6.19.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/mali-bifrost/patches/001-fix-mm_get_unmapped_area-6.19.patch
@@ -1,0 +1,13 @@
+--- a/product/kernel/include/linux/version_compat_defs.h
++++ b/product/kernel/include/linux/version_compat_defs.h
+@@ -418,7 +418,9 @@
+ kbase_mm_get_unmapped_area_helper(struct mm_struct *mm, struct file *filp, unsigned long addr,
+ 				  unsigned long len, unsigned long pgoff, unsigned long flags)
+ {
+-#if (KERNEL_VERSION(6, 10, 0) <= LINUX_VERSION_CODE)
++#if (KERNEL_VERSION(6, 19, 0) <= LINUX_VERSION_CODE)
++	return mm_get_unmapped_area(filp, addr, len, pgoff, flags);
++#elif (KERNEL_VERSION(6, 10, 0) <= LINUX_VERSION_CODE)
+ 	return mm_get_unmapped_area(mm, filp, addr, len, pgoff, flags);
+ #else
+ 	return mm->get_unmapped_area(filp, addr, len, pgoff, flags);

--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -32,11 +32,11 @@ case ${DEVICE} in
     ;;
   *)
     case ${DEVICE} in
-      SM8250|SM8650|H700)
+      SM8250|SM8650|H700|RK3566)
         PKG_VERSION="6.19.5"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
-      S922X|RK3399|RK3566|SM8550)
+      S922X|RK3399|SM8550)
         PKG_VERSION="6.18.13"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;


### PR DESCRIPTION
mali-bifrost: 6.19 compat and MGLRU/madvise support
Fix mm_get_unmapped_area() signature change in kernel 6.19 where the
struct mm_struct* first parameter was removed. Adds version check
for >= 6.19 to use new signature. Applies to all mali-bifrost targets
(RK3566, RK3326, S922X).

Also enables Multi-Gen LRU (MGLRU) reclaim and madvise compatibility
in Mali kbase driver for RK3566. VM_NOHUGEPAGE prevents kernel fault
failures during standard 4K Mali buffer mapping under compaction. 

REF #2388 