### PR TITLE
GPU governor - handle 'default' from EmulationStation

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
+++ b/projects/ROCKNIX/packages/rocknix/profile.d/099-freqfunctions
@@ -105,7 +105,7 @@ get_gpu_performance_level() {
 
 gpu_performance_level() {
   case ${1} in
-    auto)
+    auto|default)
       set_gpu_gov ondemand
       ;;
     *)

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="d6fd911e246ec5bb0cd2ec6b7e2782369dd1d93f"
+PKG_VERSION="af01158fdf26248d47050b0d740e939e837ef27a"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
## Summary

Handle 'default' GPU governor from EmulationStation

## Testing

Tested on my OGU

## Additional Context

Bump ES so it sends a 'default' GPU governor, and map this to the `ondemand / simple_ondemand` governor

Related ES PR: https://github.com/ROCKNIX/emulationstation-next/pull/9

### AI Usage

**Did you use AI tools to help write this code?** NO
