### PR TITLE
Add LED control script variant for Anbernic RG DS

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/ledcontrol
@@ -1,0 +1,96 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+LED_PATH="/sys/class/leds"
+LED_STATUS=$(get_setting led.color)
+DEFAULT=green
+
+function led_state() {
+  echo ${2} >${LED_PATH}/${1}/brightness
+}
+
+function led_off() {
+    led_state green:power 0
+    led_state red:status 0
+    led_state amber:charging 0
+}
+
+function brightness() {
+  led_off
+  case ${1} in
+    green)
+      led_state green:power $2
+    ;;
+    red)
+      led_state red:status $2
+    ;;
+    amber)
+      led_state amber:charging $2
+    ;;
+  esac
+}
+
+GETBRIGHTNESS=$(get_setting led.brightness)
+if [ ! -z "${2}" ]
+then
+  LEDBRIGHTNESS=${2}
+else
+  LEDBRIGHTNESS=${GETBRIGHTNESS:-max}
+fi
+
+# on first run (no setting) or on new brightness update settings
+if [[ ${LEDBRIGHTNESS} != ${GETBRIGHTNESS} ]]; then
+  set_setting led.brightness ${LEDBRIGHTNESS}
+fi
+
+# expand aliases
+case ${LEDBRIGHTNESS} in
+  max)
+    LEDBRIGHTNESS=255
+  ;;
+  mid)
+    LEDBRIGHTNESS=63
+  ;;
+  min)
+    LEDBRIGHTNESS=15
+  ;;
+esac
+
+case ${1} in
+  default)
+    del_setting led.color
+    brightness ${DEFAULT} ${LEDBRIGHTNESS}
+  ;;
+  green|red|amber|off)
+    brightness ${1} ${LEDBRIGHTNESS}
+    set_setting led.color ${1}
+  ;;
+  discharging)
+    brightness ${LED_STATUS:-${DEFAULT}} ${LEDBRIGHTNESS}
+  ;;
+  charging)
+    if [ ! "${LED_STATUS}" = "off" ]
+    then
+      brightness amber ${LEDBRIGHTNESS}
+    fi
+  ;;
+  poweroff)
+    led_off
+  ;;
+  brightness)
+    brightness ${LED_STATUS:-${DEFAULT}} ${LEDBRIGHTNESS}
+  ;;
+  list)
+cat <<EOF
+default
+off
+green
+red
+amber
+EOF
+  ;;
+esac


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Use amber LED instead of red for charging. Green and Red share the same diffuser slot on this device, making charging indication invisible other than via the screen.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Tested with a mount bind over the original ledcontrol and plugging in the charger.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

Seems a tiny bit heavy handed to add a new script to change one word, but also seems like the 'correct' way to do it...?

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
