### PR TITLE
duckstation-sa - fix set_kill

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/duckstation-sa/scripts/start_duckstation.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/duckstation-sa/scripts/start_duckstation.sh
@@ -4,7 +4,7 @@
 # Copyright (C) 2022-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 . /etc/profile
-set_kill set "-9 duckstation-mini"
+set_kill set "-9 AppRun.wrapped"
 
 # Filesystem vars
 IMMUTABLE_CONF_DIR="/usr/config/duckstation"

--- a/projects/ROCKNIX/packages/emulators/standalone/duckstation-sa/sources/Start Duckstation.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/duckstation-sa/sources/Start Duckstation.sh
@@ -4,7 +4,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 . /etc/profile
-set_kill set "-9 duckstation-sa"
+set_kill set "-9 AppRun.wrapped"
 
 # Filesystem vars
 IMMUTABLE_CONF_DIR="/usr/config/duckstation"


### PR DESCRIPTION
## Summary

Get L1 + Select + Start kill working again for duckstation-sa

## Testing

Tested on my OGU with bind mounts

## Additional Context

This has been broken since we switched away from duckstation mini

---

### AI Usage

**Did you use AI tools to help write this code?** NO
