### PR TITLE
SDL3 EGL: try GLES API when desktop GL bind fails (Mali / gl4es)

### DIFF
--- a/projects/ROCKNIX/packages/graphics/SDL3/patches/0008-egl-check-eglBindAPI-return-value.patch
+++ b/projects/ROCKNIX/packages/graphics/SDL3/patches/0008-egl-check-eglBindAPI-return-value.patch
@@ -1,29 +1,34 @@
-Subject: [PATCH] video: egl: check eglBindAPI return value
+Subject: [PATCH] video: egl: fall back to GLES when desktop GL eglBindAPI fails
 
-eglBindAPI(EGL_OPENGL_API) can fail on GLES-only drivers (e.g. libmali)
-that do not support desktop OpenGL.  Without checking the return value,
-SDL proceeds to create what it thinks is a desktop GL context (but is
-actually GLES), then crashes when calling desktop GL functions on it.
+eglBindAPI(EGL_OPENGL_API) fails on GLES-only drivers (e.g. libmali)
+that do not support desktop OpenGL.  Rather than returning NULL (which
+breaks SDL 1.2 ports using gl4es through box86 → SDL2-compat → SDL3),
+fall back to EGL_OPENGL_ES_API so the context can still be created.
 
-Check the return value and fail early so the renderer fallback logic can
-try the next backend (opengles2).
+gl4es translates desktop GL calls into GLES internally, so an ES EGL
+context is correct on these devices.
 
 ---
- src/video/SDL_egl.c | 5 ++++-
- 1 file changed, 4 insertions(+), 1 deletion(-)
+ src/video/SDL_egl.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/src/video/SDL_egl.c b/src/video/SDL_egl.c
 --- a/src/video/SDL_egl.c
 +++ b/src/video/SDL_egl.c
-@@ -746,7 +746,10 @@
+@@ -746,7 +746,15 @@
      } else {
          _this->egl_data->apitype = EGL_OPENGL_API;
      }
 -    _this->egl_data->eglBindAPI(_this->egl_data->apitype);
 +    if (!_this->egl_data->eglBindAPI(_this->egl_data->apitype)) {
-+        SDL_SetError("Could not bind EGL API");
-+        return NULL;
++        /* GLES-only driver (e.g. libmali): desktop GL unavailable.
++         * Fall back to GLES so gl4es / ES-native apps still work. */
++        _this->egl_data->apitype = EGL_OPENGL_ES_API;
++        if (!_this->egl_data->eglBindAPI(_this->egl_data->apitype)) {
++            SDL_SetError("Could not bind EGL API (tried GL and GLES)");
++            return NULL;
++        }
 +    }
-
+ 
      egl_context = _this->egl_data->eglCreateContext(_this->egl_data->egl_display,
                                                      _this->egl_data->egl_config,


### PR DESCRIPTION
After this https://github.com/ROCKNIX/distribution/pull/2345 on GLES-only stacks, eglBindAPI can fail while GLES remains valid. SDL3 EGL path currently treats a failed desktop-GL bind as fatal and returned NULL, which breaks apps that request an OpenGL window through the legacy stack (e.g. SDL 1.2 → box86 → SDL2-compat → SDL3 with SDL_OPENGL). With this if binding EGL_OPENGL_API fails, SDL retries EGL_OPENGL_ES_API before failing and allows GL-on-GLES layers to work.

The prior hard failurre on eglBindAPI is ok on desktop GL drivers, but on embedded Mali builds that only expose the GLES EGL API, the first bind fails. Wayland/SDL renderer fallback paths do not apply to raw SDL_GL_CreateContext / legacy OpenGL window creation.

If eglBindAPI(EGL_OPENGL_API) fails, call eglBindAPI(EGL_OPENGL_ES_API) and continue when that succeeds.
If both fail, set a single clear error: Could not bind EGL API (tried GL and GLES).

Verified with a PortMaster title using box86 + gl4es on an RK3566 device where only the Mali GLES path is available: check the logs. 
Devices using native desktop GL (e.g. Mesa/Panfrost) are unaffected when EGL_OPENGL_API binds successfully on the first try and SHOULD BE unaffected when the first bind fails and then a retry is run.
[log-postpatch.txt](https://github.com/user-attachments/files/26317416/log-postpatch.txt)
[log-panfrost.txt](https://github.com/user-attachments/files/26317417/log-panfrost.txt)
[log-prepatch.txt](https://github.com/user-attachments/files/26317418/log-prepatch.txt)