### PR TITLE
feat: multi-state battery led status for rg ds

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/battery_led_status
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/battery_led_status
@@ -1,0 +1,117 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+# Battery LED status monitor for RK3566 devices (Anbernic RG DS)
+#
+# Upper LED (green:power + red:status):
+#   Green  = normal (>20%)
+#   Red    = low battery (<=20%)
+#   Blink  = critical battery (<=5%)
+#
+# Lower LED (amber:charging):
+#   Amber  = charging
+#   Off    = discharging / full
+#
+# Thresholds and poll interval can be overridden via environment variables, e.g.:
+#   THRESHOLD_CRITICAL=50 THRESHOLD_LOW=80 /usr/bin/battery_led_status
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+LED_PATH="/sys/class/leds"
+
+THRESHOLD_LOW=${THRESHOLD_LOW:-20}
+THRESHOLD_CRITICAL=${THRESHOLD_CRITICAL:-5}
+POLL_INTERVAL=${POLL_INTERVAL:-1}
+
+function get_brightness() {
+  case $(get_setting led.brightness) in
+    mid) echo 63 ;;
+    min) echo 15 ;;
+    *)   echo 255 ;;
+  esac
+}
+
+function led_upper() {
+  local bri=$(get_brightness)
+  case ${1} in
+    green)
+      echo "none" >${LED_PATH}/red:status/trigger
+      echo ${bri} >${LED_PATH}/green:power/brightness
+      echo 0      >${LED_PATH}/red:status/brightness
+    ;;
+    red)
+      echo "none" >${LED_PATH}/red:status/trigger
+      echo 0      >${LED_PATH}/green:power/brightness
+      echo ${bri} >${LED_PATH}/red:status/brightness
+    ;;
+    blink_red)
+      echo 0 >${LED_PATH}/green:power/brightness
+      local BLINK=$(cat ${LED_PATH}/red:status/brightness)
+      [ "${BLINK}" = "0" ] && echo ${bri} >${LED_PATH}/red:status/brightness \
+                           || echo 0      >${LED_PATH}/red:status/brightness
+    ;;
+  esac
+}
+
+function led_lower() {
+  local bri=$(get_brightness)
+  [ "${1}" = "0" ] && echo 0      >${LED_PATH}/amber:charging/brightness \
+                   || echo ${bri} >${LED_PATH}/amber:charging/brightness
+}
+
+function get_upper_state() {
+  local capacity=${1}
+  if (( ${capacity} <= ${THRESHOLD_CRITICAL} )); then
+    echo "blink_red"
+  elif (( ${capacity} <= ${THRESHOLD_LOW} )); then
+    echo "red"
+  else
+    echo "green"
+  fi
+}
+
+PREV_UPPER=""
+PREV_LOWER=""
+PREV_BRI=""
+
+while true; do
+  CAP=$(cat /sys/class/power_supply/battery/capacity)
+  STAT=$(cat /sys/class/power_supply/battery/status)
+  UPPER=$(get_upper_state ${CAP})
+  LOWER=0
+  BRI=$(get_brightness)
+
+  case ${STAT} in
+    Charging)
+      # No blinking while charging, show battery level colour + amber lower
+      [ "${UPPER}" = "blink_red" ] && UPPER="red"
+      LOWER=${BRI}
+    ;;
+    Full|"Not charging")
+      UPPER="green"
+    ;;
+    Discharging)
+      : # UPPER is already correct from get_upper_state; no override needed unlike Charging/Full
+    ;;
+    *)
+      # Unknown state — fall back to green
+      UPPER="green"
+    ;;
+  esac
+
+  BRI_CHANGED=0
+  [ "${BRI}" != "${PREV_BRI}" ] && BRI_CHANGED=1 && PREV_BRI="${BRI}"
+
+  # Always call led_upper for blink_red (needs to toggle every poll), otherwise only on state or brightness change
+  if [ "${UPPER}" = "blink_red" ] || [ "${UPPER}" != "${PREV_UPPER}" ] || [ "${BRI_CHANGED}" = "1" ]; then
+    led_upper ${UPPER}
+    PREV_UPPER="${UPPER}"
+  fi
+  if [ "${LOWER}" != "${PREV_LOWER}" ] || [ "${BRI_CHANGED}" = "1" ]; then
+    led_lower ${LOWER}
+    PREV_LOWER="${LOWER}"
+  fi
+
+  sleep ${POLL_INTERVAL}
+done

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG DS/bin/ledcontrol
@@ -73,16 +73,13 @@ case ${1} in
     brightness ${LED_STATUS:-${DEFAULT}} ${LEDBRIGHTNESS}
   ;;
   charging)
-    if [ ! "${LED_STATUS}" = "off" ]
-    then
-      brightness amber ${LEDBRIGHTNESS}
-    fi
+    : # handled by battery_led_status daemon
   ;;
   poweroff)
     led_off
   ;;
   brightness)
-    brightness ${LED_STATUS:-${DEFAULT}} ${LEDBRIGHTNESS}
+    : # handled by battery_led_status daemon
   ;;
   list)
 cat <<EOF


### PR DESCRIPTION


## Summary

Introduces a battery LED status daemon that reflects battery level and charging state across the device's three discrete LEDs (red and green on top, amber on bottom). The upper LED shows green (normal), red (<=20%), or blinking red (<=5%), while the lower amber LED indicates charging status.

## Testing

**How was this tested?**
It is tested both with mount binds and a custom build.

**Test results:** 
- brightness can be set and is remembered across different states
- LED colour could be changed in ES (although this defeats the purpose)
- detects charging
- becomes red at 20%
- blinks red at 5% and stops blinking when charger is connected.

This feature does does not conflict with the LED colour setting in ES, but the battery status feedback will stop working. It only works with the values `Default` or `Off`. But maybe this is acceptable?

As for the Off setting, it will turn the LEDs off. When a charger is plugged in, only the amber LED will switch on. 

## Additional Context

The script polls every second, which has a negligible impact on both battery life and CPU usage, while still keeping LED feedback as responsive as possible. It picks up both the charging state and any settings configured for the LEDs in ES, including brightness and potential colour overrides.

When polling every second it uses around 0.5% of one CPU core.
Dropping the polling rate to 3 seconds would bring it down to around 0.2% of one CPU core.
For comparison, an active SSH session uses around 0.2% CPU on this device.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
