### PR TITLE
inputplumber - INSECURE_DISABLE_POLKIT

### DIFF
--- a/projects/ROCKNIX/packages/tools/inputplumber/package.mk
+++ b/projects/ROCKNIX/packages/tools/inputplumber/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="inputplumber"
-PKG_VERSION="v0.74.2"
+PKG_VERSION="v0.75.2"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ShadowBlip/InputPlumber"
 PKG_URL="https://github.com/ShadowBlip/InputPlumber/releases/download/${PKG_VERSION}/inputplumber-aarch64.tar.gz"

--- a/projects/ROCKNIX/packages/tools/inputplumber/sources/usr/lib/systemd/system/inputplumber.service
+++ b/projects/ROCKNIX/packages/tools/inputplumber/sources/usr/lib/systemd/system/inputplumber.service
@@ -6,6 +6,7 @@ Type=dbus
 BusName=org.shadowblip.InputPlumber
 Environment=LOG_LEVEL=info
 Environment=HIDE_DEVICES_FROM_ROOT=1
+Environment=INSECURE_DISABLE_POLKIT=1
 ExecStart=/usr/bin/inputplumber
 ProtectSystem=full
 


### PR DESCRIPTION
We don't have the `polkitd` service running. Adding it to the build is not straightforward.

`INSECURE_DISABLE_POLKIT` env var added to inputplumber in v0.75.2: https://github.com/ShadowBlip/InputPlumber/releases/tag/v0.75.2

Tested on my Odin 2