### PR TITLE
SM6115 - use rocknix-fake-suspend

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/030-suspend_mode
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/030-suspend_mode
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
-. /etc/profile.d/001-functions
+# Resume often does not work, disable suspend
+/usr/bin/suspendmode off
 
-MYSLEEPMODE=$(get_setting system.suspendmode)
-if [ -z "${MYSLEEPMODE}" ]
-then
-  /usr/bin/suspendmode freeze
-fi
+### Ignore power button presses for now
+cat <<EOF >~/.config/logind.conf.d/login.conf
+[Login]
+HandlePowerKey=ignore
+HandleSuspendKey=ignore
+EOF

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -364,6 +364,8 @@ INPUT_WHITELIST=(
   "gpio-keys-lid" \
   # S922X
   "rk805 pwrkey" \
+  # SM6115
+  "pm8941_pwrkey" \
   # SM8550
   "pmic_pwrkey"
 )


### PR DESCRIPTION
## Summary

SM6115 - use rocknix-fake-suspend

## Testing

Tested on my MQ66 Air X

## Additional Context

My Air X frequently will not resume from suspend. Fake suspend settings are already displayed and enabled in ES

---

### AI Usage

**Did you use AI tools to help write this code?** NO
