### PR TITLE
[Mangmi Air X] Add powermanagment, error checking and UART desync managment

### DIFF
--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0005-input-joystick-add-mangmi-airx-driver.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0005-input-joystick-add-mangmi-airx-driver.patch
@@ -41,7 +41,7 @@ diff --git a/drivers/input/joystick/mangmi.c b/drivers/input/joystick/mangmi.c
 new file mode 100644
 --- /dev/null
 +++ b/drivers/input/joystick/mangmi.c
-@@ -0,0 +1,526 @@
+@@ -0,0 +1,531 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * MANGMI Air X Joypad Driver

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0005-input-joystick-add-mangmi-airx-driver.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0005-input-joystick-add-mangmi-airx-driver.patch
@@ -41,12 +41,16 @@ diff --git a/drivers/input/joystick/mangmi.c b/drivers/input/joystick/mangmi.c
 new file mode 100644
 --- /dev/null
 +++ b/drivers/input/joystick/mangmi.c
-@@ -0,0 +1,445 @@
+@@ -0,0 +1,526 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * MANGMI Air X Joypad Driver
 + *
 + * Copyright (c) 2025, ROCKNIX <https://rocknix.org>
++ *
++ * Packet synchronization modeled after twidjoy.c and sermouse.c:
++ * - Header byte validation at rx_idx == 0 (twidjoy pattern)
++ * - Timeout-based resync when packet assembly stalls (sermouse pattern)
 + */
 +
 +#include <linux/errno.h>
@@ -54,6 +58,7 @@ new file mode 100644
 +#include <linux/interrupt.h>
 +#include <linux/init.h>
 +#include <linux/input.h>
++#include <linux/jiffies.h>
 +#include <linux/kernel.h>
 +#include <linux/module.h>
 +#include <linux/of.h>
@@ -65,6 +70,8 @@ new file mode 100644
 +#define DRIVER_NAME         "mangmi-air-x-joypad"
 +#define MCU_PKT_LEN         64
 +#define MCU_HEADER_BYTE     0x00
++#define MCU_PKT_TIMEOUT_MS  100
++#define MCU_BAUDRATE        4000000
 +
 +#define MANGMI_ADC_LO       900
 +#define MANGMI_ADC_HI       3300
@@ -172,6 +179,7 @@ new file mode 100644
 +
 +	u8 rx_buf[MCU_PKT_LEN];
 +	int rx_idx;
++	unsigned long rx_start;
 +};
 +
 +static void mangmi_set_axis_absinfo(struct input_dev *idev)
@@ -211,7 +219,6 @@ new file mode 100644
 +	return (int32_t)DIV_ROUND_CLOSEST(adc * (int64_t)0x580, MANGMI_ADC_HALFSPAN);
 +}
 +
