### PR TITLE
gamepadtester: fix for SM8250 with InputPlumber

### DIFF
--- a/projects/ROCKNIX/packages/apps/gamepadtester/package.mk
+++ b/projects/ROCKNIX/packages/apps/gamepadtester/package.mk
@@ -12,7 +12,7 @@ PKG_TOOLCHAIN="cmake"
 PKG_PATCH_DIRS+="${DEVICE}"
 
 case ${DEVICE} in
-  SM8650|SM8550)
+  SM8650|SM8550|SM8250)
     PKG_PATCH_DIRS+=" xbox"
   ;;
   *)


### PR DESCRIPTION
### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
