### PR TITLE
Add AYN Thor built-in microphone support

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/lib/kernel-overlays/base/lib/firmware/qcom/sm8550/AYN-Thor-tplg.bin
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/lib/kernel-overlays/base/lib/firmware/qcom/sm8550/AYN-Thor-tplg.bin
@@ -1,0 +1,1 @@
+AYN-Odin2-tplg.bin

--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
@@ -347,6 +347,21 @@
 	};
 };
 
+&{/sound} {
+	model = "AYN-Thor";
+	audio-routing =
+			"IN1_HPHL", "HPHL_OUT",
+			"IN2_HPHR", "HPHR_OUT",
+			"AMIC2", "MIC BIAS2",
+			"TX SWR_INPUT1", "ADC2_OUTPUT",
+			"DMIC3", "MIC BIAS3",
+			"TX SWR_INPUT7", "DMIC3_OUTPUT";
+};
+
+&{/sound/wcd-capture-dai-link/codec} {
+	sound-dai = <&wcd938x 1>, <&swr2 1>, <&lpass_txmacro 0>;
+};
+
 &i2c_hub_3 {
 	clock-frequency = <100000>;
 	status = "okay";

--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0200-ASoC-wcd938x-add-DMIC-DAPM-inputs.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0200-ASoC-wcd938x-add-DMIC-DAPM-inputs.patch
@@ -1,0 +1,75 @@
+From 7f1ce3a44393fee4288db81a5d0432abe16ca8f5 Fri May 8 22:40:00 2026
+From: Luke Johnson <jaewun@me.com>
+Date: Fri, 8 May 2026 22:40:00 +1200
+Subject: [PATCH] ASoC: wcd938x: add DAPM input sources for DMIC widgets
+
+The WCD938x TX path exposes DMIC ADC widgets and DMIC output mixers, but
+the DMIC ADC widgets have no source-side DAPM input route. Board routing can
+therefore connect MIC BIAS to "DMIC2" / "DMIC3" and the TX macro can request
+DMIC2_OUTPUT / DMIC3_OUTPUT, while DAPM still cannot power the DMIC ADC
+widgets as a complete capture path.
+
+Add explicit DAPM input widgets for the eight WCD DMICs and route each DMIC
+ADC from its matching input. This lets boards with WCD digital microphones
+power the full DMIC -> WCD TX SoundWire -> LPASS TX macro capture route.
+---
+ sound/soc/codecs/wcd938x.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/sound/soc/codecs/wcd938x.c b/sound/soc/codecs/wcd938x.c
+index f4f95985b61c..d759083af92b 100644
+--- a/sound/soc/codecs/wcd938x.c
++++ b/sound/soc/codecs/wcd938x.c
+@@ -2651,6 +2651,14 @@ static const struct snd_soc_dapm_widget wcd938x_dapm_widgets[] = {
+ 	SND_SOC_DAPM_MIC("Analog Mic3", NULL),
+ 	SND_SOC_DAPM_MIC("Analog Mic4", NULL),
+ 	SND_SOC_DAPM_MIC("Analog Mic5", NULL),
++	SND_SOC_DAPM_INPUT("DMIC1_IN"),
++	SND_SOC_DAPM_INPUT("DMIC2_IN"),
++	SND_SOC_DAPM_INPUT("DMIC3_IN"),
++	SND_SOC_DAPM_INPUT("DMIC4_IN"),
++	SND_SOC_DAPM_INPUT("DMIC5_IN"),
++	SND_SOC_DAPM_INPUT("DMIC6_IN"),
++	SND_SOC_DAPM_INPUT("DMIC7_IN"),
++	SND_SOC_DAPM_INPUT("DMIC8_IN"),
+ 
+ 	/*tx widgets*/
+ 	SND_SOC_DAPM_ADC_E("ADC1", NULL, SND_SOC_NOPM, 0, 0,
+@@ -2889,27 +2897,35 @@ static const struct snd_soc_dapm_route wcd938x_audio_map[] = {
+ 
+ 	{"DMIC1_OUTPUT", NULL, "DMIC1_MIXER"},
+ 	{"DMIC1_MIXER", "Switch", "DMIC1"},
++	{"DMIC1", NULL, "DMIC1_IN"},
+ 
+ 	{"DMIC2_OUTPUT", NULL, "DMIC2_MIXER"},
+ 	{"DMIC2_MIXER", "Switch", "DMIC2"},
++	{"DMIC2", NULL, "DMIC2_IN"},
+ 
+ 	{"DMIC3_OUTPUT", NULL, "DMIC3_MIXER"},
+ 	{"DMIC3_MIXER", "Switch", "DMIC3"},
++	{"DMIC3", NULL, "DMIC3_IN"},
+ 
+ 	{"DMIC4_OUTPUT", NULL, "DMIC4_MIXER"},
+ 	{"DMIC4_MIXER", "Switch", "DMIC4"},
++	{"DMIC4", NULL, "DMIC4_IN"},
+ 
+ 	{"DMIC5_OUTPUT", NULL, "DMIC5_MIXER"},
+ 	{"DMIC5_MIXER", "Switch", "DMIC5"},
++	{"DMIC5", NULL, "DMIC5_IN"},
+ 
+ 	{"DMIC6_OUTPUT", NULL, "DMIC6_MIXER"},
+ 	{"DMIC6_MIXER", "Switch", "DMIC6"},
++	{"DMIC6", NULL, "DMIC6_IN"},
+ 
+ 	{"DMIC7_OUTPUT", NULL, "DMIC7_MIXER"},
+ 	{"DMIC7_MIXER", "Switch", "DMIC7"},
++	{"DMIC7", NULL, "DMIC7_IN"},
+ 
+ 	{"DMIC8_OUTPUT", NULL, "DMIC8_MIXER"},
+ 	{"DMIC8_MIXER", "Switch", "DMIC8"},
++	{"DMIC8", NULL, "DMIC8_IN"},
+ 
+ 	{"IN1_HPHL", NULL, "VDD_BUCK"},
+ 	{"IN1_HPHL", NULL, "CLS_H_PORT"},
+-- 
+2.43.0

--- a/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8550/0005_Add-AYN-Thor.patch
+++ b/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8550/0005_Add-AYN-Thor.patch
@@ -1,0 +1,181 @@
+From 2037560fdc8aff449764f91992a24bf4087807f4 Sat May 9 00:45:00 2026
+From: Luke Johnson <jaewun@me.com>
+Date: Sat, 9 May 2026 00:45:00 +1200
+Subject: [PATCH] Add AYN Thor
+
+Add a Thor UCM profile with the verified built-in microphone route.
+Thor's internal mic uses the WCD938x DMIC3 path through SWR_MIC7.
+---
+ ucm2/AYN/Thor/AYN-Thor.conf        |  33 ++++++++++++
+ ucm2/AYN/Thor/HiFi.conf            | 100 ++++++++++++++++++++++++++++++++++++
+ ucm2/conf.d/sm8550/AYN-Thor.conf   |   1 +
+ ucm2/conf.d/sm8550/ayn-AYNThor-.conf | 1 +
+ 4 files changed, 135 insertions(+)
+ create mode 100644 ucm2/AYN/Thor/AYN-Thor.conf
+ create mode 100644 ucm2/AYN/Thor/HiFi.conf
+ create mode 120000 ucm2/conf.d/sm8550/AYN-Thor.conf
+ create mode 120000 ucm2/conf.d/sm8550/ayn-AYNThor-.conf
+
+diff --git a/ucm2/AYN/Thor/AYN-Thor.conf b/ucm2/AYN/Thor/AYN-Thor.conf
+new file mode 100644
+index 0000000..ecba163
+--- /dev/null
++++ b/ucm2/AYN/Thor/AYN-Thor.conf
+@@ -0,0 +1,33 @@
++# Use case configuration for AYN Thor
++
++Syntax 4
++
++SectionUseCase."HiFi" {
++	File "/AYN/Thor/HiFi.conf"
++	Comment "HiFi quality Music."
++}
++
++BootSequence [
++	cset "name='RX_RX0 Digital Volume' 84"
++	cset "name='RX_RX1 Digital Volume' 84"
++	cset "name='HPHL Volume' 20"
++	cset "name='HPHR Volume' 20"
++	cset "name='SPK_L PCM Playback Volume' 0"
++	cset "name='SPK_R PCM Playback Volume' 0"
++	cset "name='ADC1 Volume' 20"
++	cset "name='ADC2 Volume' 10"
++]
++
++LibraryConfig.remap.Config {
++
++	ctl.default.map {
++		"name='HP Volume'" {
++			"name='HPHL Volume'".vindex.0 0
++			"name='HPHR Volume'".vindex.1 0
++		}
++	}
++}
++
++Include.card-init.File "/lib/card-init.conf"
++Include.ctl-remap.File "/lib/ctl-remap.conf"
++Include.wcd-init.File "/codecs/wcd938x/init.conf"
+diff --git a/ucm2/AYN/Thor/HiFi.conf b/ucm2/AYN/Thor/HiFi.conf
+new file mode 100644
+index 0000000..d9489f1
+--- /dev/null
++++ b/ucm2/AYN/Thor/HiFi.conf
+@@ -0,0 +1,100 @@
++# Use case configuration for AYN Thor
++
++SectionVerb {
++	EnableSequence [
++		cset "name='PRIMARY_MI2S_RX Audio Mixer MultiMedia1' 1"
++		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
++		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 0"
++		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
++	]
++
++	DisableSequence [
++		cset "name='PRIMARY_MI2S_RX Audio Mixer MultiMedia1' 0"
++		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
++		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 0"
++		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 0"
++	]
++
++	Value {
++		TQ "HiFi"
++	}
++}
++
++SectionDevice."Speaker" {
++	Comment "Speaker playback"
++
++	Value {
++		PlaybackPriority 150
++		PlaybackPCM "hw:${CardId},0"
++		PlaybackChannels 2
++	}
++}
++
++SectionDevice."Headphones" {
++	Comment "Headphones Playback"
++
++	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneEnableSeq.conf"
++	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
++	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
++	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
++
++	Value {
++		PlaybackPriority 200
++		PlaybackPCM "hw:${CardId},1"
++		PlaybackMixer "default:${CardId}"
++		PlaybackMixerElem "HP"
++		PlaybackChannels 2
++		JackControl "Headphone Jack"
++		JackHWMute "Speaker"
++	}
++}
++
++SectionDevice."Mic" {
++	Comment "Internal Microphone"
++
++	EnableSequence [
++		cset "name='TX DEC0 MUX' SWR_MIC"
++		cset "name='TX SMIC MUX0' SWR_MIC7"
++		cset "name='DMIC3 Switch' 1"
++		cset "name='DMIC3_MIXER Switch' 1"
++		cset "name='TX_AIF1_CAP Mixer DEC0' 1"
++		cset "name='DEC0 MODE' ADC_DEFAULT"
++		cset "name='TX_DEC0 Volume' 100"
++	]
++
++	DisableSequence [
++		cset "name='TX_AIF1_CAP Mixer DEC0' 0"
++		cset "name='DMIC3_MIXER Switch' 0"
++		cset "name='DMIC3 Switch' 0"
++		cset "name='TX SMIC MUX0' ZERO"
++	]
++
++	Value {
++		CapturePriority 200
++		CapturePCM "hw:${CardId},2"
++		CaptureChannels 2
++	}
++}
++
++SectionDevice."DisplayPort" {
++	Comment "DisplayPort playback"
++
++	EnableSequence [
++		cset "name='PRIMARY_MI2S_RX Audio Mixer MultiMedia1' 0"
++		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
++		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 1"
++	]
++
++	DisableSequence [
++		cset "name='PRIMARY_MI2S_RX Audio Mixer MultiMedia1' 1"
++		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 0"
++		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
++	]
++
++	Value {
++		PlaybackPriority 100
++		PlaybackPCM "hw:${CardId},1"
++		JackControl "DP0 Jack"
++		JackHWMute "Speaker"
++	}
++}
+diff --git a/ucm2/conf.d/sm8550/AYN-Thor.conf b/ucm2/conf.d/sm8550/AYN-Thor.conf
+new file mode 120000
+index 0000000..6c6aaec
+--- /dev/null
++++ b/ucm2/conf.d/sm8550/AYN-Thor.conf
+@@ -0,0 +1 @@
++../../AYN/Thor/AYN-Thor.conf
+\ No newline at end of file
+diff --git a/ucm2/conf.d/sm8550/ayn-AYNThor-.conf b/ucm2/conf.d/sm8550/ayn-AYNThor-.conf
+new file mode 120000
+index 0000000..6c6aaec
+--- /dev/null
++++ b/ucm2/conf.d/sm8550/ayn-AYNThor-.conf
+@@ -0,0 +1 @@
++../../AYN/Thor/AYN-Thor.conf
+\ No newline at end of file
+-- 
+2.49.0


### PR DESCRIPTION
## Summary

This PR is based on the [Thorch microphone bring-up work](https://github.com/thorch-os/thorch/pull/2), narrowed down to the minimal changes needed for ROCKNIX.

* Add built-in microphone support for AYN Thor.
* Add Thor-specific sound routing in the Thor DTS override.
* Add the WCD938x DMIC DAPM input routes needed for digital microphone capture - maybe needs fixing upstream? Not sure, new to this
* Add an AYN Thor UCM profile for speaker, headphone, DisplayPort, and internal microphone use.
* Add an `AYN-Thor-tplg.bin` firmware alias to the existing Odin2 topology so the Thor sound card can keep its own model name.

## Testing

* Built ROCKNIX SM8550 successfully with:

```sh
make docker-SM8550
```

* Booted the generated image on AYN Thor.
* Verified the sound card registers as `AYN-Thor`.
* Verified speaker playback.
* Verified internal microphone capture.
* Tested recording and playback through ALSA/PipeWire, and inside sideloaded Firefox (to make sure it was reaching that level)

* **Test results:**
  * `arecord -l` exposes `MultiMedia3 Capture`.
  * Internal microphone records audible voice.
  * Speaker playback works.

---

### AI Usage

**Did you use AI tools to help write this code?** 

Yes, interactively and under close supervision and strict verification requirements. Was instrumental in research, debugging and iterating.

The final changes were tested on an AYN Thor device with manual audio capture/playback checks.
