### PR TITLE
RK356x: lazy PMIC pinctrl for RK817/RK809 SLPPIN + ON/OFF source logging

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3566-powkiddy-rk2023.dtsi
@@ -464,8 +464,10 @@
 		assigned-clock-parents = <&cru CLK_I2S1_8CH_TX>;
 		#clock-cells = <1>;
 		#sound-dai-cells = <0>;
-		pinctrl-names = "default";
+		pinctrl-names = "default", "pmic-sleep", "pmic-power-off";
 		pinctrl-0 = <&i2s1m0_mclk>, <&pmic_int_l>;
+		pinctrl-1 = <&soc_slppin_slp>;
+		pinctrl-2 = <&soc_slppin_gpio>;
 		wakeup-source;
 		system-power-controller;
 
@@ -724,6 +726,19 @@
 		pmic_int_l: pmic-int-l {
 			rockchip,pins =
 				<0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+
+		/* GPIO0_PA2 = PMIC SLPPIN mux states for suspend/resume/poweroff */
+		soc_slppin_slp: soc-slppin-slp {
+			rockchip,pins = <0 RK_PA2 1 &pcfg_pull_none>;
+		};
+
+		soc_slppin_gpio: soc-slppin-gpio {
+			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_output_low>;
+		};
+
+		soc_slppin_gpio_idle: soc-slppin-gpio-idle {
+			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 

--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -671,8 +671,10 @@
 		clocks = <&cru I2S1_MCLKOUT_TX>;
 		interrupt-parent = <&gpio0>;
 		interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
+		pinctrl-names = "default", "pmic-sleep", "pmic-power-off";
 		pinctrl-0 = <&i2s1m0_mclk>, <&pmic_int_l>;
-		pinctrl-names = "default";
+		pinctrl-1 = <&soc_slppin_slp>;
+		pinctrl-2 = <&soc_slppin_gpio>;
 		#sound-dai-cells = <0>;
 		system-power-controller;
 		wakeup-source;
@@ -978,6 +980,19 @@
 		pmic_int_l: pmic-int-l {
 			rockchip,pins =
 				<0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+
+		/* GPIO0_PA2 = PMIC SLPPIN mux states for suspend/resume/poweroff */
+		soc_slppin_slp: soc-slppin-slp {
+			rockchip,pins = <0 RK_PA2 1 &pcfg_pull_none>;
+		};
+
+		soc_slppin_gpio: soc-slppin-gpio {
+			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_output_low>;
+		};
+
+		soc_slppin_gpio_idle: soc-slppin-gpio-idle {
+			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 

--- a/projects/ROCKNIX/devices/RK3566/patches/linux/0029-mfd-rk8xx-otg-disable-and-clear-flags-on-shutdown.patch
+++ b/projects/ROCKNIX/devices/RK3566/patches/linux/0029-mfd-rk8xx-otg-disable-and-clear-flags-on-shutdown.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joel Wiramu Pauling <aenertia@aenertia.net>
+Date: Fri, 20 Mar 2026 00:00:00 +1300
+Subject: [PATCH] mfd: rk8xx: OTG disable + clear stale flags before
+ RK817/RK809 shutdown
+
+Disable the OTG switch (USB VBUS) before poweroff to prevent current
+backfeed during the power-down sequence. Clear all three interrupt
+status registers (W1C) that persist across reboots to prevent stale
+UVLO/OVP flags from interfering with the next power-on.
+
+Both operations are added BEFORE the existing SLPPIN_DN_FUN write,
+which is preserved — it is required for DEV_OFF to cleanly power
+down all PMIC rails.
+
+ADB register tracing on Android/GammaOS (RG-DS) confirmed that the
+BSP disables OTG_SWITCH before shutdown. INT_STS flags persist across
+reboot and should be cleared to avoid false fault detection.
+
+Signed-off-by: Joel Wiramu Pauling <aenertia@aenertia.net>
+---
+--- a/drivers/mfd/rk8xx-core.c
++++ b/drivers/mfd/rk8xx-core.c
+@@ -15,6 +15,7 @@
+ #include <linux/mfd/rk808.h>
+ #include <linux/mfd/core.h>
+ #include <linux/module.h>
++#include <linux/delay.h>
+ #include <linux/property.h>
+ #include <linux/regmap.h>
+ #include <linux/reboot.h>
+@@ -679,6 +680,19 @@
+ 	case RK809_ID:
+ 	case RK817_ID:
++		/* Disable OTG switch to cut USB VBUS before poweroff */
++		regmap_update_bits(rk808->regmap,
++				   RK817_POWER_EN_REG(3),
++				   BIT(2) | BIT(6), BIT(6));
++		mdelay(1);
++
++		/* Clear stale interrupt status flags (W1C) —
++		 * INT_STS registers at 0xf8, 0xfa, 0xfc (mask regs at 0xf9, 0xfb, 0xfd) */
++		regmap_write(rk808->regmap, RK817_INT_STS_REG0, 0xff);
++		regmap_write(rk808->regmap, RK817_INT_STS_REG1, 0xff);
++		regmap_write(rk808->regmap, RK817_INT_STS_REG2, 0xff);
++
+ 		ret = regmap_update_bits(rk808->regmap,
+ 					 RK817_SYS_CFG(3),
+ 					 RK817_SLPPIN_FUNC_MSK,

--- a/projects/ROCKNIX/devices/RK3566/patches/linux/0030-mfd-rk8xx-log-on-off-source-for-RK817-RK809.patch
+++ b/projects/ROCKNIX/devices/RK3566/patches/linux/0030-mfd-rk8xx-log-on-off-source-for-RK817-RK809.patch
@@ -1,32 +1,34 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Zetarancio <zetarancio@users.noreply.github.com>
 Date: Sun, 16 Mar 2026 00:00:00 +0000
-Subject: [PATCH] mfd: rk8xx: log ON_SOURCE/OFF_SOURCE at probe for
- RK817/RK809
+Subject: [PATCH] mfd: rk8xx: log ON/OFF_SOURCE and clear stale INT_STS at
+ probe for RK817/RK809
 
 Read the RK817/RK809 ON_SOURCE and OFF_SOURCE registers at probe time
 and log them as dev_info.  These registers record the reason the PMIC
 last powered on (power key, RTC alarm, plug-in, etc.) and the reason
 it last powered off (software, power key, UVLO, etc.).
 
-This is a standard BSP practice that aids debugging
-power-cycle and battery-drain issues: a single dmesg line tells you
-whether the last boot was a cold start, a watchdog reset, or an RTC
-wake, and whether the previous shutdown was clean or caused by
-under-voltage.
+Also clear all three interrupt status registers (W1C) at probe time.
+After a hard fault (PMIC OCP brownout, watchdog reset), stale INT_STS
+flags persist across reboot and can confuse the PMIC power state
+machine, preventing clean boot. Clearing them early in probe — before
+any interrupt handler is registered — ensures a clean slate regardless
+of how the previous session ended.
 
 Signed-off-by: Zetarancio <zetarancio@users.noreply.github.com>
+Signed-off-by: Joel Wiramu Pauling <aenertia@aenertia.net>
 ---
- drivers/mfd/rk8xx-core.c | 15 +++++++++++++++
- 1 file changed, 15 insertions(+)
+ drivers/mfd/rk8xx-core.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
 
 diff --git a/drivers/mfd/rk8xx-core.c b/drivers/mfd/rk8xx-core.c
 --- a/drivers/mfd/rk8xx-core.c
 +++ b/drivers/mfd/rk8xx-core.c
-@@ -899,6 +899,21 @@
+@@ -899,6 +899,28 @@
  		}
  	}
- 
+
 +	switch (rk808->variant) {
 +	case RK809_ID:
 +	case RK817_ID: {
@@ -36,6 +38,13 @@ diff --git a/drivers/mfd/rk8xx-core.c b/drivers/mfd/rk8xx-core.c
 +		    !regmap_read(rk808->regmap, RK817_OFF_SOURCE_REG, &off_source))
 +			dev_info(dev, "ON_SOURCE=0x%02x OFF_SOURCE=0x%02x\n",
 +				 on_source, off_source);
++
++		/* Clear stale interrupt status flags (W1C) from previous
++		 * session — prevents confused PMIC state after hard faults
++		 * (OCP brownout, watchdog) where no clean shutdown ran. */
++		regmap_write(rk808->regmap, RK817_INT_STS_REG0, 0xff);
++		regmap_write(rk808->regmap, RK817_INT_STS_REG1, 0xff);
++		regmap_write(rk808->regmap, RK817_INT_STS_REG2, 0xff);
 +		break;
 +	}
 +	default:

--- a/projects/ROCKNIX/devices/RK3566/patches/linux/0030-mfd-rk8xx-log-on-off-source-for-RK817-RK809.patch
+++ b/projects/ROCKNIX/devices/RK3566/patches/linux/0030-mfd-rk8xx-log-on-off-source-for-RK817-RK809.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zetarancio <zetarancio@users.noreply.github.com>
+Date: Sun, 16 Mar 2026 00:00:00 +0000
+Subject: [PATCH] mfd: rk8xx: log ON_SOURCE/OFF_SOURCE at probe for
+ RK817/RK809
+
+Read the RK817/RK809 ON_SOURCE and OFF_SOURCE registers at probe time
+and log them as dev_info.  These registers record the reason the PMIC
+last powered on (power key, RTC alarm, plug-in, etc.) and the reason
+it last powered off (software, power key, UVLO, etc.).
+
+This is a standard BSP practice that aids debugging
+power-cycle and battery-drain issues: a single dmesg line tells you
+whether the last boot was a cold start, a watchdog reset, or an RTC
+wake, and whether the previous shutdown was clean or caused by
+under-voltage.
+
+Signed-off-by: Zetarancio <zetarancio@users.noreply.github.com>
+---
+ drivers/mfd/rk8xx-core.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/mfd/rk8xx-core.c b/drivers/mfd/rk8xx-core.c
+--- a/drivers/mfd/rk8xx-core.c
++++ b/drivers/mfd/rk8xx-core.c
+@@ -899,6 +899,21 @@
+ 		}
+ 	}
+ 
++	switch (rk808->variant) {
++	case RK809_ID:
++	case RK817_ID: {
++		unsigned int on_source, off_source;
++
++		if (!regmap_read(rk808->regmap, RK817_ON_SOURCE_REG, &on_source) &&
++		    !regmap_read(rk808->regmap, RK817_OFF_SOURCE_REG, &off_source))
++			dev_info(dev, "ON_SOURCE=0x%02x OFF_SOURCE=0x%02x\n",
++				 on_source, off_source);
++		break;
++	}
++	default:
++		break;
++	}
++
+ 	return 0;
+ }
+ EXPORT_SYMBOL_GPL(rk8xx_probe);

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/system.d/sway.service
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/system.d/sway.service
@@ -14,7 +14,8 @@ EnvironmentFile=-/run/sway/sway-daemon.conf
 WorkingDirectory=/storage
 ExecStartPre=-/usr/lib/sway/sway-config
 ExecStart=/usr/bin/sway.sh
