### PR TITLE
systemd: reduce default service stop timeout to 5s

### DIFF
--- a/projects/ROCKNIX/packages/network/iwd/system.d/iwd.service
+++ b/projects/ROCKNIX/packages/network/iwd/system.d/iwd.service
@@ -13,6 +13,7 @@ ExecStart=/usr/lib/iwd
 NotifyAccess=main
 LimitNPROC=1
 Restart=on-failure
+TimeoutStopSec=1s
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
 #PrivateTmp=true
 #NoNewPrivileges=true

--- a/projects/ROCKNIX/packages/sysutils/systemd/config/system.conf.d/10-shutdown-timeout.conf
+++ b/projects/ROCKNIX/packages/sysutils/systemd/config/system.conf.d/10-shutdown-timeout.conf
@@ -1,0 +1,7 @@
+[Manager]
+# Reduce default service stop timeout from 90s to 5s.
+# ROCKNIX uses a read-only squashfs root with persistent storage at /storage/.
+# Network services don't need graceful shutdown — only filesystem sync matters,
+# which is handled by systemd's built-in shutdown ordering.
+DefaultTimeoutStopSec=5s
+DefaultTimeoutAbortSec=5s

--- a/projects/ROCKNIX/packages/sysutils/systemd/package.mk
+++ b/projects/ROCKNIX/packages/sysutils/systemd/package.mk
@@ -266,6 +266,10 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/etc/udev/rules.d
   ln -sf /storage/.config/udev.rules.d ${INSTALL}/etc/udev/rules.d
 
+  # system manager timeout overrides
+  mkdir -p ${INSTALL}/etc/systemd/system.conf.d
+  cp -PR ${PKG_DIR}/config/system.conf.d/* ${INSTALL}/etc/systemd/system.conf.d/
+
   # journald
   ln -sf /storage/.cache/journald.conf.d ${INSTALL}/usr/lib/systemd/journald.conf.d
 }

--- a/projects/ROCKNIX/packages/sysutils/systemd/system.d/systemd-resolved.service.d/override.conf
+++ b/projects/ROCKNIX/packages/sysutils/systemd/system.d/systemd-resolved.service.d/override.conf
@@ -3,3 +3,4 @@
 # Fixes error: NAMESPACE "Failed to set up mount namespacing" which can occur based on overlayfs setup speed
 PrivateTmp=no
 ProtectSystem=full
+TimeoutStopSec=1s


### PR DESCRIPTION
Noticed during testing - this is already set for some things - this makes it consistent.

On ROCKNIX's read-only squashfs root, network services don't need graceful shutdown — only persistent storage sync matters.  Services like iwd and systemd-resolved can hang for 90s (the systemd default) on shutdown/reboot, blocking device access during development and causing poor user experience on handheld gaming devices.

Changes:
- Add system.conf.d/10-shutdown-timeout.conf with DefaultTimeoutStopSec=5s and DefaultTimeoutAbortSec=5s
- Add TimeoutStopSec=1s to iwd.service (matches existing pattern used by avahi, bluez, sshd, samba)
- Add TimeoutStopSec=1s to systemd-resolved override