-+/* Interrupt Handler for Start/Select/Mode/Back */
 +static irqreturn_t mcu_gpio_btn_handler(int irq, void *dev_id)
 +{
 +	struct mcu_joy_drv *drv = dev_id;
@@ -238,9 +245,8 @@ new file mode 100644
 +	int32_t x, y, rx, ry, z, rz;
 +	int32_t rl, rr;
 +
-+	if (!dev || data[0] != MCU_HEADER_BYTE)
++	if (!dev)
 +		return;
-+
 +
 +	if (update_params) {
 +		mangmi_set_axis_absinfo(dev);
@@ -257,16 +263,16 @@ new file mode 100644
 +	}
 +
 +	/* Thumb Sticks (Click) */
-+	input_report_key(dev, BTN_THUMBL, data[2] & MASK_BTN_THUMBL);
-+	input_report_key(dev, BTN_THUMBR, data[2] & MASK_BTN_THUMBR);
++	input_report_key(dev, BTN_THUMBL, !!(data[2] & MASK_BTN_THUMBL));
++	input_report_key(dev, BTN_THUMBR, !!(data[2] & MASK_BTN_THUMBR));
 +
 +	/* Face Buttons & Shoulders */
-+	input_report_key(dev, BTN_A, data[3] & MASK_BTN_A);
-+	input_report_key(dev, BTN_B, data[3] & MASK_BTN_B);
-+	input_report_key(dev, BTN_X, data[3] & MASK_BTN_X);
-+	input_report_key(dev, BTN_Y, data[3] & MASK_BTN_Y);
-+	input_report_key(dev, BTN_TL, data[3] & MASK_BTN_TL);
-+	input_report_key(dev, BTN_TR, data[3] & MASK_BTN_TR);
++	input_report_key(dev, BTN_A, !!(data[3] & MASK_BTN_A));
++	input_report_key(dev, BTN_B, !!(data[3] & MASK_BTN_B));
++	input_report_key(dev, BTN_X, !!(data[3] & MASK_BTN_X));
++	input_report_key(dev, BTN_Y, !!(data[3] & MASK_BTN_Y));
++	input_report_key(dev, BTN_TL, !!(data[3] & MASK_BTN_TL));
++	input_report_key(dev, BTN_TR, !!(data[3] & MASK_BTN_TR));
 +
 +	/* Left Stick */
 +	raw_val = get_unaligned_le16(&data[6]);
@@ -298,7 +304,7 @@ new file mode 100644
 +	     INT_SIGN(ry) * (abs(ry) - axis_righty_antideadzone);
 +	input_report_abs(dev, ABS_RY, ry);
 +
-+	/* Analog Triggers — scale MCU range into 0..trigger_*_max for GPcal */
++	/* Analog Triggers */
 +	rl = ((u32)data[14] << 8) | data[4];
 +	rl = clamp(rl, (int32_t)MANGMI_TRIG_LO, (int32_t)MANGMI_TRIG_HI);
 +	z = DIV_ROUND_CLOSEST((rl - MANGMI_TRIG_LO) * (int64_t)trigger_left_max, MANGMI_TRIG_SPAN);
@@ -314,12 +320,23 @@ new file mode 100644
 +	input_sync(dev);
 +}
 +
-+static size_t mcu_joy_receive_buf(struct serdev_device *serdev, const u8 *data, size_t count)
++static size_t mcu_joy_receive_buf(struct serdev_device *serdev,
++				  const u8 *data, size_t count)
 +{
 +	struct mcu_joy_drv *drv = serdev_device_get_drvdata(serdev);
-+	int i;
++	size_t i;
++
++	if (drv->rx_idx > 0 &&
++	    time_after(jiffies, drv->rx_start + msecs_to_jiffies(MCU_PKT_TIMEOUT_MS)))
++		drv->rx_idx = 0;
 +
 +	for (i = 0; i < count; i++) {
++		if (drv->rx_idx == 0) {
++			if (data[i] != MCU_HEADER_BYTE)
++				continue;
++			drv->rx_start = jiffies;
++		}
++
 +		drv->rx_buf[drv->rx_idx++] = data[i];
 +
 +		if (drv->rx_idx == MCU_PKT_LEN) {
@@ -349,9 +366,62 @@ new file mode 100644
 +		return irq;
 +
 +	error = devm_request_threaded_irq(dev, irq, NULL, mcu_gpio_btn_handler,
-+					  IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING | IRQF_ONESHOT,
++					  IRQF_TRIGGER_RISING |
++					  IRQF_TRIGGER_FALLING |
++					  IRQF_ONESHOT,
 +					  name, drv);
 +	return error;
++}
++
++static int mcu_hw_init(struct mcu_joy_drv *drv)
++{
++	int error;
++
++	if (drv->power_gpio)
++		gpiod_set_value_cansleep(drv->power_gpio, 0);
++	if (drv->stick_en_gpio)
++		gpiod_set_value_cansleep(drv->stick_en_gpio, 0);
++	if (drv->reset_gpio)
++		gpiod_set_value_cansleep(drv->reset_gpio, 1);
++
++	msleep(500);
++
++	if (drv->power_gpio)
++		gpiod_set_value_cansleep(drv->power_gpio, 1);
++	if (drv->stick_en_gpio)
++		gpiod_set_value_cansleep(drv->stick_en_gpio, 1);
++
++	/* Boot pins high = MCU runs from internal flash */
++	if (drv->boot0_gpio)
++		gpiod_set_value_cansleep(drv->boot0_gpio, 1);
++	if (drv->boot1_gpio)
++		gpiod_set_value_cansleep(drv->boot1_gpio, 1);
++
++	error = serdev_device_set_parity(drv->serdev, SERDEV_PARITY_NONE);
++	if (error)
++		return error;
++
++	serdev_device_set_flow_control(drv->serdev, false);
++	serdev_device_set_baudrate(drv->serdev, MCU_BAUDRATE);
++
++	if (drv->reset_gpio) {
++		msleep(20);
++		gpiod_set_value_cansleep(drv->reset_gpio, 0);
++	}
++
++	drv->rx_idx = 0;
++
++	return 0;
++}
++
++static void mcu_hw_shutdown(struct mcu_joy_drv *drv)
++{
++	if (drv->reset_gpio)
++		gpiod_set_value_cansleep(drv->reset_gpio, 1);
++	if (drv->stick_en_gpio)
++		gpiod_set_value_cansleep(drv->stick_en_gpio, 0);
++	if (drv->power_gpio)
++		gpiod_set_value_cansleep(drv->power_gpio, 0);
 +}
 +
 +static int mcu_joy_probe(struct serdev_device *serdev)
@@ -367,15 +437,40 @@ new file mode 100644
 +	drv->serdev = serdev;
 +
 +	drv->boot0_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-boot0", GPIOD_OUT_LOW);
++	if (IS_ERR(drv->boot0_gpio))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->boot0_gpio), "boot0 GPIO\n");
++
 +	drv->boot1_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-boot1", GPIOD_OUT_LOW);
