### PR TITLE
Fix bash invalid regular expression while scanning for SCUMMVM games

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/scummvmsa/sources/start_scummvm.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/scummvmsa/sources/start_scummvm.sh
@@ -12,7 +12,7 @@ BIOSPATH="${ROMSPATH}/bios"
 RATMPCONF="/storage/.config/retroarch/retroarch.cfg"
 
 shopt -s extglob
-if [[ "$1" =~ ?(add|create|libretro) ]]
+if [[ "$1" =~ ^(add|create|libretro)$ ]]
 then
   GAME="$2"
 else


### PR DESCRIPTION
## Summary

Fix for regular expression in start_scummvm.sh

## Testing

Before:

$ ./start_scummvm_old.sh add game
./start_scummvm_old.sh: line 1: [[: invalid regular expression `?(add|create|libretro)': Invalid preceding regular expression

After:

$ ./start_scummvm.sh add game
$
*GAME variable populated*

## Additional Context

* It's strange that no one fixed it before, it seems like been here for a while and it is breaking games' scan completely
---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
