### PR TITLE
Actually enable increased speed bin

### DIFF
--- a/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
+++ b/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
@@ -483,9 +483,32 @@
 &gpu {
 	status = "okay";
 
+	interconnects = <&bimc MASTER_GRAPHICS_3D RPM_ACTIVE_TAG
+			 &bimc SLAVE_EBI_CH0 RPM_ACTIVE_TAG>;
+	interconnect-names = "gfx-mem";
+
 	zap-shader {
 		firmware-name = "qcom/qrb4210/a610_zap.mbn";
 	};
+};
+
+&gpu_opp_table {
+	opp-320000000  { opp-peak-kBps = < 3523437>; };
+	opp-465000000  { opp-peak-kBps = < 6000000>; };
+	opp-600000000  { opp-peak-kBps = < 7950000>; };
+	opp-745000000  { opp-peak-kBps = <10570312>; };
+	opp-820000000  { opp-peak-kBps = <12152533>; };
+	opp-900000000  { opp-peak-kBps = <14092726>; };
+	opp-950000000  { opp-peak-kBps = <14092726>; };
+	opp-980000000  { opp-peak-kBps = <14092726>; };
+	opp-1050000000 { opp-peak-kBps = <16343750>; };
+};
+
+&cpu_bwmon_opp_table {
+	opp-10 { opp-peak-kBps = <10570312>; };
+	opp-11 { opp-peak-kBps = <12152533>; };
+	opp-12 { opp-peak-kBps = <14092726>; };
+	opp-13 { opp-peak-kBps = <16343750>; };
 };
 
 &mdss {

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0004-gpu-drm-msm-a610-unlock-1050MHz-overclock.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0004-gpu-drm-msm-a610-unlock-1050MHz-overclock.patch
@@ -2,29 +2,29 @@ From a1068b755e5787a3b676fba670be9f702d807767 Mon Sep 17 00:00:00 2001
 From: Philippe Simons <simons.philippe@gmail.com>
 Date: Sat, 27 Dec 2025 20:49:13 +0100
 Subject: [PATCH] gpu:drm:msm: a610 add 221 speedbin
+Updated Subject: [PATCH] gpu:drm:msm: a610 unlock 1050 MHz based on stock values
 
 ---
- arch/arm64/boot/dts/qcom/sm6115.dtsi      | 24 ++++++++++++++++-------
- drivers/gpu/drm/msm/adreno/a6xx_catalog.c |  1 +
+ arch/arm64/boot/dts/qcom/sm6115.dtsi      | 17 +++++++++++++----
+ drivers/clk/qcom/gpucc-sm6115.c           |  3 ++-
+ drivers/gpu/drm/msm/adreno/a6xx_catalog.c |  3 ++-
  drivers/pmdomain/qcom/rpmpd.c             |  2 +-
- 3 files changed, 19 insertions(+), 8 deletions(-)
+ 4 files changed, 18 insertions(+), 7 deletions(-)
 
-diff --git a/arch/arm64/boot/dts/qcom/sm6115.dtsi b/arch/arm64/boot/dts/qcom/sm6115.dtsi
-index 91fc36b59abf..7b6b6602cdeb 100644
 --- a/arch/arm64/boot/dts/qcom/sm6115.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm6115.dtsi
-@@ -429,6 +429,10 @@ rpmpd_opp_turbo: opp7 {
+@@ -428,6 +428,10 @@
+ 
  						rpmpd_opp_turbo_plus: opp8 {
  							opp-level = <RPM_SMD_LEVEL_TURBO_NO_CPR>;
- 						};
++						};
 +
 +						rpmpd_opp_turbo_high: opp9 {
 +							opp-level = <464>;
-+						};
+ 						};
  					};
  				};
- 			};
-@@ -1755,37 +1759,37 @@ gpu_opp_table: opp-table {
+@@ -1759,37 +1763,37 @@
  				opp-320000000 {
  					opp-hz = /bits/ 64 <320000000>;
  					required-opps = <&rpmpd_opp_low_svs>;
@@ -68,7 +68,7 @@ index 91fc36b59abf..7b6b6602cdeb 100644
  				};
  
  				/* Speed bin 2 can reach 950 Mhz instead of 980 like the rest. */
-@@ -1798,8 +1802,14 @@ opp-950000000 {
+@@ -1802,8 +1806,14 @@
  				opp-980000000 {
  					opp-hz = /bits/ 64 <980000000>;
  					required-opps = <&rpmpd_opp_turbo_plus>;
@@ -84,23 +84,44 @@ index 91fc36b59abf..7b6b6602cdeb 100644
  			};
  		};
  
-diff --git a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
-index 44df6410bce1..6d879871522f 100644
+--- a/drivers/clk/qcom/gpucc-sm6115.c
++++ b/drivers/clk/qcom/gpucc-sm6115.c
+@@ -39,7 +39,7 @@
+ };
+ 
+ static const struct pll_vco default_vco[] = {
+-	{ 1000000000, 2000000000, 0 },
++	{ 1000000000, 2100000000, 0 },
+ };
+ 
+ static const struct pll_vco pll1_vco[] = {
+@@ -216,6 +216,7 @@
+ 	F(900000000, P_GPU_CC_PLL0_OUT_AUX2, 2, 0, 0),
+ 	F(950000000, P_GPU_CC_PLL0_OUT_AUX2, 2, 0, 0),
+ 	F(980000000, P_GPU_CC_PLL0_OUT_AUX2, 2, 0, 0),
++	F(1050000000, P_GPU_CC_PLL0_OUT_AUX2, 2, 0, 0),
+ 	{ }
+ };
+ 
 --- a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
 +++ b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
-@@ -704,6 +704,7 @@ static const struct adreno_info a6xx_gpus[] = {
+@@ -706,11 +706,12 @@
+ 		 * table is only valid for bengal.
+ 		 */
+ 		.speedbins = ADRENO_SPEEDBINS(
+-			{ 0,   0 },
++			{ 0,   5 },
+ 			{ 206, 1 },
  			{ 200, 2 },
  			{ 157, 3 },
  			{ 127, 4 },
 +			{ 221, 5 },
  		),
  	}, {
- 		.chip_ids = ADRENO_CHIP_IDS(0x06010500),
-diff --git a/drivers/pmdomain/qcom/rpmpd.c b/drivers/pmdomain/qcom/rpmpd.c
-index f8580ec0f737..fd299d94cd76 100644
+ 		.chip_ids = ADRENO_CHIP_IDS(0x06010200),
 --- a/drivers/pmdomain/qcom/rpmpd.c
 +++ b/drivers/pmdomain/qcom/rpmpd.c
-@@ -877,7 +877,7 @@ static struct rpmpd *sm6115_rpmpds[] = {
+@@ -877,7 +877,7 @@
  static const struct rpmpd_desc sm6115_desc = {
  	.rpmpds = sm6115_rpmpds,
  	.num_pds = ARRAY_SIZE(sm6115_rpmpds),


### PR DESCRIPTION
Override gpu_opp_table with per OPP opp-peak-kBps values taken from vendor dts

Override cpu_bwmon opp table, unlikely to reach these but carried over from stock

## Summary

* **What is the goal of this PR?**  Enables use of higher speedbin (Matches stock)

## Testing

* **How was this tested?** Quick vkmark test, about 5-10% uplift. 

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
