### PR TITLE
post-update - clean azahar config after version bump

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -212,8 +212,9 @@ grep -q "^system\.suspend\.park_cores=" /storage/.config/system/configs/system.c
 grep -q "^system\.suspend\.dpms=" /storage/.config/system/configs/system.cfg ||
     sed -i '$ a\system.suspend.dpms=1' /storage/.config/system/configs/system.cfg
 
-# Wipe azahar gptokeyb mappings as they have changed
-rm -rf /storage/.config/azahar/*.gptk
+# Wipe azahar gptokeyb mappings and config file as they have changed
+rm -f /storage/.config/azahar/*.gptk
+rm -f /storage/.config/azahar/qt-config.ini
 
 # Clean RGB10X mupen64plus-sa config
 if echo ${QUIRK_DEVICE} | grep RGB10X; then


### PR DESCRIPTION
## Summary

post-update - clean azahar config after version bump

## Testing

Tested on my Gameforce ACE

## Additional Context

The azahar-sa `qt-config.ini` files have changed after the version bump to 2125.0.0

---

### AI Usage

**Did you use AI tools to help write this code?** NO