++	if (IS_ERR(drv->boot1_gpio))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->boot1_gpio), "boot1 GPIO\n");
++
 +	drv->reset_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-reset", GPIOD_OUT_LOW);
++	if (IS_ERR(drv->reset_gpio))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->reset_gpio), "reset GPIO\n");
++
 +	drv->power_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-power", GPIOD_OUT_LOW);
++	if (IS_ERR(drv->power_gpio))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->power_gpio), "power GPIO\n");
++
 +	drv->stick_en_gpio = devm_gpiod_get_optional(&serdev->dev, "stick-en", GPIOD_OUT_LOW);
++	if (IS_ERR(drv->stick_en_gpio))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->stick_en_gpio), "stick-en GPIO\n");
 +
 +	drv->btn_start = devm_gpiod_get_optional(&serdev->dev, "mcu-start", GPIOD_IN);
++	if (IS_ERR(drv->btn_start))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_start), "start GPIO\n");
++
 +	drv->btn_select = devm_gpiod_get_optional(&serdev->dev, "mcu-select", GPIOD_IN);
++	if (IS_ERR(drv->btn_select))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_select), "select GPIO\n");
++
 +	drv->btn_mode = devm_gpiod_get_optional(&serdev->dev, "mcu-mode", GPIOD_IN);
++	if (IS_ERR(drv->btn_mode))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_mode), "mode GPIO\n");
++
 +	drv->btn_back = devm_gpiod_get_optional(&serdev->dev, "mcu-back", GPIOD_IN);
++	if (IS_ERR(drv->btn_back))
++		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_back), "back GPIO\n");
 +
 +	input = devm_input_allocate_device(&serdev->dev);
 +	if (!input)
@@ -408,47 +503,27 @@ new file mode 100644
 +	if (error)
 +		return error;
 +
