### PR TITLE
[Vita3K] Add more ES options, update initial config

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/vita3k-sa/config/config.yml
+++ b/projects/ROCKNIX/packages/emulators/standalone/vita3k-sa/config/config.yml
@@ -45,8 +45,8 @@ sys-date-format: 2
 sys-time-format: 0
 cpu-pool-size: 10
 modules-mode: 0
-delay-background: 0
-delay-start: 0
+delay-background: 4
+delay-start: 30
 background-alpha: 0.3
 log-level: 8
 cpu-opt: true
@@ -63,7 +63,7 @@ overlay-show-touch-switch: false
 overlay-scale: 1
 overlay-opacity: 100
 screenshot-format: 1
-disable-motion: false
+disable-motion: true
 controller-analog-multiplier: 1
 keyboard-button-select: 229
 keyboard-button-start: 40

--- a/projects/ROCKNIX/packages/emulators/standalone/vita3k-sa/scripts/start_vita3k.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/vita3k-sa/scripts/start_vita3k.sh
@@ -32,10 +32,22 @@ fi
 ROMNAME=$(echo "${1}" | sed "s#^/.*/##")
 PLATFORM="${2}"
 RENDERER=$(get_setting graphics_backend "${PLATFORM}" "${ROMNAME}")
+PSTVMODE=$(get_setting pstv_mode "${PLATFORM}" "${ROMNAME}")
 IRES=$(get_setting internal_resolution "${PLATFORM}" "${ROMNAME}")
 FILTER=$(get_setting bilinear_filtering "${PLATFORM}" "${ROMNAME}")
 ACCURACY=$(get_setting high_accuracy "${PLATFORM}" "${ROMNAME}")
+MEMMAPPING=$(get_setting memory_mapping "${PLATFORM}" "${ROMNAME}")
 VSYNC=$(get_setting vsync "${PLATFORM}" "${ROMNAME}")
+ANISO=$(get_setting anisotropic_filtering "${PLATFORM}" "${ROMNAME}")
+FPSHACK=$(get_setting fps_hack "${PLATFORM}" "${ROMNAME}")
+NGSENABLE=$(get_setting ngs_audio "${PLATFORM}" "${ROMNAME}")
+DISABLEMOTION=$(get_setting disable_gyro "${PLATFORM}" "${ROMNAME}")
+DISABLESURFACESYNC=$(get_setting disable_surface_sync "${PLATFORM}" "${ROMNAME}")
+SYSBUTTON=$(get_setting confirm_button "${PLATFORM}" "${ROMNAME}")
+FILELOADINGDELAY=$(get_setting file_loading_delay "${PLATFORM}" "${ROMNAME}")
+SPIRVSHADER=$(get_setting spirv_shader "${PLATFORM}" "${ROMNAME}")
+HASHLESSTEXCACHE=$(get_setting hashless_texture_cache "${PLATFORM}" "${ROMNAME}")
+HTTPENABLE=$(get_setting network_features "${PLATFORM}" "${ROMNAME}")
 
 # Graphics Backend
 if [ "${RENDERER}" = "opengl" ]; then
@@ -61,6 +73,13 @@ else
   sed -i "/^resolution-multiplier:/c\resolution-multiplier: 1" /storage/.config/Vita3K/config.yml
 fi
 
+# PSTV Mode
+if [ "${PSTVMODE}" = "true" ]; then
+  sed -i "/^pstv-mode:/c\pstv-mode: true" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^pstv-mode:/c\pstv-mode: false" /storage/.config/Vita3K/config.yml
+fi
+
 # Bilinear Filtering
 if [ "${FILTER}" = "0" ]; then
   sed -i '/^screen-filter:/c\screen-filter: Nearest' /storage/.config/Vita3K/config.yml
@@ -81,11 +100,88 @@ else
   sed -i "/^high-accuracy:/c\high-accuracy: false" /storage/.config/Vita3K/config.yml
 fi
 
