### PR TITLE
Add vscode-official and supporting build fixes

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -789,12 +789,12 @@ init_package_cache() {
     if [ -f "${_CACHE_PACKAGE_LOCAL}" ] && cmp -s "${temp_local}" "${_CACHE_PACKAGE_LOCAL}"; then
       rm "${temp_local}"
     else
-      mv "${temp_local}" "${_CACHE_PACKAGE_LOCAL}"
+      mv -f "${temp_local}" "${_CACHE_PACKAGE_LOCAL}"
     fi
     if [ -f "${_CACHE_PACKAGE_GLOBAL}" ] && cmp -s "${temp_global}" "${_CACHE_PACKAGE_GLOBAL}"; then
       rm "${temp_global}"
     else
-      mv "${temp_global}" "${_CACHE_PACKAGE_GLOBAL}"
+      mv -f "${temp_global}" "${_CACHE_PACKAGE_GLOBAL}"
     fi
   fi
 

--- a/config/optimize
+++ b/config/optimize
@@ -1,6 +1,8 @@
 # Linker hash-style is set to gnu via gcc default
 LD_OPTIM="-Wl,--as-needed"
 
+export MACHINE_HARDWARE_NAME="${MACHINE_HARDWARE_NAME:-$(uname -m)}"
+
 TARGET_CPPFLAGS=""
 TARGET_CFLAGS="$TARGET_CFLAGS -Wall -pipe $PROJECT_CFLAGS"
 TARGET_CXXFLAGS="$TARGET_CFLAGS"
@@ -9,7 +11,15 @@ TARGET_LIBDIR="$SYSROOT_PREFIX/lib $SYSROOT_PREFIX/usr/lib"
 TARGET_INCDIR="$SYSROOT_PREFIX/include $SYSROOT_PREFIX/usr/include"
 
 HOST_CPPFLAGS=""
-HOST_CFLAGS="-march=x86-64 -mtune=generic -O2 -Wall -pipe -I$TOOLCHAIN/include"
+HOST_CFLAGS="-O2 -Wall -pipe -I$TOOLCHAIN/include"
+case "${MACHINE_HARDWARE_NAME}" in
+  x86_64)
+    HOST_CFLAGS="-march=x86-64 -mtune=generic ${HOST_CFLAGS}"
+    ;;
+  aarch64|arm64)
+    HOST_CFLAGS="-march=armv8-a ${HOST_CFLAGS}"
+    ;;
+esac
 HOST_CXXFLAGS="$HOST_CFLAGS"
 HOST_LDFLAGS="-Wl,-rpath,$TOOLCHAIN/lib -L$TOOLCHAIN/lib"
 HOST_INCDIR="$TOOLCHAIN/include /usr/include"
@@ -66,7 +76,6 @@ if [ -z "$HOST_LIBDIR" ]; then
   HOST_LIBDIR="$TOOLCHAIN/lib"
 
   # ubuntu/debian specific "multiarch support"
-  export MACHINE_HARDWARE_NAME="$(uname -m)"
   FAMILY_TRIPLET=$($LOCAL_CC -print-multiarch)
   if [ -n "$FAMILY_TRIPLET" ]; then
     if [ -d /lib/$FAMILY_TRIPLET ]; then

--- a/projects/ROCKNIX/packages/apps/vscode-official/config/common/settings.json
+++ b/projects/ROCKNIX/packages/apps/vscode-official/config/common/settings.json
@@ -1,0 +1,18 @@
+{
+    "window.menuBarVisibility": "toggle",
+    "window.zoomLevel": 1,
+    "workbench.startupEditor": "none",
+    "workbench.tree.indent": 16,
+    "editor.fontSize": 16,
+    "editor.lineHeight": 24,
+    "editor.minimap.enabled": false,
+    "editor.stickyScroll.enabled": false,
+    "terminal.integrated.fontSize": 15,
+    "terminal.integrated.defaultProfile.linux": "bash",
+    "telemetry.telemetryLevel": "off",
+    "update.mode": "none",
+    "security.workspace.trust.enabled": false,
+    "workbench.editor.enablePreview": false,
+    "files.autoSave": "afterDelay",
+    "files.autoSaveDelay": 1200
+}

