### PR TITLE
Add bottom screen

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/retroarch/patches/0013-network-cmd.patch
+++ b/projects/ROCKNIX/packages/emulators/libretro/retroarch/patches/0013-network-cmd.patch
@@ -1,0 +1,19 @@
+--- a/command.c
++++ b/command.c
+@@ -476,6 +476,16 @@
+          strlcpy(value_dynamic, "0 0 0", sizeof(value_dynamic));
+    }
+    #endif
++#ifdef HAVE_MENU
++   else if (memcmp(arg, "menu_active", sizeof("menu_active")) == 0)
++   {
++      struct menu_state *menu_st = menu_state_get_ptr();
++      if (menu_st && (menu_st->flags & MENU_ST_FLAG_ALIVE))
++         value = "true";
++      else
++         value = "false";
++   }
++#endif
+    /* TODO: query any string */
+ 
+    _len  = strlcpy(reply, "GET_CONFIG_PARAM ", sizeof(reply));

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
@@ -262,6 +262,22 @@ case ${EMULATOR} in
     ${VERBOSE} && log $0 "Execute setsettings (${PLATFORM} ${ROMNAME} ${CORE} --controllers=${CONTROLLERCONFIG} --autosave=${AUTOSAVE} --snapshot=${SNAPSHOT})"
     (/usr/bin/setsettings.sh "${PLATFORM}" "${ROMNAME}" "${CORE}" --controllers="${CONTROLLERCONFIG}" --autosave="${AUTOSAVE}" --snapshot="${SNAPSHOT}" >${SET_SETTINGS_TMP})
 
+    ### Enable RetroArch Network Control for this session on dual-screen devices
+    ### so the bottom-screen UI can forward save-state / load-state / resume commands.
+    if [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ]; then
+      echo 'network_cmd_enable = "true"' >> "${RETROARCH_APPEND_CONFIG}"
+      echo 'network_cmd_port = "55355"'  >> "${RETROARCH_APPEND_CONFIG}"
+      echo 'savestate_thumbnail_enable = "true"' >> "${RETROARCH_APPEND_CONFIG}"
+
+      if ! pgrep -f 'python3 .*/lowerdeck/ra_proxy\.py' >/dev/null 2>&1; then
+        ( python3 /usr/share/lowerdeck/ra_proxy.py >/dev/null 2>&1 ) &
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+          netstat -ln 2>/dev/null | grep -q ':8080 ' && break
+          sleep 0.1
+        done
+      fi
+    fi
+
     ### If setsettings wrote data in the background, grab it and assign it to EXTRAOPTS
     if [ -e "${SET_SETTINGS_TMP}" ]
     then

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
@@ -3,10 +3,19 @@
 . /etc/profile
 
 ARCADEROMS_XML="/usr/config/emulationstation/resources/arcaderoms.xml"
+BOTTOM_SCREEN_UI_DIR="/usr/share/lowerdeck"
+BOTTOM_SCREEN_PID_FILE="/run/lowerdeck.pid"
 
 RUNEMU_LINE=$(ps aux | grep '[r]unemu.sh' | head -n 1)
 CURRENT_CORE=$(echo "${RUNEMU_LINE}" | sed -n 's/.*--core=\([^ ]*\).*/\1/p')
-ROM_PATH=$(echo "${RUNEMU_LINE}" | sed -n 's|.*runemu\.sh \([^ ]*\).*|\1|p')
+PLATFORM=$(echo "${RUNEMU_LINE}" | sed -n 's/.* -P *\([^ ]*\).*/\1/p')
+ROM_PATH=$(echo "${RUNEMU_LINE}" | sed '
+    s|.*runemu\.sh ||
+    s/\\ /__ESC_SP__/g
+    s/ .*//
+    s/__ESC_SP__/ /g
+    s/\\\(.\)/\1/g
+')
 
 if [ -z "${CURRENT_CORE}" ] || [ -z "${ROM_PATH}" ]; then
     exit 0
@@ -80,5 +89,46 @@ if [ "${IS_VERTICAL}" = "true" ]; then
         swaymsg input "0:0:generic_ft5x06_(a0)" events enabled
         swaymsg input "0:0:generic_ft5x06_(8d)" map_to_output DSI-1
         swaymsg input "0:0:generic_ft5x06_(8d)" events enabled
+    fi
+elif [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ]; then
+    BOTTOM_SCREEN_TYPE=$(get_setting rocknix.bottomscreen.type 2>/dev/null)
+    if [ -z "${BOTTOM_SCREEN_TYPE}" ]; then
+        set_setting rocknix.bottomscreen.type vc 2>/dev/null
+        BOTTOM_SCREEN_TYPE=vc
+    fi
+    if [ "${BOTTOM_SCREEN_TYPE}" = "vc" ] && [ -d "${BOTTOM_SCREEN_UI_DIR}" ]; then
+        if [ -f "${BOTTOM_SCREEN_PID_FILE}" ] && kill -0 "$(cat "${BOTTOM_SCREEN_PID_FILE}" 2>/dev/null)" 2>/dev/null; then
+            exit 0
+        fi
+        if pgrep -f 'python3 .*/lowerdeck/main\.py' >/dev/null 2>&1; then
+            exit 0
+        fi
+
+        case "${QUIRK_DEVICE}" in
+            "AYANEO Pocket DS") OUTPUT="DSI-2" ;;
+            *)                  OUTPUT="DSI-1" ;;
+        esac
+
+        swaymsg "output ${OUTPUT} power on" >/dev/null 2>&1
+        RA_PID=$(pgrep -f '/usr/bin/retroarch' | head -n 1)
+        USE_CHEEVOS=$(get_setting "retroachievements" 2>/dev/null)
+
+        ( cd "${BOTTOM_SCREEN_UI_DIR}" && \
+          exec python3 "${BOTTOM_SCREEN_UI_DIR}/main.py" \
+              --rom      "${ROM_PATH}" \
+              --core     "${CURRENT_CORE}" \
+              --platform "${PLATFORM}" \
+              --ra-pid   "${RA_PID:-0}" \
+              --cheevos-enabled  "${USE_CHEEVOS:-1}" \
+          >/dev/null 2>&1 ) &
+        echo $! > "${BOTTOM_SCREEN_PID_FILE}"
+
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            if swaymsg -t get_tree 2>/dev/null | grep -q '"app_id": "lowerdeck"'; then
+                break
+            fi
+            sleep 0.05
+        done
+        swaymsg "[app_id=\"lowerdeck\"] move container to output ${OUTPUT}, fullscreen enable" >/dev/null 2>&1 ||:
     fi
 fi

