### PR TITLE
Uses empty string check instead of result code, the latter misses sometimes

### DIFF
--- a/scripts/get_git
+++ b/scripts/get_git
@@ -33,7 +33,7 @@ _repo_exists_and_valid() {
     pushd "${PACKAGE}" > /dev/null
     _clean_repo || return 1
 
-    if ! git ls-remote . | grep -q -m1 "^${PKG_VERSION}"; then
+    if [[ -z "$(git ls-remote . | grep -m1 "^${PKG_VERSION}")" ]]; then
       echo "ERROR: ${PACKAGE}: failed to determine git HEAD" >&2
       return 1
     fi


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
On my local build sometimes git repo cache fails the existence check, and is re-pulled every time i trigger a rebuild.
This seems to workaround it.

## Testing

* **How was this tested?**
Doing local build, component wise.

* **Test results:**
Seems working :>

## Additional Context

(Ideally I should figure out why git return code is not what is expected, but this seems to work)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
