### PR TITLE
Enable iris video accel for sm8550 on ayaneo devices

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayaneo-pocket-common.dtsi
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayaneo-pocket-common.dtsi
@@ -1410,3 +1410,7 @@
 		max-speed = <3200000>;
 	};
 };
+
+&iris {
+	status = "okay";
+};


### PR DESCRIPTION
## Summary

As titled

## Testing

Tested on Ayeneo Pocket DS, with moonlight, firefox, mpv, and gstreamer with Fedora userspace (I know..)

H264 and HEVC encode work with gst. H264, HEVC, VP9 and AV1 decode works (via libdav1d in firefox in case of av1)

## Additional Context

It's already enabled for Ayaneo devices on sm8650 and Ayn devices on sm8550, I only have one Ayaneo sm8550 device to test this one but frankly it shouldn't hurt to enable it in general.

Will help with moonlight streaming for one.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
