### PR TITLE
SM8750 (AYN Odin 3): Add thermal zones, PWM fan sysfs, and userspace fan control

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0600-ROCKNIX-sm8750-tsens-thermal-zones.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0600-ROCKNIX-sm8750-tsens-thermal-zones.patch
@@ -1,0 +1,414 @@
+From: Manaf Meethalavalappu Pallikunhi <quic_manafm@quicinc.com>
+Date: Wed, 25 Mar 2026 16:50:00 +0530
+Subject: [PATCH] arm64: dts: qcom: sm8750: Enable TSENS and thermal zones
+
+Add four TSENS instances and define 47 thermal zones covering CPU, GPU,
+NPU, modem, camera, video and DDR sensors. Hot trip at 120C, critical
+at 125C.
+
+Signed-off-by: Gaurav Kohli <gaurav.kohli@oss.qualcomm.com>
+[ROCKNIX: backported from upstream commit 0a78d270a40ecec6bae69920bb4319442b98cf24]
+---
+diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+--- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+@@ -19,6 +19,7 @@
+ #include <dt-bindings/soc/qcom,gpr.h>
+ #include <dt-bindings/soc/qcom,rpmh-rsc.h>
+ #include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
++#include <dt-bindings/thermal/thermal.h>
+ 
+ / {
+ 	interrupt-parent = <&intc>;
+@@ -3447,6 +3448,54 @@ pdc: interrupt-controller@b220000 {
+ 			interrupt-controller;
+ 		};
+ 
++		tsens0: thermal-sensor@c228000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c228000 0x0 0x1000>,
++			      <0x0 0x0c222000 0x0 0x1000>;
++			interrupts = <GIC_SPI 771 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 484 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <15>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens1: thermal-sensor@c229000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c229000 0x0 0x1000>,
++			      <0x0 0x0c223000 0x0 0x1000>;
++			interrupts = <GIC_SPI 772 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 485 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <7>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens2: thermal-sensor@c22a000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c22a000 0x0 0x1000>,
++			      <0x0 0x0c224000 0x0 0x1000>;
++			interrupts = <GIC_SPI 773 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 486 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <16>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens3: thermal-sensor@c22b000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c22b000 0x0 0x1000>,
++			      <0x0 0x0c225000 0x0 0x1000>;
++			interrupts = <GIC_SPI 774 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 487 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <9>;
++			#thermal-sensor-cells = <1>;
++		};
++
+ 		aoss_qmp: power-management@c300000 {
+ 			compatible = "qcom,sm8750-aoss-qmp", "qcom,aoss-qmp";
+ 			reg = <0x0 0x0c300000 0x0 0x400>;
+@@ -6274,3 +6274,335 @@
+ 		};
+ 	};
+-};
++
++	thermal-zones {
++		aoss0-thermal {
++			thermal-sensors = <&tsens0 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-0-0-thermal {
++			thermal-sensors = <&tsens0 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-0-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-0-1-thermal {
++			thermal-sensors = <&tsens0 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-0-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-1-0-thermal {
++			thermal-sensors = <&tsens0 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-1-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-1-1-thermal {
++			thermal-sensors = <&tsens0 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-1-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-2-0-thermal {
++			thermal-sensors = <&tsens0 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-2-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-2-1-thermal {
++			thermal-sensors = <&tsens0 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-2-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-3-0-thermal {
++			thermal-sensors = <&tsens0 7>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-3-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-3-1-thermal {
++			thermal-sensors = <&tsens0 8>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-3-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-4-0-thermal {
++			thermal-sensors = <&tsens0 9>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-4-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-4-1-thermal {
++			thermal-sensors = <&tsens0 10>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-4-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-5-0-thermal {
++			thermal-sensors = <&tsens0 11>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-5-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-0-5-1-thermal {
++			thermal-sensors = <&tsens0 12>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-0-5-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_0_0_thermal: cpuss-0-0-thermal {
++			thermal-sensors = <&tsens0 13>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-0-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_0_1_thermal: cpuss-0-1-thermal {
++			thermal-sensors = <&tsens0 14>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-0-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		aoss1-thermal {
++			thermal-sensors = <&tsens1 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-0-0-thermal {
++			thermal-sensors = <&tsens1 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-0-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-0-1-thermal {
++			thermal-sensors = <&tsens1 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-0-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-1-0-thermal {
++			thermal-sensors = <&tsens1 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-1-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpu-1-1-1-thermal {
++			thermal-sensors = <&tsens1 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpu-1-1-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_1_0_thermal: cpuss-1-0-thermal {
++			thermal-sensors = <&tsens1 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-1-0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		cpuss_1_1_thermal: cpuss-1-1-thermal {
++			thermal-sensors = <&tsens1 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				cpuss-1-1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		aoss2-thermal {
++			thermal-sensors = <&tsens2 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss0_thermal: gpuss0-thermal {
++			thermal-sensors = <&tsens2 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss1_thermal: gpuss1-thermal {
++			thermal-sensors = <&tsens2 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss2_thermal: gpuss2-thermal {
++			thermal-sensors = <&tsens2 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss3_thermal: gpuss3-thermal {
++			thermal-sensors = <&tsens2 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss4_thermal: gpuss4-thermal {
++			thermal-sensors = <&tsens2 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss4-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss5_thermal: gpuss5-thermal {
++			thermal-sensors = <&tsens2 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss5-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss6_thermal: gpuss6-thermal {
++			thermal-sensors = <&tsens2 7>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss6-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		gpuss7_thermal: gpuss7-thermal {
++			thermal-sensors = <&tsens2 8>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				gpuss7-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem0-thermal {
++			thermal-sensors = <&tsens2 9>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem1-thermal {
++			thermal-sensors = <&tsens2 10>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem2-thermal {
++			thermal-sensors = <&tsens2 11>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		modem3-thermal {
++			thermal-sensors = <&tsens2 12>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				modem3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		camera0-thermal {
++			thermal-sensors = <&tsens2 13>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				camera0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		camera1-thermal {
++			thermal-sensors = <&tsens2 14>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				camera1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		video-thermal {
++			thermal-sensors = <&tsens2 15>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				video-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		aoss3-thermal {
++			thermal-sensors = <&tsens3 0>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				aoss3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphvx0-thermal {
++			thermal-sensors = <&tsens3 1>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphvx0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphvx1-thermal {
++			thermal-sensors = <&tsens3 2>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphvx1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphvx2-thermal {
++			thermal-sensors = <&tsens3 3>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphvx2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx0-thermal {
++			thermal-sensors = <&tsens3 4>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx0-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx1-thermal {
++			thermal-sensors = <&tsens3 5>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx1-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx2-thermal {
++			thermal-sensors = <&tsens3 6>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx2-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		nsphmx3-thermal {
++			thermal-sensors = <&tsens3 7>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <5000>; type = "hot"; };
++				nsphmx3-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++		ddr-thermal {
++			thermal-sensors = <&tsens3 8>;
++			trips {
++				trip-point0 { temperature = <120000>; hysteresis = <2000>; type = "hot"; };
++				ddr-critical { temperature = <125000>; hysteresis = <0>; type = "critical"; };
++			};
++		};
++	};
++};

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0601-ROCKNIX-odin3-pwm-fan-sysfs.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0601-ROCKNIX-odin3-pwm-fan-sysfs.patch
@@ -1,0 +1,22 @@
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn-common: Add pwm-fan cooling cells
+
+Add #cooling-cells and cooling-levels to the pwm-fan node so the fan
+is accessible to userspace fan control via sysfs.
+
+Cooling levels (8 states): 0=off, 1-7=30/45/60/70/90/120/150 PWM
+---
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -91,10 +91,12 @@
+ 	pwm_fan: pwm-fan {
+ 		compatible = "pwm-fan";
+ 
+ 		fan-supply = <&vdd_fan_5v0>;
+ 		pwms = <&pm8550_pwm 3 40000>;
+ 
++		#cooling-cells = <2>;
++		cooling-levels = <0 30 45 60 70 90 120 150>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&fan_pwm_default>;
+ 	};

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/020-fan_control
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/020-fan_control
@@ -1,0 +1,25 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+
+# Build thermal sensor path list, skipping PMIC and battery zones
+DEVICE_TEMP_SENSOR=""
+for zone in /sys/devices/virtual/thermal/thermal_zone*/; do
+  type=$(cat "${zone}type" 2>/dev/null)
+  case "${type}" in
+    *pm8550*|*pmih*|*battery*)
+      continue
+      ;;
+  esac
+  DEVICE_TEMP_SENSOR="${DEVICE_TEMP_SENSOR} ${zone}temp"
+done
+
+# Build PWM fan path
+FANPATH="$(ls /sys/class/hwmon/hwmon*/pwm1 | grep hwmon | cut -c 18-24)"
+
+cat <<PROFILE >/storage/.config/profile.d/020-fan_control
+DEVICE_TEMP_SENSOR="${DEVICE_TEMP_SENSOR}"
+DEVICE_HAS_FAN="true"
+DEVICE_PWM_FAN="/sys/class/hwmon/${FANPATH}/pwm1"
+DEVICE_FAN_INPUT="/sys/class/hwmon/${FANPATH}/pwm1"
+PROFILE

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/bin/fancontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/bin/fancontrol
@@ -1,0 +1,134 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+DEBUG=false
+COOLING_PROFILE=$(get_setting "cooling.profile")
+FAN_PWM="${DEVICE_PWM_FAN}"
+
+# Enable fan if it's turned off
+if [ -f "${DEVICE_PWM_FAN}_enable" ] && [ "$(cat "${DEVICE_PWM_FAN}_enable")" != "1" ]; then
+  echo 1 > "${DEVICE_PWM_FAN}_enable"
+  echo "Enabling fan pwm"
+fi
+
+log $0 "Setting profile to ${COOLING_PROFILE}"
+
+function set_control() {
+  log $0 "Set fan control to ${1}"
+  if [ -e "${DEVICE_PWM_FAN}_enable" ]
+  then
+    echo ${1} >${DEVICE_PWM_FAN}_enable
+  fi
+}
+
+trap "set_control 0 && exit 0" SIGHUP SIGINT SIGQUIT SIGABRT
+
+if [ "${COOLING_PROFILE}" = "custom" ]
+then
+  if [ -e "/storage/.config/fancontrol.conf" ]
+  then
+    log $0 "Loading configuration file" 2>/dev/null
+    source /storage/.config/fancontrol.conf
+    if [ ! $? = 0 ]
+    then
+      WARN="Custom fan profile could not be loaded, defaulting to moderate."
+      log $0 "${WARN}"
+      COOLING_PROFILE="moderate"
+      set_setting cooling.profile moderate
+    fi
+  else
+    log $0 "No custom config found, defaulting to moderate."
+    COOLING_PROFILE="moderate"
+    set_setting cooling.profile moderate
+  fi
+fi
+
+# Temperature thresholds and PWM values tuned for AYN Odin 3 (SM8750)
+# Idle: 30-45C | Gaming peak: 97-98C | Hardware max: 105C
+# PWM scale: 0=off, 51=20%, 77=30%, 102=40%, 128=50%, 153=60%, 204=80%, 255=100%
+
+if [ ! "${COOLING_PROFILE}" = "custom" ]
+then
+  if [ "${COOLING_PROFILE}" = "aggressive" ]; then
+    MAXTEMP="80000"
+    T6="75000"
+    T5="70000"
+    T4="65000"
+    T3="60000"
+    T2="55000"
+    T1="45000"
+  elif [ "${COOLING_PROFILE}" = "moderate" ]; then
+    MAXTEMP="85000"
+    T6="80000"
+    T5="75000"
+    T4="70000"
+    T3="65000"
+    T2="60000"
+    T1="50000"
+  elif [ "${COOLING_PROFILE}" = "quiet" ]; then
+    MAXTEMP="90000"
+    T6="85000"
+    T5="80000"
+    T4="75000"
+    T3="70000"
+    T2="65000"
+    T1="55000"
+  else
+    MAXTEMP="85000"
+    T6="80000"
+    T5="75000"
+    T4="70000"
+    T3="65000"
+    T2="60000"
+    T1="50000"
+  fi
+fi
+
+CTEMP="1"
+
+log $0 "Enabling fan control."
+set_control 1 >/dev/null 2>&1
+
+while true
+  do
+  INDEX=0
+  CPU_TEMP=$(awk '{total += $1; count++} END {printf "%d", total/count}' ${DEVICE_TEMP_SENSOR})
+  $DEBUG && log $0 "CPU TEMP: ${CPU_TEMP}" 2>/dev/null
+  if (( "${CPU_TEMP}" > "${MAXTEMP}" )); then
+    FSPEED="255"
+    TEMP="${MAXTEMP}"
+  elif (( "${CPU_TEMP}" > "${T6}" )); then
+    FSPEED="204"
+    TEMP="${T6}"
+  elif (( "${CPU_TEMP}" > "${T5}" )); then
+    FSPEED="153"
+    TEMP="${T5}"
+  elif (( "${CPU_TEMP}" > "${T4}" )); then
+    FSPEED="128"
+    TEMP="${T4}"
+  elif (( "${CPU_TEMP}" > "${T3}" )); then
+    FSPEED="102"
+    TEMP="${T3}"
+  elif (( "${CPU_TEMP}" > "${T2}" )); then
+    FSPEED="77"
+    TEMP="${T2}"
+  elif (( "${CPU_TEMP}" > "${T1}" )); then
+    FSPEED="51"
+    TEMP="${T1}"
+  else
+    FSPEED="0"
+    TEMP=0
+  fi
+  if (( ${TEMP} != ${CTEMP} )); then
+    echo ${FSPEED} > ${FAN_PWM}
+    CTEMP=${TEMP}
+    $DEBUG && log $0 "Setting PWM FAN to ${FSPEED} at CPU Temp: ${CPU_TEMP}" 2>/dev/null
+  fi
+  sleep 3
+done
+
+log $0 "Disabling fan control."
+set_control 0 >/dev/null 2>&1


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Enables full thermal monitoring and user-controllable fan speed on the AYN Odin 3 (SM8750/Snapdragon 8 Elite).
0600-ROCKNIX-sm8750-tsens-thermal-zones.patch

Backported from upstream commit **0a78d270a40ecec6bae69920bb4319442b98cf24** (Gaurav Kohli, Qualcomm, March 2026). Adds four TSENS hardware instances and 47 thermal zone definitions to sm8750.dtsi covering CPU clusters, GPU shaders, NPU, modem, camera, video and DDR. Sets a software hot trip at 120°C and critical shutdown at 125°C, below the SM8750's silicon-hardcoded hardware reset at 130°C. Applies to all SM8750 devices.

**0601-ROCKNIX-odin3-pwm-fan-sysfs.patch**
Adds #cooling-cells and cooling-levels to the pwm_fan node in cq8725s-ayn-common.dtsi, exposing the Odin 3's PWM fan to the Linux kernel sysfs interface at /sys/class/hwmon/hwmon*/pwm1. Required for userspace fan control. Odin 3 specific.

**020-fan_control**
Runs once at boot. Discovers the PWM fan hwmon path and builds a list of CPU/GPU thermal sensor paths, excluding PMIC and battery zones. Saves the result to /storage/.config/profile.d/020-fan_control so the fancontrol service knows where to read temperatures and write fan speed.

**bin/fancontrol**
Userspace fan control service tuned for the AYN Odin 3. Reads the average temperature across all CPU and GPU thermal zones every 3 seconds and sets fan PWM accordingly. Three profiles selectable from System Settings:

- Aggressive — fan starts at 45°C, full speed at 80°C
- Moderate/Auto — fan starts at 50°C, full speed at 85°C
- Quiet — fan starts at 55°C, full speed at 90°C
- Custom — user-defined thresholds via /storage/.config/fancontrol.conf. If the file is missing, fan runs at 0%.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
Tested all four fan profiles under load using RPCS3 (Drakengard 3) as the stress workload. Using _watch_ command to monitor pwm from _/255 and system temps.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES

<img width="4032" height="2268" alt="PXL_20260505_220849737 MP2" src="https://github.com/user-attachments/assets/b03f8b4f-1c5b-46d7-8244-5a68e7397c9a" />
<img width="4032" height="2268" alt="PXL_20260505_220856522 MP2" src="https://github.com/user-attachments/assets/f68d2c60-7a48-4740-8a5a-fa8ab9354182" />