--- a/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
+++ b/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="lowerdeck"
-PKG_VERSION="0ad677c37419218bc284c3aec0d30b131e8efb8c"
+PKG_VERSION="faf3cd5b259f15581dda0e2569a877f3d8d821c0"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/bulzipke/lowerdeck"

--- a/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
+++ b/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="lowerdeck"
+PKG_VERSION="dffc09f6a3f3af5cf4e1a30fe7595aae436a75a7"
+PKG_GIT_CLONE_BRANCH="main"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/bulzipke/lowerdeck"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain Python3 SDL2 SDL2_image SDL2_ttf"
+PKG_LONGDESC="Touch UI for the second screen of dual-screen handhelds."
+PKG_TOOLCHAIN="manual"
+GET_HANDLER_SUPPORT="git"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/share/lowerdeck
+  cp -a ${PKG_BUILD}/. ${INSTALL}/usr/share/lowerdeck/
+
+  rm -rf ${INSTALL}/usr/share/lowerdeck/devices
+  if [ -d "${PKG_BUILD}/devices/${DEVICE}" ]; then
+    cp -rf ${PKG_BUILD}/devices/${DEVICE}/. ${INSTALL}/usr/share/lowerdeck/
+  fi
+}

--- a/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
+++ b/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="lowerdeck"
-PKG_VERSION="dffc09f6a3f3af5cf4e1a30fe7595aae436a75a7"
+PKG_VERSION="0ad677c37419218bc284c3aec0d30b131e8efb8c"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/bulzipke/lowerdeck"

--- a/projects/ROCKNIX/packages/virtual/image/package.mk
+++ b/projects/ROCKNIX/packages/virtual/image/package.mk
@@ -15,7 +15,7 @@ PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host 
                     bash coreutils system-utils autostart quirks powerstate \
                     gzip six xmlstarlet pyudev dialog network mako-osd rocknix"
 
-PKG_UI="emulationstation es-themes textviewer"
+PKG_UI="emulationstation es-themes textviewer lowerdeck"
 
 PKG_UI_TOOLS="fbgrab grim"
 

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -129,7 +129,10 @@ if [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ]; then
   second_con=$([[ "${connected_cons[0]}" == "$con" ]] && echo "${connected_cons[1]}" || echo "${connected_cons[0]}")
   echo "SDL_VIDEO_DISPLAY_PRIORITY=${con},${second_con}" >> ${env_file}
   echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] move window to output '"${second_con}" >> $SWAY_HOME/config
-  echo 'for_window [title="RetroArch\s(melonDS|DeSmuME|VecX|MAME|FinalBurn|FB Alpha).*"] exec /usr/bin/vertical-check' >> $SWAY_HOME/config
+  echo 'for_window [title="RetroArch.*"] exec /usr/bin/vertical-check' >> $SWAY_HOME/config
+
+  echo 'for_window [app_id="lowerdeck"] floating enable, fullscreen enable, move window to output '"${second_con}" >> $SWAY_HOME/config
+  echo 'no_focus [app_id="lowerdeck"]' >> $SWAY_HOME/config
   # Required for the touch keyboard to both accept inputs on bottom screen and sent those events to the top screen
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat0 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:wlr_virtual_keyboard_v1\"" >> $SWAY_HOME/config


### PR DESCRIPTION
## Summary

* Added a bottom screen UI for RetroArch cores that use a single screen.
* Currently, brightness control and state save/load are available.

## Testing
https://github.com/user-attachments/assets/b70df043-6595-46ed-aa04-216ba547138a

* Built for SM8550 and tested on the AYN Thor, which is the device I own.
* Recorded the feature where the bottom screen turns off after a certain number of blinks to prevent burn-in.

## Additional Context

* Fixed an error in handling special characters like spaces and '&' in the ROM_PATH of vertical-check.
(Discovered while parsing the PNG state filename for Sonic & Knuckles.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
* Assisted with drawing the Python UI.