+# Memory Mapping
+if [ -n "${MEMMAPPING}" ]; then
+  sed -i "/^memory-mapping:/c\memory-mapping: ${MEMMAPPING}" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^memory-mapping:/c\memory-mapping: double-buffer" /storage/.config/Vita3K/config.yml
+fi
+
 # Vsync
 if [ "${VSYNC}" = "false" ]; then
   sed -i "/^v-sync:/c\v-sync: false" /storage/.config/Vita3K/config.yml
 else
   sed -i "/^v-sync:/c\v-sync: true" /storage/.config/Vita3K/config.yml
+fi
+
+# Anisotropic Filtering
+if [ -n "${ANISO}" ]; then
+  sed -i "/^anisotropic-filtering:/c\anisotropic-filtering: ${ANISO}" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^anisotropic-filtering:/c\anisotropic-filtering: 1" /storage/.config/Vita3K/config.yml
+fi
+
+# FPS Hack
+if [ "${FPSHACK}" = "true" ]; then
+  sed -i "/^fps-hack:/c\fps-hack: true" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^fps-hack:/c\fps-hack: false" /storage/.config/Vita3K/config.yml
+fi
+
+# NGS Audio Engine
+if [ "${NGSENABLE}" = "false" ]; then
+  sed -i "/^ngs-enable:/c\ngs-enable: false" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^ngs-enable:/c\ngs-enable: true" /storage/.config/Vita3K/config.yml
+fi
+
+# Disable Motion Controls
+if [ "${DISABLEMOTION}" = "true" ]; then
+  sed -i "/^disable-motion:/c\disable-motion: true" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^disable-motion:/c\disable-motion: false" /storage/.config/Vita3K/config.yml
+fi
+
+# Disable Surface Sync
+if [ "${DISABLESURFACESYNC}" = "false" ]; then
+  sed -i "/^disable-surface-sync:/c\disable-surface-sync: false" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^disable-surface-sync:/c\disable-surface-sync: true" /storage/.config/Vita3K/config.yml
+fi
+
+# System Confirm Button
+if [ "${SYSBUTTON}" = "0" ]; then
+  sed -i "/^sys-button:/c\sys-button: 0" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^sys-button:/c\sys-button: 1" /storage/.config/Vita3K/config.yml
+fi
+
+# File Loading Delay
+if [ -n "${FILELOADINGDELAY}" ]; then
+  sed -i "/^file-loading-delay:/c\file-loading-delay: ${FILELOADINGDELAY}" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^file-loading-delay:/c\file-loading-delay: 0" /storage/.config/Vita3K/config.yml
+fi
+
+# SPIR-V Shader Path
+if [ "${SPIRVSHADER}" = "true" ]; then
+  sed -i "/^spirv-shader:/c\spirv-shader: true" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^spirv-shader:/c\spirv-shader: false" /storage/.config/Vita3K/config.yml
+fi
+
+# Hashless Texture Cache
+if [ "${HASHLESSTEXCACHE}" = "true" ]; then
+  sed -i "/^hashless-texture-cache:/c\hashless-texture-cache: true" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^hashless-texture-cache:/c\hashless-texture-cache: false" /storage/.config/Vita3K/config.yml
+fi
+
+# HTTP Networking
+if [ "${HTTPENABLE}" = "true" ]; then
+  sed -i "/^http-enable:/c\http-enable: true" /storage/.config/Vita3K/config.yml
+else
+  sed -i "/^http-enable:/c\http-enable: false" /storage/.config/Vita3K/config.yml
 fi
 
 # Check if system vita3k folder exists, which needs to be populated by Vita3K before we can do anything.

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -1732,34 +1732,89 @@
     <cores>
       <core name="vita3k-sa">
         <features>
