### PR TITLE
ppsspp-sa - add clock speed ES feature

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/ppsspp-sa/scripts/start_ppsspp.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/ppsspp-sa/scripts/start_ppsspp.sh
@@ -29,6 +29,7 @@ IRES=$(get_setting internal_resolution "${PLATFORM}" "${GAME}")
 GRENDERER=$(get_setting graphics_backend "${PLATFORM}" "${GAME}")
 SKIPB=$(get_setting skip_buffer_effects "${PLATFORM}" "${GAME}")
 VSYNC=$(get_setting vsync "${PLATFORM}" "${GAME}")
+CLOCK_SPEED=$(get_setting clock_speed "${PLATFORM}" "${GAME}")
 
 #Set the cores to use
 CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
@@ -87,6 +88,15 @@ fi
 		sed -i '/^VSyncInterval =/c\VSyncInterval = True' ${CONF_DIR}/${PPSSPP_INI}
 	else
 		sed -i '/^VSyncInterval =/c\VSyncInterval = False' ${CONF_DIR}/${PPSSPP_INI}
+	fi
+
+  #Clock Speed
+	if [ "${CLOCK_SPEED}" = "222" ]; then
+		sed -i '/^CPUSpeed =/c\CPUSpeed = 222' ${CONF_DIR}/${PPSSPP_INI}
+  elif [ "${CLOCK_SPEED}" = "333" ]; then
+		sed -i '/^CPUSpeed =/c\CPUSpeed = 333' ${CONF_DIR}/${PPSSPP_INI}
+	else
+		sed -i '/^CPUSpeed =/c\CPUSpeed = 0' ${CONF_DIR}/${PPSSPP_INI}
 	fi
 
 #Retroachievements

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -367,6 +367,11 @@
         <choice name="on" value="1"/>
         <choice name="off" value="0"/>
       </feature>
+      <feature name="clock speed">
+        <choice name="autodetect" value="0"/>
+        <choice name="222 mhz" value="222"/>
+        <choice name="333 mhz" value="333"/>
+      </feature>
      </features>
     </core>
    </cores>


### PR DESCRIPTION
## Summary

Add an ES feature for ppsspp-sa to allow the clock speed to be set to:

- autodetect (determined by the game)
- 222 MHz
- 333 MHz

## Testing

Tested on my OGU, Outrun 2006 runs much better at 333 MHz.

## Additional Context

The PPSSPP CPU could run at 333 MHz but Sony originally shipped it clocked at 222 MHz to save battery. Later the higher clock speed was unlocked for some games to use. Running a game at the higher clock speed can be helpful to avoid frame drops, but can also break compatibility with some games.

---

### AI Usage

**Did you use AI tools to help write this code?** NO
