### PR TITLE
sm8750: Implement chip thermal zones and AYN Odin 3 active fan cooling

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0600-ROCKNIX-sm8750-tsens-thermal-zones.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0600-ROCKNIX-sm8750-tsens-thermal-zones.patch
@@ -1,0 +1,75 @@
+From: Manaf Meethalavalappu Pallikunhi <quic_manafm@quicinc.com>
+Date: Wed, 25 Mar 2026 16:50:00 +0530
+Subject: [PATCH] arm64: dts: qcom: sm8750: Enable TSENS hardware nodes
+
+Add four TSENS instances to the SM8750 SoC device tree.
+
+Signed-off-by: Gaurav Kohli <gaurav.kohli@oss.qualcomm.com>
+[ROCKNIX: backported from upstream commit 0a78d270a40ecec6bae69920bb4319442b98cf24]
+---
+diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+--- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+@@ -19,6 +19,7 @@
+ #include <dt-bindings/soc/qcom,gpr.h>
+ #include <dt-bindings/soc/qcom,rpmh-rsc.h>
+ #include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
++#include <dt-bindings/thermal/thermal.h>
+ 
+ / {
+ 	interrupt-parent = <&intc>;
+@@ -3447,6 +3448,54 @@ pdc: interrupt-controller@b220000 {
+ 			interrupt-controller;
+ 		};
+ 
++		tsens0: thermal-sensor@c228000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c228000 0x0 0x1000>,
++			      <0x0 0x0c222000 0x0 0x1000>;
++			interrupts = <GIC_SPI 771 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 484 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <15>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens1: thermal-sensor@c229000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c229000 0x0 0x1000>,
++			      <0x0 0x0c223000 0x0 0x1000>;
++			interrupts = <GIC_SPI 772 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 485 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <7>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens2: thermal-sensor@c22a000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c22a000 0x0 0x1000>,
++			      <0x0 0x0c224000 0x0 0x1000>;
++			interrupts = <GIC_SPI 773 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 486 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <16>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens3: thermal-sensor@c22b000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c22b000 0x0 0x1000>,
++			      <0x0 0x0c225000 0x0 0x1000>;
++			interrupts = <GIC_SPI 774 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 487 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <9>;
++			#thermal-sensor-cells = <1>;
++		};
++
+ 		aoss_qmp: power-management@c300000 {
+ 			compatible = "qcom,sm8750-aoss-qmp", "qcom,aoss-qmp";
+ 			reg = <0x0 0x0c300000 0x0 0x400>;

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0601-ROCKNIX-sm8750-thermal-zones.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0601-ROCKNIX-sm8750-thermal-zones.patch
@@ -1,0 +1,350 @@
+From: Manaf Meethalavalappu Pallikunhi <quic_manafm@quicinc.com>
+Date: Wed, 25 Mar 2026 16:50:01 +0530
+Subject: [PATCH] arm64: dts: qcom: sm8750: Add thermal zones for TSENS
+
+Define 47 thermal zones covering CPU, GPU, NPU, modem, camera,
+video and DDR sensors. Hot trip at 120C, critical at 125C.
+
+Signed-off-by: Gaurav Kohli <gaurav.kohli@oss.qualcomm.com>
+[ROCKNIX: backported from upstream commit 0a78d270a40ecec6bae69920bb4319442b98cf24]
+---
+diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+--- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+@@ -6274,3 +6274,335 @@
+ 		};
+ 	};
+-};
++
++	thermal-zones {
++		aoss0-thermal {
++			thermal-sensors = <&tsens0 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-0-0-thermal {
++			thermal-sensors = <&tsens0 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-0-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-0-1-thermal {
++			thermal-sensors = <&tsens0 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-0-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-1-0-thermal {
++			thermal-sensors = <&tsens0 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-1-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-1-1-thermal {
++			thermal-sensors = <&tsens0 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-1-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-2-0-thermal {
++			thermal-sensors = <&tsens0 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-2-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-2-1-thermal {
++			thermal-sensors = <&tsens0 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-2-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-3-0-thermal {
++			thermal-sensors = <&tsens0 7>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-3-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-3-1-thermal {
++			thermal-sensors = <&tsens0 8>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-3-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-4-0-thermal {
++			thermal-sensors = <&tsens0 9>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-4-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-4-1-thermal {
++			thermal-sensors = <&tsens0 10>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-4-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-5-0-thermal {
++			thermal-sensors = <&tsens0 11>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-5-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-5-1-thermal {
++			thermal-sensors = <&tsens0 12>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-5-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_0_0_thermal: cpuss-0-0-thermal {
++			thermal-sensors = <&tsens0 13>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-0-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_0_1_thermal: cpuss-0-1-thermal {
++			thermal-sensors = <&tsens0 14>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-0-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		aoss1-thermal {
++			thermal-sensors = <&tsens1 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-0-0-thermal {
++			thermal-sensors = <&tsens1 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-0-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-0-1-thermal {
++			thermal-sensors = <&tsens1 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-0-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-1-0-thermal {
++			thermal-sensors = <&tsens1 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-1-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-1-1-thermal {
++			thermal-sensors = <&tsens1 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-1-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_1_0_thermal: cpuss-1-0-thermal {
++			thermal-sensors = <&tsens1 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-1-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_1_1_thermal: cpuss-1-1-thermal {
++			thermal-sensors = <&tsens1 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-1-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		aoss2-thermal {
++			thermal-sensors = <&tsens2 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss0_thermal: gpuss0-thermal {
++			thermal-sensors = <&tsens2 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss1_thermal: gpuss1-thermal {
++			thermal-sensors = <&tsens2 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss2_thermal: gpuss2-thermal {
++			thermal-sensors = <&tsens2 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss3_thermal: gpuss3-thermal {
++			thermal-sensors = <&tsens2 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss4_thermal: gpuss4-thermal {
++			thermal-sensors = <&tsens2 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss4-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss5_thermal: gpuss5-thermal {
++			thermal-sensors = <&tsens2 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss5-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss6_thermal: gpuss6-thermal {
++			thermal-sensors = <&tsens2 7>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss6-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss7_thermal: gpuss7-thermal {
++			thermal-sensors = <&tsens2 8>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss7-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem0-thermal {
++			thermal-sensors = <&tsens2 9>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem1-thermal {
++			thermal-sensors = <&tsens2 10>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem2-thermal {
++			thermal-sensors = <&tsens2 11>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem3-thermal {
++			thermal-sensors = <&tsens2 12>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		camera0-thermal {
++			thermal-sensors = <&tsens2 13>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				camera0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		camera1-thermal {
++			thermal-sensors = <&tsens2 14>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				camera1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		video-thermal {
++			thermal-sensors = <&tsens2 15>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				video-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		aoss3-thermal {
++			thermal-sensors = <&tsens3 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphvx0-thermal {
++			thermal-sensors = <&tsens3 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphvx0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphvx1-thermal {
++			thermal-sensors = <&tsens3 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphvx1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphvx2-thermal {
++			thermal-sensors = <&tsens3 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphvx2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx0-thermal {
++			thermal-sensors = <&tsens3 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx1-thermal {
++			thermal-sensors = <&tsens3 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx2-thermal {
++			thermal-sensors = <&tsens3 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx3-thermal {
++			thermal-sensors = <&tsens3 7>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		ddr-thermal {
++			thermal-sensors = <&tsens3 8>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <2000>; type = "hot"; };
++				ddr-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++	};
++};

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0602-ROCKNIX-odin3-fan-cooling-maps.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0602-ROCKNIX-odin3-fan-cooling-maps.patch
@@ -1,0 +1,291 @@
+From: ROCKNIX Contributors <rocknix@rocknix.org>
+Date: Mon, 28 Apr 2026 00:00:00 +0000
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn-odin3: Add fan cooling maps for CPU and GPU clusters
+
+Wire the pwm-fan into the thermal framework for all four CPU performance
+clusters (cpuss-0-0, cpuss-0-1, cpuss-1-0, cpuss-1-1) and all eight GPU
+clusters (gpuss0 through gpuss7). All changes are isolated to the Odin 3
+device tree so that future SM8750 devices are unaffected.
+
+Fan states (8 levels): 0=off, 1-7=30/45/60/70/90/120/150 PWM
+Curve: 40C->L1, 50C->L2, 60C->L3, 65C->L4, 70C->L5, 75C->L6, 80C->L7
+Hysteresis: 3C on all active trips
+
+Depends-on: 0601-ROCKNIX-sm8750-thermal-zones.patch
+---
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts b/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts
+@@ -311,3 +311,272 @@
+ 		drive-strength = <2>;
+ 	};
+ };
++
++&pwm_fan {
++	#cooling-cells = <2>;
++	cooling-levels = <0 30 45 60 70 90 120 150>;
++};
++
++&cpuss_0_0_thermal {
++	trips {
++		cpu00_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		cpu00_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		cpu00_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		cpu00_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		cpu00_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		cpu00_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		cpu00_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu00_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu00_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu00_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu00_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu00_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu00_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu00_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&cpuss_0_1_thermal {
++	trips {
++		cpu01_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		cpu01_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		cpu01_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		cpu01_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		cpu01_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		cpu01_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		cpu01_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu01_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu01_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu01_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu01_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu01_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu01_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu01_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&cpuss_1_0_thermal {
++	trips {
++		cpu10_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		cpu10_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		cpu10_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		cpu10_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		cpu10_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		cpu10_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		cpu10_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu10_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu10_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu10_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu10_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu10_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu10_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu10_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&cpuss_1_1_thermal {
++	trips {
++		cpu11_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		cpu11_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		cpu11_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		cpu11_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		cpu11_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		cpu11_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		cpu11_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu11_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu11_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu11_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu11_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu11_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu11_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu11_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss0_thermal {
++	trips {
++		gpu0_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu0_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu0_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu0_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu0_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu0_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu0_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu0_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu0_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu0_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu0_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu0_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu0_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu0_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss1_thermal {
++	trips {
++		gpu1_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu1_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu1_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu1_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu1_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu1_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu1_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu1_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu1_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu1_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu1_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu1_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu1_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu1_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss2_thermal {
++	trips {
++		gpu2_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu2_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu2_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu2_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu2_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu2_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu2_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu2_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu2_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu2_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu2_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu2_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu2_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu2_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss3_thermal {
++	trips {
++		gpu3_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu3_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu3_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu3_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu3_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu3_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu3_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu3_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu3_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu3_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu3_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu3_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu3_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu3_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss4_thermal {
++	trips {
++		gpu4_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu4_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu4_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu4_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu4_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu4_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu4_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu4_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu4_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu4_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu4_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu4_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu4_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu4_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss5_thermal {
++	trips {
++		gpu5_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu5_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu5_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu5_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu5_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu5_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu5_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu5_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu5_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu5_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu5_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu5_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu5_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu5_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss6_thermal {
++	trips {
++		gpu6_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu6_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu6_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu6_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu6_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu6_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu6_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu6_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu6_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu6_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu6_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu6_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu6_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu6_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&gpuss7_thermal {
++	trips {
++		gpu7_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <3000>; type = "active"; };
++		gpu7_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <3000>; type = "active"; };
++		gpu7_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <3000>; type = "active"; };
++		gpu7_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <3000>; type = "active"; };
++		gpu7_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <3000>; type = "active"; };
++		gpu7_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <3000>; type = "active"; };
++		gpu7_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <3000>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu7_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu7_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu7_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu7_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu7_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu7_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu7_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};


### PR DESCRIPTION
## Summary
This commit establishes the base thermal framework and applies active cooling maps specifically for the AYN Odin 3.

**What is the goal of this PR?**

Implementing generic patch files for SM8750 and specific fan patch for Ayn Odin 3 :

*Backported upstream TSENS hardware nodes and 47 base thermal zones (Patches 0600 & 0601).
*Injected explicit reference labels into the base silicon for all 4 CPU performance clusters and 8 GPU clusters.
*Implemented a 8-level PWM fan curve (<0 30 45 60 70 90 120 150>)
*Mapped the fan curve across all 12 critical CPU/GPU zones, utilizing a 3°C hysteresis to attempt to prevent rapid fan cycling.
*Isolated all active cooling logic strictly to cq8725s-ayn-odin3.dts (Patch 0602) to prevent kernel panics on future passively cooled SM8750 boards.

## Testing

Ran on Ayn Odin 3. On the menu, the fan is off or running at low speeds. Running Cyberpunk 2077 as a test, the fan dynamically ramps up and down.

## Additional Context

In 0602-ROCKNIX-odin3-fan-cooling-maps.patch the trip points use hysteresis = <3000> which is 3°C (values are in millidegrees). The fan won't drop a state until the temp falls 3°C below the trip point that triggered it. However 3°C can fluctuate quickly causing the fan to ramp up and down. Dialing in 5°C, 7°C, and 10°C should be tested. 

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES