### PR TITLE
linux - bump 6.18 LTS to 6.18.21

### DIFF
--- a/projects/ROCKNIX/devices/S922X/linux/linux.aarch64.conf
+++ b/projects/ROCKNIX/devices/S922X/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.18.20 Kernel Configuration
+# Linux/arm64 6.18.21 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-rocknix-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y

--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -37,7 +37,7 @@ case ${DEVICE} in
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
       S922X|RK3399|RK3566|SM6115)
-        PKG_VERSION="6.18.20"
+        PKG_VERSION="6.18.21"
         PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
         ;;
       *)


### PR DESCRIPTION
## Summary

linux - bump 6.18 LTS to 6.18.21

## Testing

Tested S922X on my OGU - works well

## Additional Context

Affects S922X, RK3399, RK3566 and SM6115

---

### AI Usage

**Did you use AI tools to help write this code?** NO
