### PR TITLE
SM8250: add missing grub.cfg generation script

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/bootloader/grub
+++ b/projects/ROCKNIX/devices/SM8250/bootloader/grub
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
+
+source ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/options
+
+mkdir -p "${INSTALL}/usr/share/bootloader/EFI/BOOT"
+cat << EOF > "${INSTALL}/usr/share/bootloader/EFI/BOOT/grub.cfg"
+set timeout="0"
+set default=""
+
+menuentry 'Retroid Pocket 5' {
+    search --set -f /KERNEL
+    linux /KERNEL boot=LABEL=${DISTRO_BOOTLABEL} disk=LABEL=${DISTRO_DISKLABEL} grub_portable ${EXTRA_CMDLINE}
+    devicetree /sm8250-retroidpocket-rp5.dtb
+}
+menuentry 'Retroid Pocket Flip2' {
+    search --set -f /KERNEL
+    linux /KERNEL boot=LABEL=${DISTRO_BOOTLABEL} disk=LABEL=${DISTRO_DISKLABEL} grub_portable ${EXTRA_CMDLINE}
+    devicetree /sm8250-retroidpocket-flip2.dtb
+}
+menuentry 'Retroid Pocket Mini' {
+    search --set -f /KERNEL
+    linux /KERNEL boot=LABEL=${DISTRO_BOOTLABEL} disk=LABEL=${DISTRO_DISKLABEL} grub_portable ${EXTRA_CMDLINE}
+    devicetree /sm8250-retroidpocket-rpmini.dtb
+}
+menuentry 'Retroid Pocket Mini V2' {
+    search --set -f /KERNEL
+    linux /KERNEL boot=LABEL=${DISTRO_BOOTLABEL} disk=LABEL=${DISTRO_DISKLABEL} grub_portable ${EXTRA_CMDLINE}
+    devicetree /sm8250-retroidpocket-rpminiv2.dtb
+}
+EOF


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

PR #2457 (`1fcfc86`) switched SM8250 from `qcom-abl` to `arm-efi` (GRUB)
but did not include a `bootloader/grub` script to generate `grub.cfg`.

Without this script, GRUB boots with no configuration. The kernel receives
no cmdline parameters, so the init script cannot resolve
`boot=LABEL=ROCKNIX` and the device shuts down with:

> Unable to find volume labeled ROCKNIX

This adds the grub config generation script with menu entries for all
four SM8250 device variants (RP5, RPFlip2, RPMini, RPMiniV2).

## Testing

* **How was this tested?**
  - Root cause confirmed by comparing working arm-efi devices against
    SM8250 — all other arm-efi devices have a `bootloader/grub` script,
    SM8250 does not.
  - Verified that upstream nightly CICD images fail to boot on SM8250
    with the "Unable to find volume labeled ROCKNIX" error.
  - Traced the boot flow through `busybox/scripts/init` to confirm the
    failure occurs at `mount_common()` when `$boot` is empty (no cmdline).
  - Build tested targeting SM8250 aarch64.

* **Test results:**
  - Without fix: Device reaches GRUB → kernel boots → init fails at
    volume label detection → shutdown.
  - With fix: grub.cfg is generated with correct `boot=LABEL=ROCKNIX
    disk=LABEL=STORAGE` cmdline and device-specific DTB references.

## Additional Context

* Every device using `BOOTLOADER="arm-efi"` requires a `bootloader/grub`
  script to generate `grub.cfg`. SM8250 was the only arm-efi device
  missing this script after the revert in PR #2457.
* SM6115 also uses `mkimage_options="abl,grub,dtb"` — it may have a
  similar issue if its grub script is missing (not investigated here).

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY

AI tools were used to trace the boot failure through the init script,
identify the missing grub config generation script by comparing device
bootloader configurations, and cross-reference recent upstream commits.
The fix itself follows the established pattern used by other arm-efi
devices in the project.
