### PR TITLE
SDL2 glesonly change to dependency of libmali

### DIFF
--- a/projects/ROCKNIX/devices/S922X/options
+++ b/projects/ROCKNIX/devices/S922X/options
@@ -72,7 +72,7 @@
     FIRMWARE=""
 
   # Additional packages to install
-    ADDITIONAL_PACKAGES="libmali SDL2_glesonly"
+    ADDITIONAL_PACKAGES="libmali"
 
   # Debug tty path
     DEBUG_TTY="/dev/ttyAML0"

--- a/projects/ROCKNIX/packages/graphics/SDL2/package.mk
+++ b/projects/ROCKNIX/packages/graphics/SDL2/package.mk
@@ -16,9 +16,6 @@ if [ ! "${OPENGL_SUPPORT}" = "no" ]; then
   PKG_CMAKE_OPTS_TARGET+=" -DSDL_OPENGL=ON \
                            -DVIDEO_OPENGL=ON \
                            -DVIDEO_KMSDRM=OFF"
-  if [ "${PREFER_GLES}" = "yes" ] && [ "${OPENGLES_SUPPORT}" = "yes" ]; then
-    PKG_DEPENDS_TARGET+=" SDL2_glesonly "
-  fi
 else
   PKG_CMAKE_OPTS_TARGET+=" -DSDL_OPENGL=OFF \
                            -DVIDEO_OPENGL=OFF \

--- a/projects/ROCKNIX/packages/graphics/libmali/package.mk
+++ b/projects/ROCKNIX/packages/graphics/libmali/package.mk
@@ -9,7 +9,7 @@ PKG_SITE="https://github.com/ROCKNIX/libmali"
 PKG_VERSION="0fe30426b822699f0a660268a6040fdafce229d1"
 # zip format makes extract very fast (<1s). tgz takes 20 seconds to scan the whole file
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.zip"
-PKG_DEPENDS_TARGET="toolchain libdrm patchelf:host gpudriver"
+PKG_DEPENDS_TARGET="toolchain libdrm patchelf:host gpudriver SDL2_glesonly"
 PKG_LONGDESC="OpenGL ES user-space binary for the ARM Mali GPU family"
 PKG_TOOLCHAIN="meson"
 PKG_PATCH_DIRS+=" ${DEVICE}"


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
Correct SDL2_glesonly to depend on libmali, it now gets built and installed on platforms that doesn't need it. I.e. panfrost only platforms.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

TBD from pipeline.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?**  NO
