### PR TITLE
S922X - explicitly list SDL2_glesonly in ADDITIONAL_PACKAGES

### DIFF
--- a/projects/ROCKNIX/devices/S922X/options
+++ b/projects/ROCKNIX/devices/S922X/options
@@ -72,7 +72,7 @@
     FIRMWARE=""
 
   # Additional packages to install
-    ADDITIONAL_PACKAGES="libmali"
+    ADDITIONAL_PACKAGES="libmali SDL2_glesonly"
 
   # Debug tty path
     DEBUG_TTY="/dev/ttyAML0"


### PR DESCRIPTION
## Summary

Seems required to reliably build / include aarch64 `SDL2_glesonly` in the final image. It's a workaround at best until I can figure out what's going on.

## Testing

Tested on my OGU

## Additional Context

Currently `SDL2_glesonly` is built for `aarch64` and `arm`, but for some reason only the 32-bit lib makes it into the final image. Without this change, `SDL_glesonly` does not appear in the build plan at all (`tools/viewplan`).

---

### AI Usage

**Did you use AI tools to help write this code?** NO
