### PR TITLE
cicd: add pull_request_template and ai-generated label workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )
+
+## Testing
+
+* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
+* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)
+
+## Additional Context
+
+* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)
+
+---
+
+### AI Usage
+
+While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
+helps set the right context for reviewers.
+
+**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

--- a/.github/workflows/ai-usage-label.yml
+++ b/.github/workflows/ai-usage-label.yml
@@ -1,0 +1,85 @@
+name: Add AI Usage Label
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-ai-usage:
+    name: Check AI Usage
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Check/Create ai-generated label with red color
+        id: check_create_label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ai-generated',
+                color: 'd73a49',
+                description: 'This PR was generated or assisted by AI tools'
+              })
+            } catch (error) {
+              const alreadyExists =
+                error.status === 422 &&
+                error.response?.data?.errors?.some(e => e.code === 'already_exists')
+
+              if (alreadyExists) {
+                console.log('Label already exists, continuing')
+                return true
+              }
+
+              console.log('Unhandled error:', error)
+              throw error
+            }
+
+      - name: Check for AI usage in PR description
+        id: check_ai
+        run: |
+          PR_BODY="${{ github.event.pull_request.body }}"
+          
+          if echo "$PR_BODY" | grep -P "(?s)Did you use AI tools to help write this code\?.*(YES|PARTIALLY)" > /dev/null; then
+            echo "ai_used=true" >> $GITHUB_OUTPUT
+          else
+            echo "ai_used=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add ai-generated label
+        if: steps.check_ai.outputs.ai_used == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ai-generated']
+            })
+
+      - name: Remove ai-generated label if not applicable
+        if: steps.check_ai.outputs.ai_used == 'false'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ai-generated'
+              })
+            } catch (error) {
+              if (error.status === 404) {
+                console.log('Label not found, skipping removal')
+                return true
+              }
+
+              console.log('Unhandled error:', error)
+              throw error
+            }


### PR DESCRIPTION
[Previous](https://github.com/ROCKNIX/distribution/pull/2415) PR closed due to force push.

Adds a very basic PR template with AI Usage disclaimer.

If set to `YES` or `PARTIALLY` this triggers a workflow to label the PR as `ai-generated`

PRs labeled as `ai-generated` can be handled differently, de-prioritized or else. Folks who're not transparent about AI usage declaration can be warned or blocked for further contribution.

Sample PR: https://github.com/edemirkan/rocknix-distribution/pull/13

@porschemad911 To answer your question in the previous PR, I added that now. It specifically checks case sensitive YES or PARTIAL response after `Did you use AI tools to help write this code?` question.