### PR TITLE
Ayaneo: Flip x/y/a/b

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayaneo_mcu_japanese.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayaneo_mcu_japanese.yaml
@@ -1,0 +1,253 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+# Schema version number
+version: 2
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: AYANEO MCU Mapping Japanese
+
+# Unique identifier of the capability mapping
+id: ayaneo_mcu_japanese
+
+# List of mapped events
+mapping:
+  - name: Guide Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_MODE
+          value_type: button
+    target_event:
+      gamepad:
+        button: Guide
+
+  - name: South Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_EAST
+          value_type: button
+    target_event:
+      gamepad:
+        button: South
+
+  - name: West Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: North Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+  - name: East Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_SOUTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: East
+
+  - name: Start Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_START
+          value_type: button
+    target_event:
+      gamepad:
+        button: Start
+
+  - name: Select Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_SELECT
+          value_type: button
+    target_event:
+      gamepad:
+        button: Select
+
+  - name: QuickAccess2 Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN5
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess2
+
+  - name: Right Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_GAS
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: RightTrigger
+
+  - name: Left Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_BRAKE
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: LeftTrigger
+
+  - name: Right Bumper
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TR
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightBumper
+
+  - name: Left Bumper
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TL
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftBumper
+
+  - name: Right Paddle
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_C
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle1
+
+  - name: Left Paddle
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_Z
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+
+  - name: Right Stick
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_RX
+          value_type: joystick_x
+      - evdev:
+          event_type: ABS
+          event_code: ABS_RY
+          value_type: joystick_y
+    target_event:
+      gamepad:
+        axis:
+          name: RightStick
+
+  - name: Left Stick
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_X
+          value_type: joystick_x
+      - evdev:
+          event_type: ABS
+          event_code: ABS_Y
+          value_type: joystick_y
+    target_event:
+      gamepad:
+        axis:
+          name: LeftStick
+
+  - name: Right Stick Click
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_THUMBR
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightStick
+
+  - name: Left Stick Click
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_THUMBL
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftStick
+
+  - name: Dpad Left
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0X
+          value_type: button
+          axis_direction: negative
+    target_event:
+      gamepad:
+        button: DPadLeft
+
+  - name: Dpad Right
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0X
+          value_type: button
+          axis_direction: positive
+    target_event:
+      gamepad:
+        button: DPadRight
+
+  - name: Dpad Down
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0Y
+          value_type: button
+          axis_direction: positive
+    target_event:
+      gamepad:
+        button: DPadDown
+
+  - name: Dpad Up
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0Y
+          value_type: button
+          axis_direction: negative
+    target_event:
+      gamepad:
+        button: DPadUp
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayaneo_mcu_xbox.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayaneo_mcu_xbox.yaml
@@ -6,10 +6,10 @@ version: 2
 kind: CapabilityMap
 
 # Name for the device event map
-name: AYANEO MCU Mapping Japanese (Xbox mode)
+name: AYANEO MCU Mapping (Xbox mode)
 
 # Unique identifier of the capability mapping
-id: ayaneo_mcu_xbox_japanese
+id: ayaneo_mcu_xbox
 
 # List of mapped events
 mapping:
@@ -27,7 +27,7 @@ mapping:
     source_events:
       - evdev:
           event_type: KEY
-          event_code: BTN_EAST
+          event_code: BTN_SOUTH
           value_type: button
     target_event:
       gamepad:
@@ -37,7 +37,7 @@ mapping:
     source_events:
       - evdev:
           event_type: KEY
-          event_code: BTN_NORTH
+          event_code: BTN_WEST
           value_type: button
     target_event:
       gamepad:
@@ -47,7 +47,7 @@ mapping:
     source_events:
       - evdev:
           event_type: KEY
-          event_code: BTN_WEST
+          event_code: BTN_NORTH
           value_type: button
     target_event:
       gamepad:
@@ -57,7 +57,7 @@ mapping:
     source_events:
       - evdev:
           event_type: KEY
-          event_code: BTN_SOUTH
+          event_code: BTN_EAST
           value_type: button
     target_event:
       gamepad:

--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller-japanese.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller-japanese.yaml
@@ -16,6 +16,16 @@ matches:
       sys_path: /sys/firmware/devicetree/base
       attributes:
         - name: model
+          value: AYANEO Pocket S 2K
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: model
+          value: AYANEO Pocket ACE
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: model
           value: AYANEO Pocket DMG
 
 # Only allow a single source device per composite device of this type.
@@ -26,10 +36,16 @@ single_source: false
 source_devices:
   - group: gamepad
     evdev:
+      vendor_id: "1c4f"
+      product_id: "0002"
+      handler: event*
+    capability_map_id: ayaneo_mcu_japanese
+  - group: gamepad
+    evdev:
       vendor_id: "045e"
       product_id: "028e"
       handler: event*
-    capability_map_id: ayaneo_mcu_xbox_japanese
+    capability_map_id: ayaneo_mcu_japanese
 
 # Optional configuration for the composite device
 options:

--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller-japanese.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller-japanese.yaml
@@ -16,11 +16,6 @@ matches:
       sys_path: /sys/firmware/devicetree/base
       attributes:
         - name: model
-          value: AYANEO Pocket S 2K
-  - udev:
-      sys_path: /sys/firmware/devicetree/base
-      attributes:
-        - name: model
           value: AYANEO Pocket ACE
   - udev:
       sys_path: /sys/firmware/devicetree/base

--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller.yaml
@@ -26,7 +26,7 @@ matches:
       sys_path: /sys/firmware/devicetree/base
       attributes:
         - name: model
-          value: AYANEO Pocket S
+          value: AYANEO Pocket S 2K
 
 # Only allow a single source device per composite device of this type.
 single_source: false

--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/01-ayaneo-controller.yaml
@@ -6,22 +6,12 @@ version: 1
 kind: CompositeDevice
 
 # Name of the composite device mapping
-name: AYANEO Japanese Layout
+name: AYANEO Layout
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.
 # /sys/class/dmi/id/product_name
 matches:
-  - udev:
-      sys_path: /sys/firmware/devicetree/base
-      attributes:
-        - name: model
-          value: AYANEO Pocket S 2K
-  - udev:
-      sys_path: /sys/firmware/devicetree/base
-      attributes:
-        - name: model
-          value: AYANEO Pocket ACE
   - udev:
       sys_path: /sys/firmware/devicetree/base
       attributes:
@@ -32,6 +22,11 @@ matches:
       attributes:
         - name: model
           value: AYANEO Pocket DS
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: model
+          value: AYANEO Pocket S
 
 # Only allow a single source device per composite device of this type.
 single_source: false
@@ -44,13 +39,13 @@ source_devices:
       vendor_id: "1c4f"
       product_id: "0002"
       handler: event*
-    capability_map_id: ayaneo_mcu_xbox_japanese
+    capability_map_id: ayaneo_mcu_xbox
   - group: gamepad
     evdev:
       vendor_id: "045e"
       product_id: "028e"
       handler: event*
-    capability_map_id: ayaneo_mcu_xbox_japanese
+    capability_map_id: ayaneo_mcu_xbox
 
 # Optional configuration for the composite device
 options:


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** switch in ayaneo MCU to not use japanese mapping. After that mapping in steam is not flipped

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?**  NO
