### PR TITLE
SM6115 - ledcontrol - add poweroff case for rocknix-fake-suspend

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/bin/ledcontrol
@@ -143,6 +143,9 @@ case ${1} in
   rainbow)
     led_rainbow
     ;;
+  poweroff)
+    led_off
+    ;;
   list)
 cat <<EOF
 off


### PR DESCRIPTION
## Summary

SM6115 - ledcontrol - add poweroff case for rocknix-fake-suspend

---

### AI Usage

**Did you use AI tools to help write this code?**NO
