### PR TITLE
Fix DSC panels on kernel 7.0+

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0130-restore_widebus_calculation_for_CMDMode_panels.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0130-restore_widebus_calculation_for_CMDMode_panels.patch
@@ -1,0 +1,50 @@
+From eb9edb2f9aee0ddc9c9c55e09aac9aebab7abf3c Mon Sep 17 00:00:00 2001
+From: Marijn Suijten <marijn.suijten@somainline.org>
+Date: Wed, 11 Mar 2026 23:31:09 +0100
+Subject: [PATCH] drm/msm/dsi: Restore widebus calculation for CMDMode panels
+
+Commit ac47870fd795 ("drm/msm/dsi: fix hdisplay calculation when
+programming dsi registers") makes a false and ungrounded statement that
+"Since CMD mode does not use this, we can remove !(msm_host->mode_flags
+& MIPI_DSI_MODE_VIDEO) safely." which isn't the case at all.
+dsi_timing_setup() affects both command mode and video mode panels, and
+by no longer having any path that sets bits_per_pclk = 48 (contrary to
+the updated code-comment) all DSI DSC panels on SM8350 and above (i.e.
+with widebus support) regress thanks to this patch.
+
+The entire reason that video mode was originally omitted from this code
+path is because it was never tested before; any change that enables
+widebus for video mode panels should not regress the command mode path.
+
+Thus add back the path allows 6 bytes or 48 bits to be sent per pclk
+on command mode DSI panels with widebus, restoring the panel on devices
+like the Sony Xperia 1 III and upwards.
+
+Fixes: ac47870fd795 ("drm/msm/dsi: fix hdisplay calculation when programming dsi registers")
+Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>
+---
+ drivers/gpu/drm/msm/dsi/dsi_host.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dsi/dsi_host.c b/drivers/gpu/drm/msm/dsi/dsi_host.c
+index db6da99375a185..d5cc27d39eb7a3 100644
+--- a/drivers/gpu/drm/msm/dsi/dsi_host.c
++++ b/drivers/gpu/drm/msm/dsi/dsi_host.c
+@@ -1046,10 +1046,14 @@ static void dsi_timing_setup(struct msm_dsi_host *msm_host, bool is_bonded_dsi)
+ 		 * unused anyway.
+ 		 */
+ 		h_total -= hdisplay;
+-		if (wide_bus_enabled)
+-			bits_per_pclk = mipi_dsi_pixel_format_to_bpp(msm_host->format);
+-		else
++		if (wide_bus_enabled) {
++			if (msm_host->mode_flags & MIPI_DSI_MODE_VIDEO)
++				bits_per_pclk = mipi_dsi_pixel_format_to_bpp(msm_host->format);
++			else
++				bits_per_pclk = 48;
++		} else {
+ 			bits_per_pclk = 24;
++		}
+ 
+ 		hdisplay = DIV_ROUND_UP(msm_dsc_get_bytes_per_line(msm_host->dsc) * 8, bits_per_pclk);
+ 

--- a/projects/ROCKNIX/devices/SM8650/patches/linux/0130-restore_widebus_calculation_for_CMDMode_panels.patch
+++ b/projects/ROCKNIX/devices/SM8650/patches/linux/0130-restore_widebus_calculation_for_CMDMode_panels.patch
@@ -1,0 +1,50 @@
+From eb9edb2f9aee0ddc9c9c55e09aac9aebab7abf3c Mon Sep 17 00:00:00 2001
+From: Marijn Suijten <marijn.suijten@somainline.org>
+Date: Wed, 11 Mar 2026 23:31:09 +0100
+Subject: [PATCH] drm/msm/dsi: Restore widebus calculation for CMDMode panels
+
+Commit ac47870fd795 ("drm/msm/dsi: fix hdisplay calculation when
+programming dsi registers") makes a false and ungrounded statement that
+"Since CMD mode does not use this, we can remove !(msm_host->mode_flags
+& MIPI_DSI_MODE_VIDEO) safely." which isn't the case at all.
+dsi_timing_setup() affects both command mode and video mode panels, and
+by no longer having any path that sets bits_per_pclk = 48 (contrary to
+the updated code-comment) all DSI DSC panels on SM8350 and above (i.e.
+with widebus support) regress thanks to this patch.
+
+The entire reason that video mode was originally omitted from this code
+path is because it was never tested before; any change that enables
+widebus for video mode panels should not regress the command mode path.
+
+Thus add back the path allows 6 bytes or 48 bits to be sent per pclk
+on command mode DSI panels with widebus, restoring the panel on devices
+like the Sony Xperia 1 III and upwards.
+
+Fixes: ac47870fd795 ("drm/msm/dsi: fix hdisplay calculation when programming dsi registers")
+Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>
+---
+ drivers/gpu/drm/msm/dsi/dsi_host.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dsi/dsi_host.c b/drivers/gpu/drm/msm/dsi/dsi_host.c
+index db6da99375a185..d5cc27d39eb7a3 100644
+--- a/drivers/gpu/drm/msm/dsi/dsi_host.c
++++ b/drivers/gpu/drm/msm/dsi/dsi_host.c
+@@ -1046,10 +1046,14 @@ static void dsi_timing_setup(struct msm_dsi_host *msm_host, bool is_bonded_dsi)
+ 		 * unused anyway.
+ 		 */
+ 		h_total -= hdisplay;
+-		if (wide_bus_enabled)
+-			bits_per_pclk = mipi_dsi_pixel_format_to_bpp(msm_host->format);
+-		else
++		if (wide_bus_enabled) {
++			if (msm_host->mode_flags & MIPI_DSI_MODE_VIDEO)
++				bits_per_pclk = mipi_dsi_pixel_format_to_bpp(msm_host->format);
++			else
++				bits_per_pclk = 48;
++		} else {
+ 			bits_per_pclk = 24;
++		}
+ 
+ 		hdisplay = DIV_ROUND_UP(msm_dsc_get_bytes_per_line(msm_host->dsc) * 8, bits_per_pclk);
+ 


### PR DESCRIPTION
Fixes RP6 panel. 

Source: https://github.com/AYNTechnologies/linux/commit/eb9edb2f9aee0ddc9c9c55e09aac9aebab7abf3c.patch