### PR TITLE
fix: azahar crashes with vulkan on Pocket DS and Thor

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/azahar-sa/scripts/start_azahar.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/azahar-sa/scripts/start_azahar.sh
@@ -198,6 +198,13 @@ case "${DISABLE_RIGHT_EYE_RENDER}" in
   *) sed -i '/^disable_right_eye_render=/c\disable_right_eye_render=false' ${CONF_FILE};;
 esac
 
+# QT platform - some device / screen combinations need xcb
+case ${HW_DEVICE} in
+    SM8550)
+        [[ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ]] && export QT_QPA_PLATFORM=xcb
+    ;;
+esac
+
 rm -rf /storage/.local/share/azahar
 ln -sf ${CONF_DIR} /storage/.local/share/azahar
 


### PR DESCRIPTION
Disables wayland on azahar so vulkan can be used on devices where multiple windows are used (like the Ayaneo Pocket DS and Ayn Thor).

## Summary

* Swaps to x11 for Azahar so that it doesnt crash on startup when using Vulkan on the Pocket DS and Thor.

## Testing

Manually edited the shell script to add the line, validated on an Ayaneo Pocket DS.

## Additional Context

This is a known bug upstream in Azahar: https://github.com/azahar-emu/azahar/issues/1162

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
