### PR TITLE
SM8250: Fix fan on linux 7.0

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/fancontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/fancontrol
@@ -8,6 +8,13 @@ DEBUG=false
 COOLING_PROFILE=$(get_setting "cooling.profile")
 FAN_PWM="${DEVICE_PWM_FAN}"
 
+# Enable fan if it's turned off
+if [ -f "${DEVICE_PWM_FAN}_enable" ] && [ "$(cat "${DEVICE_PWM_FAN}_enable")" != "1" ]; then
+  echo 1 > "${DEVICE_PWM_FAN}_enable"
+  echo "Enabling fan pwm"
+fi
+
+
 log $0 "Setting profile to ${COOLING_PROFILE}"
 
 function set_control() {


### PR DESCRIPTION
Make sure the SM8250 fan enable pwm is set to 1