### PR TITLE
SM6115 - installtointernal support

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/installtointernal
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/installtointernal
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 case "$HW_DEVICE" in
-  SM8250|SM8550|SM8650)
+  SM6115|SM8250|SM8550|SM8650)
     ;;
   *)
     echo "This script is not compatible with this device!"
@@ -16,7 +16,15 @@ case "$HW_DEVICE" in
     ;;
 esac
 
+# Derive internal storage block device
 DEVICE=/dev/sda
+
+if [[ "$HW_DEVICE" == "SM6115" ]]; then
+  # SM6115 is eMMC - slightly different
+  DEVICE=/dev/mmcblk1
+fi
+
+# Directory vars
 FLASH_DIR=/flash
 OLD_STORAGE=/storage
 TMP_ROCKNIX=/tmp/rocknix
@@ -78,6 +86,22 @@ IFS=':' read -r UD_NUM UD_STARTB UD_ENDB _ <<< "${ud_line[0]}"
 UD_START=${UD_STARTB%B}
 UD_END=${UD_ENDB%B}
 
+# Derive partition numbers
+RK_NUM=$(( UD_NUM + 1 ))
+ST_NUM=$(( UD_NUM + 2 ))
+
+# Derive partition block devices
+UD_PART_DEV="${DEVICE}${UD_NUM}"
+RK_PART_DEV="${DEVICE}${RK_NUM}"
+ST_PART_DEV="${DEVICE}${ST_NUM}"
+
+if [[ "$HW_DEVICE" == "SM6115" ]]; then
+  # SM6115 is eMMC - slightly different
+  UD_PART_DEV="${DEVICE}p${UD_NUM}"
+  RK_PART_DEV="${DEVICE}p${RK_NUM}"
+  ST_PART_DEV="${DEVICE}p${ST_NUM}"
+fi
+
 # Compute MiB-aligned boundaries for Android userdata
 UD_START_MB=$(( (UD_START + 1048575) / 1048576 ))     # round up to MiB
 UD_END_MB=$(( UD_END / 1048576 ))                     # round down to MiB
@@ -117,11 +141,10 @@ parted -a optimal -s "$DEVICE" \
 parted -s "$DEVICE" name "$UD_NUM" userdata
 
 # 5b) Wipe first 8 MiB of the new Android userdata partition
-echo "Zeroing first 8 MiB of ${DEVICE}${UD_NUM}..."
-dd if=/dev/zero of="${DEVICE}${UD_NUM}" bs=1M count=8 &>/dev/null
+echo "Zeroing first 8 MiB of ${UD_PART_DEV}..."
+dd if=/dev/zero of="${UD_PART_DEV}" bs=1M count=8 &>/dev/null
 
 # 6) Create ROCKNIX partition
-RK_NUM=$(( UD_NUM + 1 ))
 RK_START_MB=$NEW_UD_END_MB
 RK_END_MB=$(( RK_START_MB + 2048 ))  # 2 GiB
 echo "Creating ROCKNIX partition #$RK_NUM (${RK_START_MB}MiB–${RK_END_MB}MiB)..."
@@ -132,36 +155,35 @@ parted -s "$DEVICE" set "$RK_NUM" msftdata on
 parted -s "$DEVICE" set "$RK_NUM" boot on
 
 # 7) Format ROCKNIX partition
-if mount | grep -q "^${DEVICE}${RK_NUM} "; then
-  echo "Auto-unmounting ${DEVICE}${RK_NUM}..."
-  umount "${DEVICE}${RK_NUM}"
+if mount | grep -q "^${RK_PART_DEV} "; then
+  echo "Auto-unmounting ${RK_PART_DEV}..."
+  umount "${RK_PART_DEV}"
 fi
-mkfs.vfat -F 32 -S 4096 -s 4 -n ROCKNIX "${DEVICE}${RK_NUM}" &>/dev/null
+mkfs.vfat -F 32 -S 4096 -s 4 -n ROCKNIX "${RK_PART_DEV}" &>/dev/null
 
 # 8) Create STORAGE partition
-ST_NUM=$(( UD_NUM + 2 ))
 echo "Creating STORAGE partition #$ST_NUM (from ${RK_END_MB}MiB to end)..."
 parted -a optimal -s "$DEVICE" \
   mkpart primary ext4 "${RK_END_MB}MiB" 100%
 parted -s "$DEVICE" name "$ST_NUM" STORAGE
 
 # 9) Format STORAGE
