### PR TITLE
drastic-sa - S922X libmali cleanup

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/package.mk
@@ -10,10 +10,6 @@ PKG_DEPENDS_TARGET="toolchain rocknix-hotkey"
 PKG_LONGDESC="Install Drastic Launcher script, will download bin on first run"
 PKG_TOOLCHAIN="make"
 
-if [ "${DEVICE}" = "S922X" ]; then
-  PKG_DEPENDS_TARGET+=" libegl"
-fi
-
 make_target() {
   ${CC} ${CFLAGS} -shared -fPIC -o libdrastouch.so \
     ${PKG_DIR}/sources/libdrastouch.c -ldl

--- a/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/scripts/start_drastic.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/scripts/start_drastic.sh
@@ -82,16 +82,6 @@ fi
 cd /storage/.config/drastic/
 @HOTKEY@
 
-# Fix for libmali gpu driver on S922X platform
-if [ "${HW_DEVICE}" = "S922X" ]; then
-  GPUDRIVER=$(/usr/bin/gpudriver)
-
-  if [ "${GPUDRIVER}" = "libmali" ]; then
-    export SDL_VIDEO_GL_DRIVER=\/usr\/lib\/egl\/libGL.so.1
-    export SDL_VIDEO_EGL_DRIVER=\/usr\/lib\/egl\/libEGL.so.1
-  fi
-fi
-
 $GPTOKEYB "drastic" -c "drastic.gptk" &
 # Fix actual touch inputs by replacing touch->mouse translation and add hw mic support
 export LD_PRELOAD="/usr/lib/libdrastouch.so"


### PR DESCRIPTION
Workaround is no longer required here with the unified Amlogic / Rockchip libmali package build.

Tested on my OGU.