### PR TITLE
linux - bump to 6.12.79 (RK3326)

### DIFF
--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -41,7 +41,7 @@ case ${DEVICE} in
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
       *)
-        PKG_VERSION="6.12.61"
+        PKG_VERSION="6.12.79"
         PKG_PATCH_DIRS+=" 6.12-LTS"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;


### PR DESCRIPTION
## Summary

linux - bump 6.12 LTS to 6.12.79

## Testing

Tested on my OGA BE - display, sound, controls, wifi, USB ethernet dongle, sleep all working fine

## Additional Context

Only affects RK3326 platform

---

### AI Usage

**Did you use AI tools to help write this code?** NO
