### PR TITLE
portmaster - reinstate PREFER_GLES compatibility logic

### DIFF
--- a/projects/ROCKNIX/packages/apps/portmaster/package.mk
+++ b/projects/ROCKNIX/packages/apps/portmaster/package.mk
@@ -28,5 +28,10 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/compat
     curl -Lo ${PKG_BUILD}/compat.tar.gz ${COMPAT_URL}
     tar -xvf ${PKG_BUILD}/compat.tar.gz -C ${INSTALL}/usr/lib
-    rm -rf ${INSTALL}/usr/lib/compat/libSDL2-2.0.so.0*
+    
+    if [ "${PREFER_GLES}" = "yes" ]; then
+      mv ${INSTALL}/usr/lib/compat/libSDL2-2.0.so.0.gles ${INSTALL}/usr/lib/compat/libSDL2-2.0.so.0
+    else
+      rm -rf ${INSTALL}/usr/lib/compat/libSDL2-2.0.so.0.gles
+    fi
 }


### PR DESCRIPTION
## Summary

portmaster - reinstate PREFER_GLES compatibility logic

## Testing

TODO

## Additional Context

GLES-only SDL2 lib still required for Amlogic libmali

---

### AI Usage

**Did you use AI tools to help write this code?** NO
