### PR TITLE
[RG DS] DTS sleep/audio pop fix attempt

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -306,12 +306,14 @@
 		simple-audio-card,aux-devs = <&aw87391_pa_l>, <&aw87391_pa_r>;
 		simple-audio-card,name = "rk817_ext";
 		simple-audio-card,pin-switches = "Internal Speakers";
-		simple-audio-card,routing =
-			"MICL", "Mic Jack",
-			"Headphones", "HPOL",
-			"Headphones", "HPOR",
-			"Internal Speakers", "HPOL",
-			"Internal Speakers", "HPOR";
+        simple-audio-card,routing =
+            "MICL", "Mic Jack",
+            "Headphones", "HPOL",
+            "Headphones", "HPOR",
+            "Internal Speakers", "Left AMP OUT",
+            "Internal Speakers", "Right AMP OUT",
+            "Left AMP IN", "HPOL",
+            "Right AMP IN", "HPOR";
 		simple-audio-card,widgets =
 			"Microphone", "Mic Jack",
 			"Headphone", "Headphones",
@@ -740,7 +742,7 @@
 			};
 		};
 
-	       rk817_charger: charger {
+	    rk817_charger: charger {
 			monitored-battery = <&battery>;
 			rockchip,resistor-sense-micro-ohms = <10000>;
 			rockchip,sleep-enter-current-microamp = <150000>;
@@ -1150,10 +1152,6 @@
 	status = "okay";
 };
 
-&usb_host0_ohci {
-	status = "okay";
-};
-
 &usb2phy0 {
 	status = "okay";
 };
@@ -1192,4 +1190,9 @@
 		reg = <ROCKCHIP_VOP2_EP_MIPI1>;
 		remote-endpoint = <&dsi1_in_vp1>;
 	};
+};
+
+/* Disabled due to PM issues */
+&usb_host0_ohci {
+	status = "disabled";
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Attempts to fix intermittent sleep issues and audio pops caused from recent DTS changes on the RG DS.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Tested on my RG DS, audio pops seem to be gone on boot and sleep works after the 30 second start up sleep blocking caused by the wifi driver looking for regulatory.db and not finding it.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

This is a tentative fix, will require mass testing to confirm.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
