### PR TITLE
[mali_kbase] Bump version

### DIFF
--- a/projects/ROCKNIX/packages/linux-drivers/mali-bifrost/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/mali-bifrost/package.mk
@@ -15,7 +15,7 @@ case ${DEVICE} in
   PKG_PATCH_DIRS+=" 6.12-LTS"
   ;;
   *)
-  PKG_VERSION="422e192b7e3aa3140f34de34765b798817c1f749"
+  PKG_VERSION="39da994bb6fc8819e5e8c1873907dd21d17e53c1"
   PKG_URL="http://github.com/rocknix/mali_kbase/archive/${PKG_VERSION}.tar.gz"
   ;;
 esac


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Bump mali_kbase version to add @sydarn 's Linux 7.0 compatibility guards for dma fence function.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Built and tested locally against RK3576 on 6.19.11 and 7.0, no obvious degradation or errors.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
