### PR TITLE
[RG DS] Fix Sway+SDL3 window sizing in DraStic hook

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
+++ b/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <unistd.h>
 
 static int ds_screen_width = 256;
 static int ds_screen_height = 192;
@@ -16,6 +17,7 @@ static int phys_height = -1;
 static int logical_width = -1;
 static int logical_height = -1;
 static int actual_touch = 0;
+static int has_swaymsg = 0;
 
 // Microphone monitoring
 static SDL_AudioDeviceID mic_device = 0;
@@ -93,25 +95,27 @@ void SDL_SetWindowSize(SDL_Window* window, int w, int h) {
         return;
     }
 
-    // Toggle between nudged (menu visible on one screen) and full (gameplay).
-    // SDL3 respects Sway's tiling (even for floating windows???), so we call swaymsg directly.
-    if (!nudged) {
-        int target_w = (xy_idx == 1) ? (int)(phys_width * 0.85) : phys_width;
-        int target_h = (xy_idx == 2) ? (int)(phys_height * 0.85) : phys_height;
-        int pos_x = (xy_idx == 1) ? -(phys_width / 6) : 0;
-        int pos_y = (xy_idx == 2) ? -(phys_height / 6) : 0;
+    if (xy_idx > 0 && has_swaymsg) {
+        // Toggle between nudged (menu visible on one screen) and full (gameplay).
+        // SDL3 respects Sway's tiling (even for floating windows???), so we call swaymsg directly.
+        if (!nudged) {
+            int target_w = (xy_idx == 1) ? (int)(phys_width * 0.85) : phys_width;
+            int target_h = (xy_idx == 2) ? (int)(phys_height * 0.85) : phys_height;
+            int pos_x = (xy_idx == 1) ? -(phys_width / 6) : 0;
+            int pos_y = (xy_idx == 2) ? -(phys_height / 6) : 0;
 
-        snprintf(cmd, sizeof(cmd),
-            "swaymsg [app_id='drastic'] 'resize set %d %d, move absolute position %d %d'",
-            target_w, target_h, pos_x, pos_y);
-    } else {
-        snprintf(cmd, sizeof(cmd),
-            "swaymsg [app_id='drastic'] 'resize set %d %d, move absolute position 0 0'",
-            phys_width, phys_height);
+            snprintf(cmd, sizeof(cmd),
+                "swaymsg [app_id='drastic'] 'resize set %d %d, move absolute position %d %d'",
+                target_w, target_h, pos_x, pos_y);
+        } else {
+            snprintf(cmd, sizeof(cmd),
+                "swaymsg [app_id='drastic'] 'resize set %d %d, move absolute position 0 0'",
+                phys_width, phys_height);
+        }
+
+        nudged = !nudged;
+        system(cmd);
     }
-
-    nudged = !nudged;
-    system(cmd);
 }
 
 SDL_Renderer* SDL_CreateRenderer(SDL_Window* window, int index, Uint32 flags) {
@@ -333,6 +337,8 @@ static void init(void) {
     real_SDL_CloseAudioDevice = dlsym(RTLD_NEXT, "SDL_CloseAudioDevice");
     real_SDL_GetNumAudioDevices = dlsym(RTLD_NEXT, "SDL_GetNumAudioDevices");
     real_SDL_GetAudioDeviceName = dlsym(RTLD_NEXT, "SDL_GetAudioDeviceName");
+
+    has_swaymsg = (access("/usr/bin/swaymsg", X_OK) == 0);
 
     const char* threshold_str = getenv("DSHOOK_MIC_THRESH");
     if (threshold_str) {

--- a/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
+++ b/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
@@ -79,33 +79,39 @@ SDL_Window* SDL_CreateWindow(const char* title, int x, int y, int w, int h, Uint
     if (num_displays > 1)
         xy_idx = (last_width > last_height) ? 1 : 2;
 
-    // Set window size to single screen to fix offsets when resizing
-    return real_SDL_CreateWindow(title, 0, 0, last_width, last_height, flags);
+    return real_SDL_CreateWindow(title, 0, 0, phys_width, phys_height, flags);
 }
 
 void SDL_SetWindowSize(SDL_Window* window, int w, int h) {
-    static int init_resize = 2;
+    static int init_calls = 2;
+    static int nudged = 0;
+    char cmd[256];
 
-    if (init_resize > 0) {
-        real_SDL_SetWindowSize(window, w, h);
-        init_resize -= 1;
+    // DraStic makes two SetWindowSize calls during startup, so we just dont()
+    if (init_calls > 0) {
+        init_calls--;
+        return;
     }
 
-    // Force window size to fill AFTER DraStic does its weird init thing
-    // Also check if this is a resize after init, if so, toggle a scale down to allow DraStic menu visibility
-    if (init_resize == 0) {
-        real_SDL_SetWindowSize(window, phys_width, phys_height);
-        init_resize = -1;
-    } else if (init_resize == -1) {
-        if (xy_idx == 1)
-            w = phys_width / 2;
-        if (xy_idx == 2)
-            h = phys_height / 2;
+    // Toggle between nudged (menu visible on one screen) and full (gameplay).
+    // SDL3 respects Sway's tiling (even for floating windows???), so we call swaymsg directly.
+    if (!nudged) {
+        int target_w = (xy_idx == 1) ? (int)(phys_width * 0.85) : phys_width;
+        int target_h = (xy_idx == 2) ? (int)(phys_height * 0.85) : phys_height;
+        int pos_x = (xy_idx == 1) ? -(phys_width / 6) : 0;
+        int pos_y = (xy_idx == 2) ? -(phys_height / 6) : 0;
 
-        real_SDL_SetWindowSize(window, w, h);
-        init_resize = 0;
+        snprintf(cmd, sizeof(cmd),
+            "swaymsg [app_id='drastic'] 'resize set %d %d, move absolute position %d %d'",
+            target_w, target_h, pos_x, pos_y);
+    } else {
+        snprintf(cmd, sizeof(cmd),
+            "swaymsg [app_id='drastic'] 'resize set %d %d, move absolute position 0 0'",
+            phys_width, phys_height);
     }
 
+    nudged = !nudged;
+    system(cmd);
 }
 
 SDL_Renderer* SDL_CreateRenderer(SDL_Window* window, int index, Uint32 flags) {

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -158,8 +158,7 @@ fi
 
 # Anbernic RG DS touchscreen setup
 if [ "${QUIRK_DEVICE}" = "Anbernic RG DS" ]; then
-  echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' power on' >> $SWAY_HOME/config 
-  echo 'for_window [app_id="drastic"] output '"${second_con}"' power on, input "1046:911:Goodix_Capacitive_TouchScreen" map_to_output '"${con}" >> $SWAY_HOME/config
+  echo 'for_window [app_id="drastic"] floating enable, border none, move to output '"${con}"', move right 320, output '"${second_con}"' power on, input "1046:911:Goodix_Capacitive_TouchScreen" map_to_output '"${con}" >> $SWAY_HOME/config
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} power off" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"1046:911:Goodix_Capacitive_TouchScreen\"" >> $SWAY_HOME/config


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Fix libdrastouch DraStic hook on the RG DS (and possibly other devices later on) inherited from SDL3/sdl2-compat migration.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)

Built via docker and tested on RG DS directly by opening DraStic, checking if the screens span properly, and opening and closing DraStic's built-in menu to ensure decent-ish visibility. (Cheats menu is serviceable now! woo!)

* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

<img width="1280" height="480" alt="ingame" src="https://github.com/user-attachments/assets/97e65ff8-035b-4989-8d63-353fa20776d1" />
<img width="1280" height="480" alt="inmenu" src="https://github.com/user-attachments/assets/7ff9f96a-0d4a-493f-9d61-5b72ec086630" />
<img width="1280" height="480" alt="cheatmenu" src="https://github.com/user-attachments/assets/0fa04907-1d4d-4bc8-a160-0a4ce97ea623" />

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

Shouldn't affect single screen devices, but additional testing is always welcome.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

PARTIALLY: I wrote the logic and asked Claude to clean it up a bit. Originally the code snprintf's were long-ish and hard to interpret at first glance. Claude made the variables ternaries rather than separate if branches.