-         <feature name="graphics backend">
-           <choice name="vulkan (default)" value="vulkan"/>
-           <choice name="opengl" value="opengl"/>
-         </feature>
-         <feature name="internal resolution">
-           <choice name="0.5x" value="0.5"/>
-           <choice name="0.75x" value="0.75"/>
-           <choice name="1x (default)" value="1"/>
-           <choice name="1.25x" value="1.25"/>
-           <choice name="1.5x" value="1.5"/>
-           <choice name="1.75x" value="1.75"/>
-           <choice name="2x" value="2"/>
-         </feature>
-         <feature name="bilinear filtering">
-           <choice name="nearest" value="0"/>
-           <choice name="bilinear (default)" value="1"/>
-           <choice name="bicubic" value="2"/>
-           <choice name="fxaa" value="3"/>
-           <choice name="fsr" value="4"/>
-         </feature>
-         <feature name="high accuracy">
-           <choice name="off (default)" value="false"/>
-           <choice name="on" value="true"/>
-         </feature>
-         <feature name="vsync">
-           <choice name="on (default)" value="true"/>
-           <choice name="off" value="false"/>
-         </feature>
+          <feature name="graphics backend">
+            <choice name="vulkan (default)" value="vulkan"/>
+            <choice name="opengl" value="opengl"/>
+          </feature>
+          <feature name="internal resolution">
+            <choice name="0.5x" value="0.5"/>
+            <choice name="0.75x" value="0.75"/>
+            <choice name="1x (default)" value="1"/>
+            <choice name="1.25x" value="1.25"/>
+            <choice name="1.5x" value="1.5"/>
+            <choice name="1.75x" value="1.75"/>
+            <choice name="2x" value="2"/>
+          </feature>
+          <feature name="pstv mode">
+            <choice name="on" value="true"/>
+            <choice name="off (default)" value="false"/>
+          </feature>
+          <feature name="bilinear filtering">
+            <choice name="nearest" value="0"/>
+            <choice name="bilinear (default)" value="1"/>
+            <choice name="bicubic" value="2"/>
+            <choice name="fxaa" value="3"/>
+            <choice name="fsr" value="4"/>
+          </feature>
+          <feature name="high accuracy">
+            <choice name="off (default)" value="false"/>
+            <choice name="on" value="true"/>
+          </feature>
+          <feature name="memory mapping">
+            <choice name="off" value="disabled"/>
+            <choice name="double buffered (default)" value="double-buffer"/>
+            <choice name="external host" value="external-host"/>
+            <choice name="page table" value="page-table"/>
+            <choice name="native buffered" value="native-buffer"/>
+          </feature>
+          <feature name="vsync">
+            <choice name="on (default)" value="true"/>
+            <choice name="off" value="false"/>
+          </feature>
+          <feature name="anisotropic filtering">
+            <choice name="off (default)" value="1"/>
+            <choice name="2x" value="2"/>
+            <choice name="4x" value="4"/>
+            <choice name="8x" value="8"/>
+            <choice name="16x" value="16"/>
+          </feature>
+          <feature name="fps hack">
+            <choice name="off (default)" value="false"/>
+            <choice name="on" value="true"/>
+          </feature>
+          <feature name="ngs audio">
+            <choice name="on (default)" value="true"/>
+            <choice name="off" value="false"/>
+          </feature>
+          <feature name="disable gyro">
+            <choice name="on (default)" value="true"/>
+            <choice name="off" value="false"/>
+          </feature>
+          <feature name="disable surface sync">
+            <choice name="on (default)" value="true"/>
+            <choice name="off" value="false"/>
+          </feature>
+          <feature name="confirm button">
+            <choice name="cross (default)" value="1"/>
+            <choice name="circle" value="0"/>
+          </feature>
+          <feature name="file loading delay">
+            <choice name="off (default)" value="0"/>
+            <choice name="30ms" value="30"/>
+            <choice name="60ms" value="60"/>
+          </feature>
+          <feature name="spirv shader">
+            <choice name="off (default)" value="false"/>
+            <choice name="on" value="true"/>
+          </feature>
+          <feature name="hashless texture cache">
+            <choice name="off (default)" value="false"/>
+            <choice name="on" value="true"/>
+          </feature>
+          <feature name="network features">
+            <choice name="off (default)" value="false"/>
+            <choice name="on" value="true"/>
+          </feature>
         </features>
       </core>
     </cores>


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Adds more options to ES menu for Vita3K.
Updates default Vita3K config:
- Gyro/Motion disabled by default to match ES default, no device support yet anyway
- Delays fixed to allow controller input in GUI menus

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Tested on RG Vita Pro with local build and update

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

Previous patch was deemed unnecessary, as it did not show any improvements when tested separately from the config fixes.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
