### PR TITLE
mpv - bump to v0.38.0

### DIFF
--- a/projects/ROCKNIX/packages/multimedia/mpv/package.mk
+++ b/projects/ROCKNIX/packages/multimedia/mpv/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="mpv"
-PKG_VERSION="f4210f84906c3b00a65fba198c8127b6757b9350" # 0.36.0
+PKG_VERSION="02254b92dd237f03aa0a151c2a68778c4ea848f9" # 0.38.0
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://github.com/mpv-player/mpv"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
## Summary

mpv - bump to v0.38.0

## Testing

Tested on S922X by the @TheTinkerer: https://discord.com/channels/948029830325235753/948034436660858971/1502105726749900871

## Additional Context

v0.36.0 is segfaulting after gcc bump. Versions > v0.38.0 introduce unpackaged dependencies.

---

### AI Usage

**Did you use AI tools to help write this code?** NO
