### PR TITLE
[RK3576] Fix debug tty to ttyS0

### DIFF
--- a/projects/ROCKNIX/devices/RK3576/options
+++ b/projects/ROCKNIX/devices/RK3576/options
@@ -33,7 +33,7 @@
     KERNEL_MAKE_EXTRACMD=" $(get_kernel_make_extracmd)"
 
   # Kernel cmdline
-    EXTRA_CMDLINE="quiet console=ttyFIQ0 console=tty0 systemd.debug_shell=ttyFIQ0 coherent_pool=2M"
+    EXTRA_CMDLINE="quiet console=ttyS0 console=tty0 systemd.debug_shell=ttyS0 coherent_pool=2M"
 
   # Bootloader to use (syslinux / u-boot)
     BOOTLOADER="u-boot"
@@ -79,7 +79,7 @@
     ADDITIONAL_PACKAGES_32BIT="libmali"
 
   # Debug tty path
-    DEBUG_TTY="/dev/ttyFIQ0"
+    DEBUG_TTY="/dev/ttyS0"
 
   # Build and install rocknix out-of-tree device trees and overlays (yes / no)
     ROCKNIX_DEVICE_TREE_OVERLAYS="no"


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Minor cmdline fix. Prevents debug shell error on boot.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Tested with rebuild and flash on RG Vita Pro

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