-ExecStopPost=-/bin/sh -c 'for bl in /sys/class/backlight/*/bl_power; do echo 4 > "$bl" 2>/dev/null; done'
+ExecStartPost=-/bin/sh -c 'for bl in /sys/class/backlight/*/bl_power; do echo 0 > "$bl" 2>/dev/null; done'
+ExecStopPost=-/bin/sh -c 'systemctl is-system-running --quiet || for bl in /sys/class/backlight/*/bl_power; do echo 4 > "$bl" 2>/dev/null; done'
 Restart=always
 RestartSec=5
 

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/system.d/sway.service
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/system.d/sway.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/run/sway/sway-daemon.conf
 WorkingDirectory=/storage
 ExecStartPre=-/usr/lib/sway/sway-config
 ExecStart=/usr/bin/sway.sh
+ExecStopPost=-/bin/sh -c 'for bl in /sys/class/backlight/*/bl_power; do echo 4 > "$bl" 2>/dev/null; done'
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
This fixes a source of  phantom drain on 353(m/p/v) and RGB30 whilst off many users encounter. Original testing done by @Zetarancio targeting the miyoo flip and then adapted to mainline compatible patchset for both rk3566 and rk3568 targets by myself with LLM assistance. 

Tested on miyoo flip (out of tree), rgb30,353p, rgds (with -next branch).


Lazy pinctrl acquisition for RK817/RK809 SLPPIN (GPIO0_PA2):
- Defer pinctrl_get() to first suspend/shutdown instead of probe time
- Prevents devm_pinctrl_get() from applying default state during probe, which can reconfigure PA2 while PMIC register state is unknown
- Cache pinctrl handle + states in struct rk808 after first load
- Falls back to register-only path if no DTS pinctrl states defined
- BSP sequence: NULL function → 2ms delay → select state → function write

DTS changes for Anbernic RG-DS and Powkiddy RK2023:
- pinctrl-0 (default) has NO slppin state (matches stock Android)
- pinctrl-1 = soc_slppin_slp (PMU_SLEEP for suspend)
- pinctrl-2 = soc_slppin_gpio (GPIO low for poweroff)

ON/OFF source logging reads RK817_ON_SOURCE_REG and RK817_OFF_SOURCE_REG at probe time for power-cycle debugging (cold-start, watchdog, RTC wake, clean shutdown vs under-voltage).