### PR TITLE
linux: bump to 7.0.1

### DIFF
--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -31,7 +31,7 @@ case ${DEVICE} in
     PKG_PATCH_DIRS="${LINUX} ${DEVICE} default"
     ;;
   H700|SM8250|RK3399|RK3576|SM8650|SM8550|SM6115|S922X|RK3566)
-    PKG_VERSION="7.0"
+    PKG_VERSION="7.0.1"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     ;;
   *)


### PR DESCRIPTION
all our current 7.0 target compiled fine one 7.0.1
build is here https://github.com/loki666/ROCKNIX/actions/runs/24788592904

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
