### PR TITLE
Updated thor dts to allow key-ayn button to register with Linux kernel.

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
@@ -16,6 +16,8 @@
 	gpio-keys {
 		compatible = "gpio-keys";
 
+		pinctrl-0 = <&volume_up_n &key_ayn_n>;
+
 		key-ayn {
 			label = "AYN Key";
 			debounce-interval = <15>;
@@ -417,6 +419,15 @@
 
 &mdss_dsi1_out {
 	qcom,te-source = "mdp_vsync_s";
+};
+
+&tlmm {
+	key_ayn_n: key-ayn-n-state {
+		pins = "gpio41";
+		function = "gpio";
+		bias-pull-up;
+		output-disable;
+	};
 };
 
 &remoteproc_adsp {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )
Fix `key-ayn` not being recognized in AYN Thor

## Testing\

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)
Built and tested again Ayn Thor Max

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO
NO