### PR TITLE
Bump ZeroTierOne and simple-http-server

### DIFF
--- a/projects/ROCKNIX/packages/network/simple-http-server/package.mk
+++ b/projects/ROCKNIX/packages/network/simple-http-server/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present NeoTheFox (https://github.com/NeoTheFox)
 
 PKG_NAME="simple-http-server"
-PKG_VERSION="0.6.7"
+PKG_VERSION="0.8.0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/TheWaWaR/simple-http-server"
 PKG_DEPENDS_TARGET="toolchain"

--- a/projects/ROCKNIX/packages/network/zerotier-one/package.mk
+++ b/projects/ROCKNIX/packages/network/zerotier-one/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2023-present NeoTheFox (https://github.com/NeoTheFox)
 
 PKG_NAME="zerotier-one"
-PKG_VERSION="1.14.0"
+PKG_VERSION="1.16.0"
 PKG_SITE="https://www.zerotier.com"
 PKG_URL="https://github.com/zerotier/ZeroTierOne/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain nlohmann-json"


### PR DESCRIPTION
## Summary

Bump ZeroTierOne to 1.16.0
Bump simple-http-server to 0.8.0

## Testing

* **How was this tested?**: Built with no issues on Actions 
https://github.com/NeoTheFox/rocknix/actions/runs/24881164237#artifacts

---

### AI Usage

**Did you use AI tools to help write this code?** 
PARTIALLY - NeoVim completion and review plugin uses Ollama