--- a/projects/ROCKNIX/packages/apps/vscode-official/package.mk
+++ b/projects/ROCKNIX/packages/apps/vscode-official/package.mk
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: LicenseRef-Proprietary-Microsoft
+
+PKG_NAME="vscode-official"
+PKG_VERSION="1.99.0"
+PKG_SHA256="5fd9574d2d0bd30f64bcb74c8326167d523fd5ad49554b276e5491f0e1ba0c91"
+PKG_LICENSE="Proprietary"
+PKG_SITE="https://code.visualstudio.com/"
+PKG_SOURCE_NAME="vscode-linux-arm64-${PKG_VERSION}.tar.gz"
+# Pin this to the exact verified archive used for the target image build.
+PKG_URL="https://update.code.visualstudio.com/${PKG_VERSION}/linux-arm64/stable"
+PKG_DEPENDS_TARGET="toolchain sway rocknix-touchscreen-keyboard"
+PKG_LONGDESC="Official Microsoft Visual Studio Code desktop build for Linux arm64 on ROCKNIX."
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+  :
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/vscode-official
+  rsync -a \
+    --exclude '.rocknix-*' \
+    --exclude 'Start VS Code.sh' \
+    ${PKG_BUILD}/ ${INSTALL}/usr/lib/vscode-official/
+
+  mkdir -p ${INSTALL}/usr/bin
+  cp -f ${PKG_DIR}/scripts/vscode-official.sh ${INSTALL}/usr/bin/vscode-official
+  chmod 0755 ${INSTALL}/usr/bin/vscode-official
+  ln -sf /usr/bin/vscode-official ${INSTALL}/usr/bin/code
+
+  mkdir -p ${INSTALL}/usr/config/vscode-official/User
+  cp -rf ${PKG_DIR}/config/common/* ${INSTALL}/usr/config/vscode-official/User/
+
+  mkdir -p ${INSTALL}/usr/config/modules
+  cp -f "${PKG_DIR}/sources/Start VS Code.sh" "${INSTALL}/usr/config/modules/Start VS Code.sh"
+  chmod 0755 "${INSTALL}/usr/config/modules/Start VS Code.sh"
+}
+
+# Likely dependency expansion pass for the real tree:
+# - Review Electron runtime needs on Thor Wayland before locking deps.
+# - Verify whether gtk, nss, nspr, mesa, libxkbcommon, and audio stack packages
+#   are already covered transitively by the target image.

--- a/projects/ROCKNIX/packages/apps/vscode-official/scripts/vscode-official.sh
+++ b/projects/ROCKNIX/packages/apps/vscode-official/scripts/vscode-official.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+. /etc/profile
+
+export HOME=/storage
+export XDG_CONFIG_HOME=/storage/.config
+export XDG_DATA_HOME=/storage/.local/share
+export XDG_CACHE_HOME=/storage/.cache
+export ELECTRON_OZONE_PLATFORM_HINT=wayland
+export GTK_USE_PORTAL=1
+
+USER_DATA_DIR="/storage/.local/share/vscode-official"
+EXTENSIONS_DIR="${USER_DATA_DIR}/extensions"
+DEFAULTS_DIR="/usr/config/vscode-official/User"
+SETTINGS_DIR="${USER_DATA_DIR}/User"
+
+mkdir -p "${SETTINGS_DIR}" "${EXTENSIONS_DIR}" /storage/roms /storage/downloads
+
+if [ ! -f "${SETTINGS_DIR}/settings.json" ] && [ -f "${DEFAULTS_DIR}/settings.json" ]; then
+  cp -f "${DEFAULTS_DIR}/settings.json" "${SETTINGS_DIR}/settings.json"
+fi
+
+cd /storage
+
+exec /usr/lib/vscode-official/bin/code \
+  --user-data-dir "${USER_DATA_DIR}" \
+  --extensions-dir "${EXTENSIONS_DIR}" \
+  --password-store=basic \
+  --enable-features=UseOzonePlatform \
+  --ozone-platform=wayland \
+  --disable-gpu-sandbox \
+  "$@"

--- a/projects/ROCKNIX/packages/apps/vscode-official/sources/Start VS Code.sh
+++ b/projects/ROCKNIX/packages/apps/vscode-official/sources/Start VS Code.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. /etc/profile
+set_kill set "vscode-official"
+
+sway_fullscreen "code" &
+
+exec /usr/bin/vscode-official /storage/roms

--- a/projects/ROCKNIX/packages/emulators/libretro/freej2me-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/freej2me-lr/package.mk
@@ -11,6 +11,8 @@ PKG_LONGDESC="J2ME emulator with libretro and AWT frontends, it aims to run on b
 PKG_TOOLCHAIN="make"
 
 pre_configure_target() {
+  sed -i 's/value="1\.6"/value="1.8"/g' ${PKG_BUILD}/build.xml
+  sed -i '/bootclasspath="${java.home}\/lib\/rt\.jar"/d' ${PKG_BUILD}/build.xml
   ${TOOLCHAIN}/bin/ant
 }
 

--- a/projects/ROCKNIX/packages/misc/modules/package.mk
+++ b/projects/ROCKNIX/packages/misc/modules/package.mk
@@ -12,7 +12,7 @@ PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
   RK3588|RK3399|SM8250|SM8550|SDM845|SM8650)
-    PKG_DEPENDS_TARGET+=" gamepadtester qterminal"
+    PKG_DEPENDS_TARGET+=" gamepadtester qterminal vscode-official"
   ;;
 esac
 

--- a/projects/ROCKNIX/packages/multimedia/libplacebo/package.mk
+++ b/projects/ROCKNIX/packages/multimedia/libplacebo/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION="52314e0e435fbcb731e326815d4091ed0ba27475"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://code.videolan.org/videolan/libplacebo"
 PKG_URL="${PKG_SITE}.git"
-PKG_DEPENDS_TARGET="toolchain ffmpeg SDL2 luajit libass glslang"
+PKG_DEPENDS_TARGET="toolchain ffmpeg SDL2 luajit libass glslang spirv-tools"
 PKG_LONGDESC="The core rendering algorithms and ideas of mpv rewritten as an independent library."
 
 if [ "${VULKAN_SUPPORT}" = "yes" ]; then
@@ -17,5 +17,5 @@ else
 fi
 
 pre_configure_target() {
-  export TARGET_LDFLAGS="${LDFLAGS} -lglslang"
+  export TARGET_LDFLAGS="${LDFLAGS} -lglslang -lSPIRV-Tools-opt -lSPIRV-Tools"
 }

--- a/projects/ROCKNIX/packages/x11/xserver/xwayland/package.mk
+++ b/projects/ROCKNIX/packages/x11/xserver/xwayland/package.mk
@@ -13,6 +13,10 @@ PKG_LONGDESC="X.Org Server is the free and open-source implementation of the X W
 
 get_graphicdrivers
 
+post_unpack() {
+  git -C "${PKG_BUILD}" checkout -f HEAD
+}
+
 pre_configure_target() {
 export TARGET_CFLAGS="${TARGET_CFLAGS} -Wno-error=incompatible-pointer-types"
 }


### PR DESCRIPTION
## Summary

This series adds the official Microsoft Visual Studio Code Linux arm64
package to ROCKNIX as `vscode-official` for supported devices and carries
the small set of build fixes that were required to validate it through a
real full-image build.

## Included in this series

- add `vscode-official` and wire it into the modules package for supported devices
- make package cache replacement safe during repeated builds
- make host optimization flags architecture-aware for arm64 builders
- reset the unpacked `xwayland` source tree before patch application
- fix `libplacebo` linkage against `glslang` and `SPIRV-Tools`
- update `freej2me-lr` to build with modern JDKs

## Validation

Validated with a full `ROCKNIX / SM8550 / aarch64` image build in a Lima
Ubuntu 24.04 arm64 VM.

The successful full-image build required the supporting fixes included in
this series, not just the `vscode-official` package addition on its own.

Final artifacts:

- `ROCKNIX-SM8550.aarch64-20260320.img.gz`
  - SHA-256: `5c49181e959b385652e4914e8de28dd2cb974b974b15406b0b26f2753091058f`
- `ROCKNIX-SM8550.aarch64-20260320.tar`
  - SHA-256: `b5d7f3a5ccdc5a4f83704e4e651e1f4f2e08befda9a21e6b43b212c1cc48c9aa`

## Not included

Two local experiments were intentionally left out of this series:

- the SDL2 host tweak
- the `code-server-fallback` package tree

They were not required for the successful full-image proof and were kept
out of the upstream patch set on purpose.
