### PR TITLE
Add initial support for ares Standalone emulator

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/ares-sa/config/settings.toml
+++ b/projects/ROCKNIX/packages/emulators/standalone/ares-sa/config/settings.toml
@@ -1,0 +1,440 @@
+Video
+  Driver: OpenGL 3.2
+  Monitor: Primary
+  Format: ARGB24
+  Exclusive: false
+  Blocking: false
+  PresentSRGB: false
+  ThreadedRenderer: true
+  NativeFullScreen: false
+  Flush: false
+  Shader: None
+  Multiplier: 2
+  Output: Scale
+  AspectCorrectionMode: Standard
+  AdaptiveSizing: true
+  AutoCentering: false
+  Luminance: 1.0
+  Saturation: 1.0
+  Gamma: 1.0
+  ColorBleed: false
+  ColorEmulation: true
+  DeepBlackBoost: false
+  InterframeBlending: true
+  Overscan: false
+  PixelAccuracy: false
+  Quality: SD
+  Supersampling: false
+  DisableVideoInterfaceProcessing: false
+  WeaveDeinterlacing: true
+Audio
+  Driver: SDL
+  Device: Default
+  Frequency: 48000
+  Latency: 20
+  Exclusive: false
+  Blocking: true
+  Dynamic: false
+  Mute: false
+  Volume: 1.0
+  Balance: 0.0
+Input
+  Driver: SDL
+  Defocus: Pause
+Boot
+  Fast: false
+  Debugger: false
+  AwaitGDBClient: false
+  Prefer: NTSC-U
+General
+  ShowStatusBar: true
+  Rewind: false
+  RunAhead: false
+  AutoSaveMemory: true
+  HomebrewMode: false
+  ForceInterpreter: false
+Rewind
+  Length: 100
+  Frequency: 10
+Paths
+  Home
+  Firmware
+  Saves
+  Screenshots
+  Debugging
+  ArcadeRoms
+  SuperFamicom
+    GameBoy
+    BSMemory
+    SufamiTurbo
+DebugServer
+  Port: 9123
+  Enabled: false
+  UseIPv4: false
+Nintendo64
+  ExpansionPak: true
+  ControllerPakBankString: 32KiB (Default)
+  Visible: true
+  Path
+GameBoyAdvance
+  Player: false
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+MegaDrive
+  TMSS: false
+  Visible: true
+  Path
+Recent
+  Game-1
+  Game-2
+  Game-3
+  Game-4
+  Game-5
+  Game-6
+  Game-7
+  Game-8
+  Game-9
+VirtualPad1
+  Pad.Up: 0x1045e0b12/1/1/Lo;;
+  Pad.Down: 0x1045e0b12/1/1/Hi;;
+  Pad.Left: 0x1045e0b12/1/0/Lo;;
+  Pad.Right: 0x1045e0b12/1/0/Hi;;
+  Select: 0x1045e0b12/3/6;;
+  Start: 0x1045e0b12/3/7;;
+  A..South: 0x1045e0b12/3/0;;
+  B..East: 0x1045e0b12/3/1;;
+  X..West: 0x1045e0b12/3/2;;
+  Y..North: 0x1045e0b12/3/3;;
+  L-Bumper: 0x1045e0b12/3/4;;
+  R-Bumper: 0x1045e0b12/3/5;;
+  L-Trigger: 0x1045e0b12/0/2/Hi;;
+  R-Trigger: 0x1045e0b12/0/5/Hi;;
+  L-Stick..Click: 0x1045e0b12/3/9;;
+  R-Stick..Click: 0x1045e0b12/3/10;;
+  L-Up: 0x1045e0b12/0/1/Lo;;
+  L-Down: 0x1045e0b12/0/1/Hi;;
+  L-Left: 0x1045e0b12/0/0/Lo;;
+  L-Right: 0x1045e0b12/0/0/Hi;;
+  R-Up: 0x1045e0b12/0/4/Lo;;
+  R-Down: 0x1045e0b12/0/4/Hi;;
+  R-Left: 0x1045e0b12/0/3/Lo;;
+  R-Right: 0x1045e0b12/0/3/Hi;;
+  Rumble: ;;
+VirtualMouse1
+  X: ;;
+  Y: ;;
+  Left: ;;
+  Middle: ;;
+  Right: ;;
+  Extra: ;;
+VirtualPad2
+  Pad.Up: ;;
+  Pad.Down: ;;
+  Pad.Left: ;;
+  Pad.Right: ;;
+  Select: ;;
+  Start: ;;
+  A..South: ;;
+  B..East: ;;
+  X..West: ;;
+  Y..North: ;;
+  L-Bumper: ;;
+  R-Bumper: ;;
+  L-Trigger: ;;
+  R-Trigger: ;;
+  L-Stick..Click: ;;
+  R-Stick..Click: ;;
+  L-Up: ;;
+  L-Down: ;;
+  L-Left: ;;
+  L-Right: ;;
+  R-Up: ;;
+  R-Down: ;;
+  R-Left: ;;
+  R-Right: ;;
+  Rumble: ;;
+VirtualMouse2
+  X: ;;
+  Y: ;;
+  Left: ;;
+  Middle: ;;
+  Right: ;;
+  Extra: ;;
+VirtualPad3
+  Pad.Up: ;;
+  Pad.Down: ;;
+  Pad.Left: ;;
+  Pad.Right: ;;
+  Select: ;;
+  Start: ;;
+  A..South: ;;
+  B..East: ;;
+  X..West: ;;
+  Y..North: ;;
+  L-Bumper: ;;
+  R-Bumper: ;;
+  L-Trigger: ;;
+  R-Trigger: ;;
+  L-Stick..Click: ;;
+  R-Stick..Click: ;;
+  L-Up: ;;
+  L-Down: ;;
+  L-Left: ;;
+  L-Right: ;;
+  R-Up: ;;
+  R-Down: ;;
+  R-Left: ;;
+  R-Right: ;;
+  Rumble: ;;
+VirtualMouse3
+  X: ;;
+  Y: ;;
+  Left: ;;
+  Middle: ;;
+  Right: ;;
+  Extra: ;;
+VirtualPad4
+  Pad.Up: ;;
+  Pad.Down: ;;
+  Pad.Left: ;;
+  Pad.Right: ;;
+  Select: ;;
+  Start: ;;
+  A..South: ;;
+  B..East: ;;
+  X..West: ;;
+  Y..North: ;;
+  L-Bumper: ;;
+  R-Bumper: ;;
+  L-Trigger: ;;
+  R-Trigger: ;;
+  L-Stick..Click: ;;
+  R-Stick..Click: ;;
+  L-Up: ;;
+  L-Down: ;;
+  L-Left: ;;
+  L-Right: ;;
+  R-Up: ;;
+  R-Down: ;;
+  R-Left: ;;
+  R-Right: ;;
+  Rumble: ;;
+VirtualMouse4
+  X: ;;
+  Y: ;;
+  Left: ;;
+  Middle: ;;
+  Right: ;;
+  Extra: ;;
+VirtualPad5
+  Pad.Up: ;;
+  Pad.Down: ;;
+  Pad.Left: ;;
+  Pad.Right: ;;
+  Select: ;;
+  Start: ;;
+  A..South: ;;
+  B..East: ;;
+  X..West: ;;
+  Y..North: ;;
+  L-Bumper: ;;
+  R-Bumper: ;;
+  L-Trigger: ;;
+  R-Trigger: ;;
+  L-Stick..Click: ;;
+  R-Stick..Click: ;;
+  L-Up: ;;
+  L-Down: ;;
+  L-Left: ;;
+  L-Right: ;;
+  R-Up: ;;
+  R-Down: ;;
+  R-Left: ;;
+  R-Right: ;;
+  Rumble: ;;
+VirtualMouse5
+  X: ;;
+  Y: ;;
+  Left: ;;
+  Middle: ;;
+  Right: ;;
+  Extra: ;;
+Hotkey
+  ToggleFullscreen: ;;
+  TogglePseudo-Fullscreen: ;;
+  ToggleMouseCapture: ;;
+  ToggleKeyboardCapture: ;;
+  FastForward: ;;
+  ToggleFastForward: ;;
+  Rewind: ;;
+  FrameAdvance: ;;
+  CaptureScreenshot: ;;
+  SaveState: ;;
+  LoadState: ;;
+  DecrementStateSlot: ;;
+  IncrementStateSlot: ;;
+  PauseEmulation: ;;
+  ResetSystem: ;;
+  ReloadCurrentGame: ;;
+  QuitEmulator: ;;
+  MuteAudio: ;;
+  IncreaseAudio: ;;
+  DecreaseAudio: ;;
+Arcade
+  Visible: true
+  Path
+Atari2600
+  Visible: true
+  Path
+WonderSwan
+  Visible: true
+  Path
+WonderSwanColor
+  Visible: true
+  Path
+PocketChallengeV2
+  Visible: true
+  Path
+ColecoVision
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+MyVision
+  Visible: true
+  Path
+MSX
+  Visible: true
+  Path
+  Firmware
+    BIOS.Japan
+MSX2
+  Visible: true
+  Path
+  Firmware
+    MAIN.Japan
+    SUB.Japan
+PCEngine
+  Visible: true
+  Path
+PCEngineCD
+  Visible: true
+  Path
+  Firmware
+    System-Card-1.0.Japan
+    System-Card-3.0.Japan
+    System-Card-3.0.US
+    Games-Express.Japan
+LaserActiveNECPAC
+  Visible: true
+  Path
+  Firmware
+    PAC-N10.US
+    PAC-N1.Japan
+    PCE-LP1.Japan
+    System-Card-1.0.Japan
+    Games-Express.Japan
+SuperGrafx
+  Visible: true
+  Path
+SuperGrafxCD
+  Visible: true
+  Path
+  Firmware
+    Arcade-Card.Japan
+Famicom
+  Visible: true
+  Path
+FamicomDiskSystem
+  Visible: true
+  Path
+  Firmware
+    BIOS.Japan
+SuperFamicom
+  Visible: true
+  Path
+Nintendo64DD
+  Visible: true
+  Path
+  Firmware
+    BIOS.Japan
+    BIOS.US
+    BIOS.DEV
+GameBoy
+  Visible: true
+  Path
+GameBoyColor
+  Visible: true
+  Path
+SG-1000
+  Visible: true
+  Path
+SC-3000
+  Visible: true
+  Path
+MasterSystem
+  Visible: true
+  Path
+  Firmware
+    BIOS.US
+    BIOS.Japan
+    BIOS.Europe
+GameGear
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+Mega32X
+  Visible: true
+  Path
+MegaCD
+  Visible: true
+  Path
+  Firmware
+    BIOS.US
+    BIOS.Japan
+    BIOS.Europe
+MegaCD32X
+  Visible: true
+  Path
+LaserActiveSEGAPAC
+  Visible: true
+  Path
+  Firmware
+    BIOS.US
+    BIOS.Japan
+NeoGeoAES
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+NeoGeoMVS
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+NeoGeoPocket
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+NeoGeoPocketColor
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+PlayStation
+  Visible: true
+  Path
+  Firmware
+    BIOS.US
+    BIOS.Japan
+    BIOS.Europe
+ZXSpectrum
+  Visible: true
+  Path
+ZXSpectrum128
+  Visible: true
+  Path