-+	mcu_setup_gpio_irq(&serdev->dev, drv->btn_start, drv, "btn-start");
-+	mcu_setup_gpio_irq(&serdev->dev, drv->btn_select, drv, "btn-select");
-+	mcu_setup_gpio_irq(&serdev->dev, drv->btn_mode, drv, "btn-mode");
-+	mcu_setup_gpio_irq(&serdev->dev, drv->btn_back, drv, "btn-back");
-+
-+	if (drv->power_gpio)
-+		gpiod_set_value_cansleep(drv->power_gpio, 0);
-+	if (drv->stick_en_gpio)
-+		gpiod_set_value_cansleep(drv->stick_en_gpio, 0);
-+	if (drv->reset_gpio)
-+		gpiod_set_value_cansleep(drv->reset_gpio, 1);
-+
-+	msleep(500);
-+
-+	if (drv->power_gpio)
-+		gpiod_set_value_cansleep(drv->power_gpio, 1);
-+	if (drv->stick_en_gpio)
-+		gpiod_set_value_cansleep(drv->stick_en_gpio, 1);
-+
-+	if (drv->boot0_gpio)
-+		gpiod_set_value_cansleep(drv->boot0_gpio, 1);
-+	if (drv->boot1_gpio)
-+		gpiod_set_value_cansleep(drv->boot1_gpio, 1);
++	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_start, drv, "btn-start");
++	if (error)
++		return error;
++	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_select, drv, "btn-select");
++	if (error)
++		return error;
++	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_mode, drv, "btn-mode");
++	if (error)
++		return error;
++	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_back, drv, "btn-back");
++	if (error)
++		return error;
 +
 +	serdev_device_set_client_ops(serdev, &mcu_joy_serdev_ops);
-+
 +	error = devm_serdev_device_open(&serdev->dev, serdev);
 +	if (error)
-+		return dev_err_probe(&serdev->dev, error, "UART Open Failed\n");
++		return dev_err_probe(&serdev->dev, error, "UART open failed\n");
 +
-+	error = serdev_device_set_parity(serdev, SERDEV_PARITY_NONE);
++	error = mcu_hw_init(drv);
 +	if (error)
-+		return dev_err_probe(&serdev->dev, error, "Set parity Failed\n");
-+
-+	serdev_device_set_flow_control(serdev, false);
-+	serdev_device_set_baudrate(serdev, 4000000);
-+
-+	if (drv->reset_gpio) {
-+		msleep(20);
-+		gpiod_set_value_cansleep(drv->reset_gpio, 0);
-+	}
++		return dev_err_probe(&serdev->dev, error, "MCU init failed\n");
 +
 +	return 0;
 +}
@@ -457,15 +532,25 @@ new file mode 100644
 +{
 +	struct mcu_joy_drv *drv = serdev_device_get_drvdata(serdev);
 +
-+	serdev_device_close(serdev);
-+
-+	if (drv->reset_gpio)
-+		gpiod_set_value_cansleep(drv->reset_gpio, 1);
-+	if (drv->stick_en_gpio)
-+		gpiod_set_value_cansleep(drv->stick_en_gpio, 0);
-+	if (drv->power_gpio)
-+		gpiod_set_value_cansleep(drv->power_gpio, 0);
++	mcu_hw_shutdown(drv);
 +}
++
++static int mcu_joy_suspend(struct device *dev)
++{
++	struct mcu_joy_drv *drv = dev_get_drvdata(dev);
++
++	mcu_hw_shutdown(drv);
++	return 0;
++}
++
++static int mcu_joy_resume(struct device *dev)
++{
++	struct mcu_joy_drv *drv = dev_get_drvdata(dev);
++
++	return mcu_hw_init(drv);
++}
++
++static DEFINE_SIMPLE_DEV_PM_OPS(mcu_joy_pm_ops, mcu_joy_suspend, mcu_joy_resume);
 +
 +static const struct of_device_id mcu_joy_of_match[] = {
 +	{ .compatible = "rocknix,mangmi-air-x-joypad" },
@@ -477,6 +562,7 @@ new file mode 100644
 +	.driver = {
 +		.name = DRIVER_NAME,
 +		.of_match_table = mcu_joy_of_match,
++		.pm = pm_sleep_ptr(&mcu_joy_pm_ops),
 +	},
 +	.probe = mcu_joy_probe,
 +	.remove = mcu_joy_remove,


### PR DESCRIPTION
Most changes based on previously available joystick drivers in mainline.

## Summary

* **What is the goal of this PR?** Implement proper suspend/resume and recovery from desync logic based on other mainline UART based controller drivers. 

## Testing

* **How was this tested?** Tested briefly on mangmi air x. 

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** No
