### PR TITLE
[SM6115]Fix suspend and controller breaking at suspend

### DIFF
--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0011-serial-qcom-geni-disable-irq-during-suspend.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0011-serial-qcom-geni-disable-irq-during-suspend.patch
@@ -1,0 +1,34 @@
+--- a/drivers/tty/serial/qcom_geni_serial.c
++++ b/drivers/tty/serial/qcom_geni_serial.c
+@@ -1851,7 +1851,9 @@
+ 	struct qcom_geni_serial_port *port = dev_get_drvdata(dev);
+ 	struct uart_port *uport = &port->uport;
+ 	struct qcom_geni_private_data *private_data = uport->private_data;
++	int ret;
+
++	disable_irq(uport->irq);
+ 	/*
+ 	 * This is done so we can hit the lowest possible state in suspend
+ 	 * even with no_console_suspend
+@@ -1860,7 +1862,12 @@
+ 		geni_icc_set_tag(&port->se, QCOM_ICC_TAG_ACTIVE_ONLY);
+ 		geni_icc_set_bw(&port->se);
+ 	}
+-	return uart_suspend_port(private_data->drv, uport);
++	ret = uart_suspend_port(private_data->drv, uport);
++	if (ret) {
++		enable_irq(uport->irq);
++		return ret;
++	}
++	return 0;
+ }
+
+ static int qcom_geni_serial_resume(struct device *dev)
+@@ -1875,6 +1882,7 @@
+ 		geni_icc_set_tag(&port->se, QCOM_ICC_TAG_ALWAYS);
+ 		geni_icc_set_bw(&port->se);
+ 	}
++	enable_irq(uport->irq);
+ 	return ret;
+ }
+

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/030-suspend_mode
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/030-suspend_mode
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile.d/001-functions
+
+MYSLEEPMODE=$(get_setting system.suspendmode)
+if [ -z "${MYSLEEPMODE}" ]
+then
+  /usr/bin/suspendmode freeze
+fi


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
* To prevent double suspending
* Patch IRQ bug

## Testing

* **How was this tested?** 
* Tested on Mangmi Air X
* **Test results:**
* Suspends and unsuspends without flickering
* Controller comes back everytime without error

## Additional Context

* **Add any other information that might be helpful for the reviewer**
* Need to check drain

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** No
