### PR TITLE
GPU governor - remove intermediate values to align with CPU governor

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
+++ b/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
@@ -105,14 +105,15 @@ get_gpu_performance_level() {
 
 gpu_performance_level() {
   case ${1} in
-    profile_peak)
-      set_gpu_gov performance
-      ;;
-    auto|profile_standard)
+    auto)
       set_gpu_gov ondemand
       ;;
-    low)
-      set_gpu_gov powersave
+    *)
+      set_gpu_gov ${1}
       ;;
   esac
+}
+
+get_available_gpu_governors() {
+  echo "default"; tr " " "\n" < $GPU_FREQ/available_governors | grep \[a-z\]
 }

--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -307,3 +307,8 @@ if [ -e "/storage/.config/duckstation/settings.ini" ]; then
   # no confirmation popup
   sed -i 's/ConfirmPowerOff = true/ConfirmPowerOff = false/' /storage/.config/duckstation/settings.ini
 fi
+
+# Clean old GPU 'governor' values
+sed -i '/gpuperf=low/d' /storage/.config/system/configs/system.cfg
+sed -i '/gpuperf=profile_standard/d' /storage/.config/system/configs/system.cfg
+sed -i '/gpuperf=profile_peak/d' /storage/.config/system/configs/system.cfg

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="a1821c1e5fde4faace989139cac891ee26d878d4"
+PKG_VERSION="d6fd911e246ec5bb0cd2ec6b7e2782369dd1d93f"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
Related ES PR: https://github.com/ROCKNIX/emulationstation-next/pull/8

Currently there is an additional layer between the user and GPU governors, with values:

- Balanced
- Battery Focus
- Best Performance

These values are translated into governors by the `gpu_performance_level()` function. This is unnecessary and also doesn't cater for the full set of available GPU governors (eg the userspace governor is currently not accessible).

In contrast the CPU governors are presented to the user for direct selection.

This PR:
- provides the `get_available_gpu_governors()` function for ES
- allows the GPU governor to be set directly
- cleans old `gpuperf` values from system config

Tested on my OGU