### PR TITLE
SM6115 - devicetree cooling-maps - raise fan trip point to 65C

### DIFF
--- a/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
+++ b/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
@@ -1207,7 +1207,7 @@
 		};
 	};
 
-	trips { gpu_fan: gpu-fan { temperature = <55000>; hysteresis = <5000>; type = "active"; }; };
+	trips { gpu_fan: gpu-fan { temperature = <65000>; hysteresis = <5000>; type = "active"; }; };
 };
 
 &cpu0123_thermal {
@@ -1226,7 +1226,7 @@
 		};
 	};
 
-	trips { cpu0123_fan: cpu0123-fan { temperature = <55000>; hysteresis = <5000>; type = "active"; }; };
+	trips { cpu0123_fan: cpu0123-fan { temperature = <65000>; hysteresis = <5000>; type = "active"; }; };
 };
 
 &cpu45_thermal {
@@ -1245,7 +1245,7 @@
 		};
 	};
 
-	trips { cpu45_fan: cpu45-fan { temperature = <55000>; hysteresis = <5000>; type = "active"; }; };
+	trips { cpu45_fan: cpu45-fan { temperature = <65000>; hysteresis = <5000>; type = "active"; }; };
 };
 
 &cpu67_thermal {
@@ -1264,5 +1264,5 @@
 		};
 	};
 
-	trips { cpu67_fan: cpu67-fan { temperature = <55000>; hysteresis = <5000>; type = "active"; }; };
+	trips { cpu67_fan: cpu67-fan { temperature = <65000>; hysteresis = <5000>; type = "active"; }; };
 };


### PR DESCRIPTION
## Summary

SM6115 - devicetree cooling-maps - raise fan trip point to 65C

## Testing

Tested on my Air X MQ66, confirmed temps are ok with higher-end emulation (aethersx2 - 3 A73 cores fully-loaded - 80C after 15 mins playtime)

## Additional Context

Just helps avoid the fan frequently spinning up sitting at the ES menu. It frequently reaches 55C, but rarely 65C in my testing.

---

### AI Usage

**Did you use AI tools to help write this code?** NO
