### PR TITLE
Gamescope/Steam: Allow "Maximum Game Resolution" setting to function

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam.sh
@@ -124,6 +124,7 @@ steam_arm64_binfmt_and_proton_prep() {
 steam_launch_bigpicture() {
   local game_uri=""
   local force_orientation="left"
+  local gamescope_mode_file="/storage/.config/gamescope/modes.cfg"
   if [ "${TRANSFORM}" = "90" ]; then
     force_orientation="right"
   elif [ "${TRANSFORM}" = "270" ]; then
@@ -136,6 +137,11 @@ steam_launch_bigpicture() {
     game_uri="${exec_line#steam } -silent"
   fi
 
+  if [ "${GAMESCOPE}" != "0" ]; then
+    mkdir -p "$(dirname "$gamescope_mode_file")"
+    touch "$gamescope_mode_file"
+  fi
+
   if [ "${STEAM_FLAVOR}" = "arm64" ]; then
     SDL_VIDEODRIVER=x11 LD_LIBRARY_PATH=/storage/.local/share/Steam/lib/aarch64-linux-gnu/ ${EMUPERF} /storage/.local/share/Steam/steamrtarm64/steam -steamdeck -exitsteam
     if [ "${GAMESCOPE}" = "0" ]; then
@@ -143,7 +149,7 @@ steam_launch_bigpicture() {
       exit 0
     else
       systemctl stop sway
-      GAMESCOPE_FAKE_OUTPUT_MM=508x286 env -u WAYLAND_DISPLAY LD_LIBRARY_PATH=/storage/.local/share/Steam/lib/aarch64-linux-gnu/ ${EMUPERF} \
+      GAMESCOPE_MODE_SAVE_FILE="${gamescope_mode_file}" GAMESCOPE_FAKE_OUTPUT_MM=508x286 env -u WAYLAND_DISPLAY LD_LIBRARY_PATH=/storage/.local/share/Steam/lib/aarch64-linux-gnu/ ${EMUPERF} \
         gamescope $PREFER_OUTPUT -W "$W" -H "$H" -r "$REFRESH_HZ" --xwayland-count 2 --mangoapp --backend drm --force-orientation "${force_orientation}" --use-rotation-shader -e -- \
         /storage/.local/share/Steam/steamrtarm64/steam -steamdeck -steamos3 -gamepadui -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles ${game_uri:+"$game_uri"}
       systemctl start essway
@@ -156,7 +162,7 @@ steam_launch_bigpicture() {
       exit 0
     else
       systemctl stop sway
-      GAMESCOPE_FAKE_OUTPUT_MM=508x286 env -u WAYLAND_DISPLAY ${EMUPERF} \
+      GAMESCOPE_MODE_SAVE_FILE="${gamescope_mode_file}" GAMESCOPE_FAKE_OUTPUT_MM=508x286 env -u WAYLAND_DISPLAY ${EMUPERF} \
         gamescope $PREFER_OUTPUT -W "$W" -H "$H" -r "$REFRESH_HZ" --xwayland-count 2 --mangoapp --backend drm --force-orientation "${force_orientation}" --use-rotation-shader -e -- \
         FEX /usr/bin/steam -steamdeck -steamos3 -gamepadui -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles ${game_uri:+"$game_uri"}
       systemctl start essway


### PR DESCRIPTION
## Summary

As titled

## Testing

Tested on Ayaneo Pocket DS (not with a full clean build, just the script)

## Additional Context

Ref:
https://github.com/ValveSoftware/gamescope/blob/02f91de630d8aba365dd0b0f8f15630be394fc15/src/Backends/DRMBackend.cpp#L1001

and based on example from
https://github.com/ChimeraOS/gamescope-session/blob/eeb3011a7e9f5ed4e7a8d7e9cff8dd0ac826d7a6/usr/share/gamescope-session-plus/gamescope-session-plus#L65

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
