### PR TITLE
RK3566: bump kernel to 6.19.5

### DIFF
--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -32,11 +32,11 @@ case ${DEVICE} in
     ;;
   *)
     case ${DEVICE} in
-      SM8250|SM8550|SM8650|H700)
+      SM8250|SM8550|SM8650|H700|RK3566)
         PKG_VERSION="6.19.5"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
-      S922X|RK3399|RK3566)
+      S922X|RK3399)
         PKG_VERSION="6.18.13"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;


### PR DESCRIPTION
Move RK3566 from kernel 6.18.13 to 6.19.5.

Depends on: #2409 2409 (mali-bifrost unified + compat patches) The mm_get_unmapped_area() signature changed in 6.19 — mali_kbase will not compile without the compat patch from PR #2409.