### PR TITLE
freqfunctions: fix boost OPPs not reachable when CPU overclock enabled

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
+++ b/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
@@ -79,19 +79,36 @@ onlinethreads() {
   set_online_threads ${1} ${2}
 }
 
+# Ensure boost OPPs are reachable by propagating cpuinfo_max_freq
+# to scaling_max_freq. Some cpufreq drivers (SCMI) do not update
+# scaling_max_freq when boost is enabled, preventing governors from
+# selecting boost frequencies even when "Enable CPU Overclock" is on.
+apply_boost_freq() {
+  if [ -f /sys/devices/system/cpu/cpufreq/boost ]; then
+    echo 1 > /sys/devices/system/cpu/cpufreq/boost 2>/dev/null
+    for POLICY in $(ls /sys/devices/system/cpu/cpufreq 2>/dev/null | grep policy[0-9]); do
+      local max=$(cat /sys/devices/system/cpu/cpufreq/${POLICY}/cpuinfo_max_freq 2>/dev/null)
+      [ -n "$max" ] && echo "$max" > /sys/devices/system/cpu/cpufreq/${POLICY}/scaling_max_freq 2>/dev/null
+    done
+  fi
+}
+
 performance() {
   set_cpu_gov performance
   set_dmc_gov performance
+  apply_boost_freq
 }
 
 ondemand() {
   set_cpu_gov ondemand
   set_dmc_gov ondemand
+  apply_boost_freq
 }
 
 schedutil() {
   set_cpu_gov schedutil
   set_dmc_gov ondemand
+  apply_boost_freq
 }
 
 powersave() {


### PR DESCRIPTION
When "Enable CPU Overclock" is turned on in ES, governors still could not reach boost frequencies because scaling_max_freq was not updated. Some cpufreq drivers (notably SCMI on Rockchip) do not propagate boost OPPs to scaling_max_freq when boost is enabled via sysfs.

Add apply_boost_freq() which unconditionally enables boost and writes cpuinfo_max_freq to scaling_max_freq for each policy. Called from performance(), ondemand(), and schedutil() governor functions.

Safe on all targets — guarded by /sys/devices/system/cpu/cpufreq/boost existence check.