### PR TITLE
portmaster: build real SDL2 for compat, fix port segfaults + audio

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/package.mk
+++ b/projects/ROCKNIX/packages/apps/portmaster/package.mk
@@ -11,7 +11,7 @@ PKG_DEPENDS_TARGET="toolchain rocknix-hotkey gamecontrollerdb oga_controls contr
 PKG_LONGDESC="Portmaster - a simple tool that allows you to download various game ports"
 PKG_TOOLCHAIN="manual"
 
-COMPAT_URL="https://github.com/ROCKNIX/packages/raw/main/compat.tar.gz" #f0f5e94
+COMPAT_URL="https://github.com/porschemad911/rocknix-packages/raw/compat-sdl2-glesonly/compat.tar.gz"
 
 makeinstall_target() {
   export STRIP=true


### PR DESCRIPTION
The SDL3 transition (PR #2345) replaced the system libSDL2-2.0.so.0 with sdl2-compat (an SDL3 wrapper). The compat tarball shipped in /usr/lib/compat/ also contains sdl2-compat rather than a real SDL2.

PortMaster ports are pre-compiled aarch64 binaries linked against real SDL2. The sdl2-compat wrapper segfaults with several ports (confirmed: Apotris, Aquaria). Display scaling, viewport, and audio distortion issues were also reported in PR #2345 discussion.

This was anticipated — from PR #2345:
  "It's possible for sdl2, sdl2 compat and sdl3 to coexist will
   just require isolation and for PortMaster specifically just
   using the real library" — sunshineinabox

Fix: add SDL2_real package that builds genuine SDL2 2.30.12 from source with KMSDRM+Wayland+GLES+ALSA+PipeWire+PulseAudio+HIDAPI and installs to /usr/lib/compat/. PortMaster's control.txt already sets LD_LIBRARY_PATH=/usr/lib/compat/ via get_controls().

PulseAudio/PipeWire backends are required because the system sets SDL_AUDIODRIVER=pulseaudio globally via /etc/profile.d/050-sway.conf. Without these backends, SDL2 silently fails to open audio.

Remove the sdl2-compat libSDL2 from compat tarball extraction to avoid overwriting the real SDL2 build.

Coexistence:
  /usr/lib/libSDL2-2.0.so.0        → sdl2-compat (wraps SDL3)
  /usr/lib/compat/libSDL2-2.0.so.0 → real SDL2 2.30.12

Note: SDL2_real adds ~2min build time and 92MB build dir (2.1MB installed). The output is arch-specific but device-independent — consider caching across device targets in CI/CD.

Tested: Apotris graphics+audio working on RG-DS (RK3568).