-if mount | grep -q "^${DEVICE}${ST_NUM} "; then
-  echo "Auto-unmounting ${DEVICE}${ST_NUM}..."
-  umount "${DEVICE}${ST_NUM}"
+if mount | grep -q "^${ST_PART_DEV} "; then
+  echo "Auto-unmounting ${ST_PART_DEV}..."
+  umount "${ST_PART_DEV}"
 fi
-mkfs.ext4 -F -q -L STORAGE -T ext4 -O ^orphan_file -m 0 "${DEVICE}${ST_NUM}" &>/dev/null
+mkfs.ext4 -F -q -L STORAGE -T ext4 -O ^orphan_file -m 0 "${ST_PART_DEV}" &>/dev/null
 
 # 10) Final mounts: unmount any auto-mounted, then mount fresh
-for dev in "${DEVICE}${RK_NUM}" "${DEVICE}${ST_NUM}"; do
+for dev in "${RK_PART_DEV}" "${ST_PART_DEV}"; do
   if mount | grep -q "^$dev "; then
     echo "Auto-unmounting $dev..."
     umount "$dev"
   fi
 done
 mkdir -p "$TMP_ROCKNIX" "$TMP_STORAGE"
-mount "${DEVICE}${RK_NUM}" "$TMP_ROCKNIX"
-mount "${DEVICE}${ST_NUM}" "$TMP_STORAGE"
+mount "${RK_PART_DEV}" "$TMP_ROCKNIX"
+mount "${ST_PART_DEV}" "$TMP_STORAGE"
 
 # 11) Copy files to ROCKNIX partition, then sync
 echo "Copying flash files to ROCKNIX..."
@@ -200,13 +222,13 @@ umount "$TMP_STORAGE"
 rmdir "$TMP_ROCKNIX" "$TMP_STORAGE"
 
 # 15) Final summary with sizes
-ud_sz=$(get_gb "${DEVICE}${UD_NUM}")
-rk_sz=$(get_gb "${DEVICE}${RK_NUM}")
-st_sz=$(get_gb "${DEVICE}${ST_NUM}")
+ud_sz=$(get_gb "${UD_PART_DEV}")
+rk_sz=$(get_gb "${RK_PART_DEV}")
+st_sz=$(get_gb "${ST_PART_DEV}")
 
 echo "Done. New partitions:"
-echo "  Android userdata: ${DEVICE}${UD_NUM} (${ud_sz} GB)"
-echo "  ROCKNIX : ${DEVICE}${RK_NUM} (${rk_sz} GB)"
-echo "  STORAGE : ${DEVICE}${ST_NUM} (${st_sz} GB)"
+echo "  Android userdata: ${UD_PART_DEV} (${ud_sz} GB)"
+echo "  ROCKNIX : ${RK_PART_DEV} (${rk_sz} GB)"
+echo "  STORAGE : ${ST_PART_DEV} (${st_sz} GB)"
 echo
 echo "ROCKNIX Installation to internal UFS was successful. You can now reboot and remove your SD card."


### PR DESCRIPTION
## Summary

SM6115 - installtointernal support

## Testing

Tested on my MQ66 Air X:
```
SM6115:~ # ./installtointernal 
WARNING: This will wipe Android userdata on /dev/mmcblk1. Proceed? [y/N]: y
Current Android userdata size: 49 GB
You may choose between 1 GB and 41 GB
Enter new Android userdata size in GB: 8
Deleting Android userdata partition #85...
Creating Android userdata partition #85 (8832MiB–17024MiB)...
Zeroing first 8 MiB of /dev/mmcblk1p85...
Creating ROCKNIX partition #86 (17024MiB–19072MiB)...
Creating STORAGE partition #87 (from 19072MiB to end)...
Copying flash files to ROCKNIX...
Copy existing /storage to new STORAGE? [y/N]: y
Copying /storage to new STORAGE (excluding roms)...
Syncing final data to disk...
Cleaning up...
Done. New partitions:
  Android userdata: /dev/mmcblk1p85 (8 GB)
  ROCKNIX : /dev/mmcblk1p86 (2 GB)
  STORAGE : /dev/mmcblk1p87 (39 GB)

ROCKNIX Installation to internal UFS was successful. You can now reboot and remove your SD card.
```

Both Android and ROCKNIX boot fine from eMMC via ROCKNIX ABL.
## Additional Context

Refactored slightly as SM6115 eMMC partition block device names differ

---

### AI Usage

**Did you use AI tools to help write this code?** NO
