### PR TITLE
RK3566: add power optimizations (govtuning + PipeWire)

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/filesystem/etc/profile.d/100-rk3566-govtuning
+++ b/projects/ROCKNIX/devices/RK3566/filesystem/etc/profile.d/100-rk3566-govtuning
@@ -1,0 +1,16 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+# RK3566: CPU DVFS drives I2C to PMIC; rate-limit ondemand to 300 ms (schedutil uses DTS clock-latency).
+
+ondemand() {
+  set_cpu_gov ondemand
+  set_dmc_gov ondemand
+  local gov="/sys/devices/system/cpu/cpufreq/ondemand"
+  if [ -d "$gov" ]; then
+    echo 300000 > "$gov/sampling_rate" 2>/dev/null
+    echo 80 > "$gov/up_threshold" 2>/dev/null
+    echo 10 > "$gov/sampling_down_factor" 2>/dev/null
+    echo 1 > "$gov/io_is_busy" 2>/dev/null
+  fi
+}

--- a/projects/ROCKNIX/devices/RK3566/filesystem/usr/share/pipewire/pipewire-pulse.conf.d/99-rk3566-power.conf
+++ b/projects/ROCKNIX/devices/RK3566/filesystem/usr/share/pipewire/pipewire-pulse.conf.d/99-rk3566-power.conf
@@ -1,0 +1,3 @@
+pulse.properties = {
+    pulse.idle.timeout = 5
+}

--- a/projects/ROCKNIX/devices/RK3566/filesystem/usr/share/pipewire/pipewire.conf.d/99-rk3566-power.conf
+++ b/projects/ROCKNIX/devices/RK3566/filesystem/usr/share/pipewire/pipewire.conf.d/99-rk3566-power.conf
@@ -1,0 +1,4 @@
+context.properties = {
+    default.clock.power-of-two-quantum = true
+    default.clock.min-quantum = 1024
+}


### PR DESCRIPTION
Governor tuning (100-rk3566-govtuning):
Boards that feed the CPU from an external I2C PMIC (RK8600, SYR827, RK817, etc.) suffer from interrupt storms that drain battery: every DVFS voltage change goes over I2C, so aggressive scaling causes excessive traffic and wakeups. Rate-limit ondemand (300 ms sampling, tuned thresholds) to reduce I2C churn while keeping responsiveness. This is what other distro are using for 

PipeWire (99-rk3566-power.conf):
- pulse: idle timeout 5 s
- pipewire: power-of-two quantum, min quantum 1024 For lower CPU wakeups and predictable latency on handhelds.