### PR TITLE
Dockerfile - NOPASSWD sudo for docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV LANG=en_US.UTF-8 \
 
 RUN adduser --disabled-password --gecos '' docker \
  && adduser docker sudo \
- && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+ && echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get install -y \
     bc default-jre file gawk gcc git golang-go gperf libjson-perl libncurses5-dev \


### PR DESCRIPTION
## Summary

We currently attempt to give all users in the `sudo` group the ability to run sudo commands without a password. This does not currently work, and I cannot get it working.

Configuring it for just the `docker` user works fine however.

## Testing

Tested using Docker on Debian Trixie

## Additional Context

`sudo` access is required for `/nix` setup: https://github.com/ROCKNIX/distribution/blob/dfb9875f76395548c2903a460a798c0e96f43e70/scripts/checkdeps#L305

---

### AI Usage

**Did you use AI tools to help write this code?** NO