--- a/projects/ROCKNIX/packages/emulators/standalone/ares-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/ares-sa/package.mk
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="ares-sa"
+PKG_VERSION="f533120df6506390635a99ad58495834a69036e0" #v147
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/ares-emulator/ares"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_LONGDESC="Ares is a multi-system emulator. It is a descendant of higan and bsnes, and focuses on accuracy and preservation."
+PKG_DEPENDS_TARGET="toolchain librashader SDL2 ares-sa:host"
+PKG_TOOLCHAIN="cmake"
+
+pre_configure_host() {
+  PKG_CMAKE_OPTS_HOST+=" -DCMAKE_BUILD_TYPE=Release \
+                         -DBUILD_SHARED_LIBS=FALSE \
+                         -DWITH_SYSTEM_ZLIB=ON \
+                         -DARES_BUILD_LOCAL=OFF \
+                         -DARES_ENABLE_MINIMUM_CPU=OFF \
+                         -DARES_BUILD_SOURCERY_ONLY=ON \
+                         -DCMAKE_CROSSCOMPILING=OFF \
+                         -DARES_CROSSCOMPILING=OFF"
+}
+
+makeinstall_host() {
+  mkdir -p ${TOOLCHAIN}/bin
+  cp ${PKG_BUILD}/.${HOST_NAME}/tools/sourcery/sourcery ${TOOLCHAIN}/bin
+  chmod +x ${TOOLCHAIN}/bin/sourcery
+}
+
+pre_configure_target() {
+  PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_BUILD_TYPE=Release \
+                           -DBUILD_SHARED_LIBS=FALSE \
+                           -DWITH_SYSTEM_ZLIB=ON \
+                           -DARES_BUILD_LOCAL=OFF \
+                           -DARES_ENABLE_MINIMUM_CPU=OFF"
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  mkdir -p ${INSTALL}/usr/share/ares
+  mkdir -p ${INSTALL}/usr/config/ares
+
+  cp -rf ${PKG_BUILD}/.${TARGET_NAME}/desktop-ui/ares ${INSTALL}/usr/bin
+  cp -rf ${PKG_DIR}/scripts/* ${INSTALL}/usr/bin
+  chmod +x ${INSTALL}/usr/bin
+  cp -rf ${PKG_BUILD}/.${TARGET_NAME}/rundir/share/ares/Database ${INSTALL}/usr/share/ares/
+  cp -rf ${PKG_DIR}/config/* ${INSTALL}/usr/config/ares
+}

--- a/projects/ROCKNIX/packages/emulators/standalone/ares-sa/patches/000-cmake-sourcery-only.patch
+++ b/projects/ROCKNIX/packages/emulators/standalone/ares-sa/patches/000-cmake-sourcery-only.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt	2025-04-28 18:01:01.129568626 +0200
++++ b/CMakeLists.txt	2025-04-28 18:00:27.891870910 +0200
+@@ -12,7 +12,9 @@
+ 
+ add_subdirectory(thirdparty)
+ 
++option(ARES_BUILD_SOURCERY_ONLY "Only build sourcery tool for cross-compiling" OFF)
+ add_subdirectory(nall/nall)
++if (NOT ARES_BUILD_SOURCERY_ONLY)
+ add_subdirectory(libco)
+ add_subdirectory(ruby)
+ add_subdirectory(hiro)
+@@ -28,6 +30,7 @@
+ add_subdirectory(ares)
+ add_subdirectory(mia)
+ add_subdirectory(desktop-ui)
++endif()
+ 
+ option(ARES_BUILD_OPTIONAL_TARGETS "Include supplemental tools and tests" OFF)
+ 

--- a/projects/ROCKNIX/packages/emulators/standalone/ares-sa/scripts/start_ares.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/ares-sa/scripts/start_ares.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+set_kill set "-9 ares"
+
+CONF_DIR="/storage/.config/ares"
+ARES_INI="settings.bml"
+
+# Check if ares exists in .config
+if [ ! -d "${CONF_DIR}" ]; then
+        cp -r "/usr/config/ares" "/storage/.config/"
+fi
+
+# Link  .config/ares to .local
+rm -rf /storage/.local/share/ares
+ln -sf /storage/.config/ares /storage/.local/share/ares
+
+# Emulation Station Features
+GAME=$(echo "${1}"| sed "s#^/.*/##")
+PLATFORM=$(echo "${2}"| sed "s#^/.*/##")
+
+# Set the cores to use
+CORES=$(get_setting "cores" "${PLATFORM}" "${GAME}")
+if [ "${CORES}" = "little" ]
+then
+  EMUPERF="${SLOW_CORES}"
+elif [ "${CORES}" = "big" ]
+then
+  EMUPERF="${FAST_CORES}"
+else
+  ### All..
+  unset EMUPERF
+fi
+
+${EMUPERF} /usr/bin/ares --fullscreen "${1}"

--- a/projects/ROCKNIX/packages/graphics/librashader/package.mk
+++ b/projects/ROCKNIX/packages/graphics/librashader/package.mk
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="librashader"
+PKG_LICENSE="MPLv2"
+PKG_VERSION="76462c030b75c4f2d56e5386c3d4d7d1128318b8"
+PKG_SITE="https://github.com/SnowflakePowered/librashader"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain cargo:host cargo rust"
+PKG_LONGDESC="Librashader is a preprocessor, compiler, and runtime for RetroArch 'slang' shaders, rewritten in pure Rust."
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+  unset CMAKE
+
+  cargo build \
+    --target ${TARGET_NAME} \
+    --features stable \
+    --release
+}
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+  mkdir -p ${SYSROOT_PREFIX}/usr/include/librashader
+  mkdir -p ${INSTALL}/usr/lib
+
+  cp ${PKG_BUILD}/.${TARGET_NAME}/target/${TARGET_NAME}/release/liblibrashader_capi.so ${SYSROOT_PREFIX}/usr/lib/librashader.so.2
+  ln -sf ${SYSROOT_PREFIX}/usr/lib/librashader.so.2 ${SYSROOT_PREFIX}/usr/lib/librashader.so
+
+  cp ${PKG_BUILD}/pkg/librashader.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig/librashader.pc
+  cp ${PKG_BUILD}/include/* ${SYSROOT_PREFIX}/usr/include/librashader/
+
+  cp ${PKG_BUILD}/.${TARGET_NAME}/target/${TARGET_NAME}/release/liblibrashader_capi.so ${INSTALL}/usr/lib/librashader.so.2
+  ln -sf ${INSTALL}/usr/lib/librashader.so.2 ${INSTALL}/usr/lib/librashader.so
+}

--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -60,7 +60,7 @@ case "${DEVICE}" in
     ;;
   SM8550)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 daedalusx64-sa desmume-lr gpsp-lr pcsx_rearmed-lr"
-    PKG_EMUS+=" aethersx2-sa azahar-sa bigpemu-sa cemu-sa dolphin-sa drastic-sa gopher64-sa mednafen melonds-sa nanoboyadvance-sa rpcs3-sa supermodel-sa \
+    PKG_EMUS+=" aethersx2-sa ares-sa azahar-sa bigpemu-sa cemu-sa dolphin-sa drastic-sa gopher64-sa mednafen melonds-sa nanoboyadvance-sa rpcs3-sa supermodel-sa \
                 xemu-sa skyemu-sa steam vita3k-sa"
     LIBRETRO_CORES+=" beetle-psx-lr beetle-saturn-lr bsnes-lr bsnes-hd-lr dolphin-lr kronos-lr"
     ;;
@@ -199,6 +199,11 @@ makeinstall_target() {
   add_emu_core arcade retroarch fbalpha2012 false
   add_emu_core arcade retroarch fbalpha2019 false
   add_emu_core arcade retroarch mame false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core arcade ares ares-sa false
+      ;;
+  esac
   add_es_system arcade
 
   ### Arduboy
@@ -255,6 +260,11 @@ makeinstall_target() {
   add_emu_core colecovision retroarch gearcoleco true
   add_emu_core colecovision retroarch bluemsx false
   add_emu_core colecovision retroarch smsplus false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core colecovision ares ares-sa false
+      ;;
+  esac
   add_es_system colecovision
 
   ### Commodore 128
@@ -348,6 +358,11 @@ makeinstall_target() {
       add_emu_core famicom mednafen nes false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core famicom ares ares-sa false
+      ;;
+  esac
   add_es_system famicom
 
   ### Nintendo Famicom Disk System
@@ -358,6 +373,11 @@ makeinstall_target() {
   case ${DEVICE} in
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core fds mednafen nes false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core fds ares ares-sa false
       ;;
   esac
   add_es_system fds
@@ -407,6 +427,11 @@ makeinstall_target() {
       install_script "Start SkyEmu.sh"
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core gb ares ares-sa false
+      ;;
+  esac
   add_es_system gb
 
   ### Nintendo GameBoy Hacks
@@ -427,6 +452,11 @@ makeinstall_target() {
   case ${DEVICE} in
     SDM845|SM8250|SM8550|SM8650)
       add_emu_core gbh skyemu skyemu-sa false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core gbh ares ares-sa false
       ;;
   esac
   add_es_system gbh
@@ -459,6 +489,11 @@ makeinstall_target() {
       add_emu_core gba skyemu skyemu-sa false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core gba ares ares-sa false
+      ;;
+  esac
   add_es_system gba
 
   ### Nintendo GameBoy Advance Hacks
@@ -479,6 +514,11 @@ makeinstall_target() {
   case ${DEVICE} in
     SDM845|SM8250|SM8550|SM8650)
       add_emu_core gbah skyemu skyemu-sa false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core gbah ares ares-sa false
       ;;
   esac
   add_es_system gbah
@@ -525,6 +565,11 @@ makeinstall_target() {
       add_emu_core gbc skyemu skyemu-sa false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core gbc ares ares-sa false
+      ;;
+  esac
   add_es_system gbc
 
   ### Nintendo GameBoy Color Hacks
@@ -545,6 +590,11 @@ makeinstall_target() {
   case ${DEVICE} in
     SDM845|SM8250|SM8550|SM8650)
       add_emu_core gbch skyemu skyemu-sa false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core gbch ares ares-sa false
       ;;
   esac
   add_es_system gbch
@@ -615,6 +665,11 @@ makeinstall_target() {
       add_emu_core gamegear mednafen gg false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core gamegear ares ares-sa false
+      ;;
+  esac
   add_es_system gamegear
 
   ### Sega GameGear Hacks
@@ -627,6 +682,11 @@ makeinstall_target() {
       add_emu_core ggh mednafen gg false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core ggh ares ares-sa false
+      ;;
+  esac
   add_es_system ggh
 
   ### Apple iOS
@@ -634,9 +694,9 @@ makeinstall_target() {
   install_script "Start touchHLE.sh"
   add_es_system ios
 
+  ## Steam
   case ${DEVICE} in
     SM8250|SM8550|SM8650|SDM845)
-      ### Steam
       add_emu_core steam steam steam true
       install_script "Start Steam.sh"
       add_es_system steam
@@ -722,11 +782,21 @@ makeinstall_target() {
   ### Microsoft MSX
   add_emu_core msx retroarch bluemsx true
   add_emu_core msx retroarch fmsx false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core msx ares ares-sa false
+      ;;
+  esac
   add_es_system msx
 
   ### Microsoft MSX 2
   add_emu_core msx2 retroarch bluemsx true
   add_emu_core msx2 retroarch fmsx false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core msx ares ares-sa false
+      ;;
+  esac
   add_es_system msx2
 
   ### Sega Naomi
@@ -757,6 +827,12 @@ makeinstall_target() {
   add_emu_core neogeo retroarch mame2015 false
   add_emu_core neogeo retroarch mame false
   add_emu_core neogeo retroarch geolith false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core neogeo ares ares-sa false
+      ;;
+  esac
+
   add_es_system neogeo
 
   ### SNK NeoCD
@@ -772,6 +848,11 @@ makeinstall_target() {
       add_emu_core ngp mednafen ngp false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core ngp ares ares-sa false
+      ;;
+  esac
   add_es_system ngp
 
   ### SNK NeoGeo Pocket Color
@@ -780,6 +861,11 @@ makeinstall_target() {
   case ${DEVICE} in
     H700|RK3326|RK3399|RK3566|RK3588|SM8250|SM8550|SM8650)
       add_emu_core ngpc mednafen ngp false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core ngpc ares ares-sa false
       ;;
   esac
   add_es_system ngpc
@@ -800,6 +886,7 @@ makeinstall_target() {
     SM8550)
       add_emu_core n64 daedalusx64 daedalusx64-sa false
       add_emu_core n64 gopher64 gopher64-sa false
+      add_emu_core n64 ares ares-sa false
       install_script "Start DaedalusX64.sh"
       ;;
     SM8650)
@@ -812,6 +899,11 @@ makeinstall_target() {
   add_emu_core n64dd retroarch mupen64plus_next true
   add_emu_core n64dd retroarch parallel_n64 false
   add_emu_core n64dd mupen64plus mupen64plus-sa false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core n64dd ares ares-sa false
+      ;;
+  esac
   add_es_system n64dd
 
   ### Nintendo DS
@@ -889,6 +981,11 @@ makeinstall_target() {
       add_emu_core nes mednafen nes false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core nes ares ares-sa false
+      ;;
+  esac
   add_es_system nes
 
   ### Nintendo NES Hacks
@@ -899,6 +996,11 @@ makeinstall_target() {
   case ${DEVICE} in
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core nesh mednafen nesh false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core nesh ares ares-sa false
       ;;
   esac
   add_es_system nesh
@@ -929,6 +1031,11 @@ makeinstall_target() {
       add_emu_core pcengine mednafen pce_fast false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core pcengine ares ares-sa false
+      ;;
+  esac
   add_es_system pcengine
 
   ### NEC PC Engine CD
@@ -939,6 +1046,11 @@ makeinstall_target() {
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core pcenginecd mednafen pce false
       add_emu_core pcenginecd mednafen pce_fast false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core pcenginecd ares ares-sa false
       ;;
   esac
   add_es_system pcenginecd
@@ -1050,16 +1162,31 @@ makeinstall_target() {
 
   ### Sega 32X
   add_emu_core sega32x retroarch picodrive true
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core sega32x ares ares-sa false
+      ;;
+  esac
   add_es_system sega32x
 
   ### Sega CD
   add_emu_core segacd retroarch genesis_plus_gx true
   add_emu_core segacd retroarch picodrive false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core segacd ares ares-sa false
+      ;;
+  esac
   add_es_system segacd
 
   ### Sega Mega-CD
   add_emu_core megacd retroarch genesis_plus_gx true
   add_emu_core megacd retroarch picodrive false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core megacd ares ares-sa false
+      ;;
+  esac
   add_es_system megacd
 
   ### Sega Genesis
@@ -1069,6 +1196,11 @@ makeinstall_target() {
   case ${DEVICE} in
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core genesis mednafen md false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core genesis ares ares-sa false
       ;;
   esac
   add_es_system genesis
@@ -1082,6 +1214,11 @@ makeinstall_target() {
       add_emu_core genh mednafen md false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core genh ares ares-sa false
+      ;;
+  esac
   add_es_system genh
 
   ### Sega MasterSystem
@@ -1092,6 +1229,11 @@ makeinstall_target() {
   case ${DEVICE} in
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core mastersystem mednafen sms false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core mastersystem ares ares-sa false
       ;;
   esac
   add_es_system mastersystem
@@ -1153,6 +1295,11 @@ makeinstall_target() {
   add_emu_core sg-1000 retroarch gearsystem true
   add_emu_core sg-1000 retroarch genesis_plus_gx false
   add_emu_core sg-1000 retroarch picodrive false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core sg-1000 ares ares-sa false
+      ;;
+  esac
   add_es_system sg-1000
 
   ### Sharp X1
@@ -1170,6 +1317,11 @@ makeinstall_target() {
 
   ### Sinclair ZX Spectrum
   add_emu_core zxspectrum retroarch fuse true
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core zxspectrum ares ares-sa false
+      ;;
+  esac
   add_es_system zxspectrum
 
   ### Sinclair ZX81
@@ -1183,6 +1335,11 @@ makeinstall_target() {
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core supergrafx mednafen pce false
       add_emu_core supergrafx mednafen pce_fast false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core supergrafx ares ares-sa false
       ;;
   esac
   add_es_system supergrafx
@@ -1211,6 +1368,11 @@ makeinstall_target() {
       add_emu_core snes mednafen snes_faust false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core snes ares ares-sa false
+      ;;
+  esac
   add_es_system snes
 
   ### Nintendo SNES Hacks
@@ -1235,6 +1397,11 @@ makeinstall_target() {
   case ${DEVICE} in
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core snesh mednafen snes_faust false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core snesh ares ares-sa false
       ;;
   esac
   add_es_system snesh
@@ -1263,6 +1430,11 @@ makeinstall_target() {
       add_emu_core sfc mednafen snes_faust false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core sfc ares ares-sa false
+      ;;
+  esac
   add_es_system sfc
 
   ### Nintendo Stellaview
@@ -1271,10 +1443,20 @@ makeinstall_target() {
   add_emu_core satellaview retroarch snes9x2002 false
   add_emu_core satellaview retroarch snes9x2005_plus false
   add_emu_core satellaview retroarch mesen-s false
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core satellaview ares ares-sa false
+      ;;
+  esac
   add_es_system satellaview
 
   ### Bandai SuFami Turbo
   add_emu_core sufami retroarch snes9x true
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core sufami ares ares-sa false
+      ;;
+  esac
   add_es_system sufami
 
   ### Watara Supervision
@@ -1345,6 +1527,11 @@ makeinstall_target() {
       add_emu_core wonderswan mednafen wswan false
       ;;
   esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core wonderswan ares ares-sa false
+      ;;
+  esac
   add_es_system wonderswan
 
   ### Bandai Wonderswan Color
@@ -1352,6 +1539,11 @@ makeinstall_target() {
   case ${DEVICE} in
     H700|RK3326|RK3399|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650)
       add_emu_core wonderswancolor mednafen wswan false
+      ;;
+  esac
+  case ${DEVICE} in
+    SM8550)
+      add_emu_core wonderswancolor ares ares-sa false
       ;;
   esac
   add_es_system wonderswancolor


### PR DESCRIPTION
Add Ares multi emulator. Currently only on SM8550 platform. 

Supports several nintendo and other retro systems. 

Thanks to @reglinux for the host build patch:
https://github.com/REG-Linux/REG-Linux/blob/master/package/emulators/ares/000-cmake-sourcery-only.patch