### PR TITLE
RK3566: bump rkbin and BL31 firmware

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/packages/u-boot-Generic/package.mk
+++ b/projects/ROCKNIX/devices/RK3566/packages/u-boot-Generic/package.mk
@@ -21,7 +21,7 @@ pre_make_target() {
   PKG_UBOOT_CONFIG="anbernic-rgxx3-rk3566_defconfig"
   PKG_RKBIN="$(get_build_dir rkbin)"
   PKG_MINILOADER="spl/u-boot-spl.bin"
-  PKG_BL31="${PKG_RKBIN}/bin/rk35/rk3568_bl31_v1.44.elf"
+  PKG_BL31="${PKG_RKBIN}/bin/rk35/rk3568_bl31_v1.45.elf"
   PKG_DDR_BIN="${PKG_RKBIN}/bin/rk35/rk3568_ddr_1056MHz_v1.23.bin"
 }
 

--- a/projects/ROCKNIX/devices/RK3566/packages/u-boot-Specific/package.mk
+++ b/projects/ROCKNIX/devices/RK3566/packages/u-boot-Specific/package.mk
@@ -22,7 +22,7 @@ pre_make_target() {
   PKG_UBOOT_CONFIG="quartz64-a-rk3566_defconfig"
   PKG_RKBIN="$(get_build_dir rkbin)"
   PKG_MINILOADER="spl/u-boot-spl.bin"
-  PKG_BL31="${PKG_RKBIN}/bin/rk35/rk3568_bl31_v1.44.elf"
+  PKG_BL31="${PKG_RKBIN}/bin/rk35/rk3568_bl31_v1.45.elf"
   PKG_DDR_BIN="${PKG_RKBIN}/bin/rk35/rk3568_ddr_1056MHz_v1.23.bin"
 }
 

--- a/projects/ROCKNIX/packages/tools/rkbin/package.mk
+++ b/projects/ROCKNIX/packages/tools/rkbin/package.mk
@@ -3,17 +3,27 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="rkbin"
-PKG_VERSION="7c35e21a8529b3758d1f051d1a5dc62aae934b2b"
 PKG_LICENSE="nonfree"
 PKG_SITE="https://github.com/rockchip-linux/rkbin"
-PKG_URL="https://github.com/rockchip-linux/rkbin/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="rkbin: Rockchip Firmware and Tool Binaries"
 PKG_TOOLCHAIN="manual"
+
+case "${DEVICE}" in
+  RK3588)
+    # Pin rk3588 here until it hits mainline
+    PKG_VERSION="7c35e21a8529b3758d1f051d1a5dc62aae934b2b"
+    ;;
+  *)
+    PKG_VERSION="74213af1e952c4683d2e35952507133b61394862"
+    ;;
+esac
+
+PKG_URL="https://github.com/rockchip-linux/rkbin/archive/${PKG_VERSION}.tar.gz"
 
 post_unpack() {
   # RK3326: tune TPL for UART5 used on K36 clones
   cp -v ${PKG_BUILD}/bin/rk33/rk3326_ddr_333MHz_*.bin ${PKG_BUILD}/rk3326_ddr_uart5.bin
-  ${PKG_BUILD}/tools/ddrbin_tool rk3326 -g ${PKG_BUILD}/rk3326_ddr_uart5.txt ${PKG_BUILD}/rk3326_ddr_uart5.bin
+  ${PKG_BUILD}/tools/ddrbin_tool.py rk3326 -g ${PKG_BUILD}/rk3326_ddr_uart5.txt ${PKG_BUILD}/rk3326_ddr_uart5.bin
   sed -i 's|uart id=.*$|uart id=5|' ${PKG_BUILD}/rk3326_ddr_uart5.txt
-  ${PKG_BUILD}/tools/ddrbin_tool rk3326 ${PKG_BUILD}/rk3326_ddr_uart5.txt ${PKG_BUILD}/rk3326_ddr_uart5.bin >/dev/null
+  ${PKG_BUILD}/tools/ddrbin_tool.py rk3326 ${PKG_BUILD}/rk3326_ddr_uart5.txt ${PKG_BUILD}/rk3326_ddr_uart5.bin >/dev/null
 }


### PR DESCRIPTION
  - rkbin bumped to ef49d0c2 (fixes ddrbin_tool → ddrbin_tool.py)
  - BL31 v1.44 → v1.45 for both Generic and Specific images

BL31 v1.45 is a safe upgrade validated on RG353P (Generic) and RGDS (Specific). Required for DMC devfreq support (PR #2423).