### PR TITLE
inputplumber - input_sense workaround / add SM6115 to yabasanshiro-sa logic

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/yabasanshiro-sa/scripts/start_yabasanshiro.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/yabasanshiro-sa/scripts/start_yabasanshiro.sh
@@ -39,7 +39,7 @@ then
   rm -f ${CONFIG_DIR}/keymapv2.json
 
   # Handle inputplumber platforms first
-  if [[ "${HW_DEVICE}" =~ SM8550|SM8650 ]]; then
+  if [[ "${HW_DEVICE}" =~ SM6115|SM8550|SM8650 ]]; then
     GAMEPAD="'InputPlumber GameController'"
   else
     # Check for js0, else fall back to joypad

--- a/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -74,6 +74,12 @@ FUNCTION_HOTKEY_BTN_EAST_EVENT="*(BTN_EAST), value 1*"
 FUNCTION_HOTKEY_BTN_BACK_EVENT="*(BTN_BACK), value 1*"
 FUNCTION_HOTKEY_KEY_RECORD_EVENT="*(KEY_RECORD), value 1*"
 
+### Inputplumber platforms need north and west swapped
+if [[ "${HW_DEVICE}" =~ SM6115|SM8550|SM8650 ]]; then
+  FUNCTION_HOTKEY_BTN_NORTH_EVENT="*(BTN_WEST), value 1*"
+  FUNCTION_HOTKEY_BTN_WEST_EVENT="*(BTN_NORTH), value 1*"
+fi
+
 FUNCTION_HOTKEY_TOUCH_EVENT="*(BTN_TOUCH), value 1*"
 
 TOUCHSCREEN_EVENTS=$(get_setting key.touchscreen.events)


### PR DESCRIPTION
## Summary

Fix input_sense mangohud / game guide hotkeys on inputplumber platforms.

Also add SM6115 to inputplumber platform list for yabasanshiro-sa.

## Testing

Tested on my Odin 2

## Additional Context

TODO - to fix properly, we should add an `INPUTPLUMBER` var to ROCKNIX build options.

---

### AI Usage

**Did you use AI tools to help write this code?** NO
