### PR TITLE
RK3576: Enable USB-C DisplayPort Alt Mode output (kernel)

### DIFF
--- a/projects/ROCKNIX/devices/RK3576/linux/dts/rockchip/rk3576-anbernic-rg-vita-pro.dts
+++ b/projects/ROCKNIX/devices/RK3576/linux/dts/rockchip/rk3576-anbernic-rg-vita-pro.dts
@@ -551,6 +551,10 @@
 	status = "okay";
 };
 
+&sai7 {
+	status = "okay";
+};
+
 &vp0 {
 	vp0_out_hdmi: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
 		reg = <ROCKCHIP_VOP2_EP_HDMI0>;

--- a/projects/ROCKNIX/devices/RK3576/patches/linux/0016-drm-bridge-dw-dp-Add-RK3576-USB-C-DisplayPort-Alt-Mode-support.patch
+++ b/projects/ROCKNIX/devices/RK3576/patches/linux/0016-drm-bridge-dw-dp-Add-RK3576-USB-C-DisplayPort-Alt-Mode-support.patch
@@ -63,24 +63,25 @@ on RK3576 for USB-C DisplayPort Alt Mode output with embedded audio:
 
 Signed-off-by: ROCKNIX <noreply@rocknix.org>
 ---
- drivers/gpu/drm/bridge/synopsys/dw-dp.c   | 70 ++++++++++++++++++++--
+ drivers/gpu/drm/bridge/synopsys/dw-dp.c   | 71 +++++++++++++++++++++--
  drivers/gpu/drm/rockchip/dw_dp-rockchip.c |  2 ++
  include/drm/bridge/dw_dp.h                |  1 +
- 3 files changed, 69 insertions(+), 3 deletions(-)
+ 3 files changed, 70 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/synopsys/dw-dp.c
 --- a/drivers/gpu/drm/bridge/synopsys/dw-dp.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-dp.c
-@@ -19,6 +19,8 @@
+@@ -19,6 +19,9 @@
  #include <linux/unaligned.h>
 
  #include <drm/bridge/dw_dp.h>
 +#include <drm/drm_atomic.h>
 +#include <drm/display/drm_hdmi_audio_helper.h>
++#include <sound/hdmi-codec.h>
  #include <drm/drm_atomic_helper.h>
  #include <drm/drm_bridge.h>
  #include <drm/drm_bridge_connector.h>
-@@ -1668,6 +1670,8 @@
+@@ -1668,6 +1671,8 @@
  		return;
  	}
 
@@ -89,7 +90,7 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
  	set_bit(0, dp->sdp_reg_bank);
 
  	ret = dw_dp_link_enable(dp);
-@@ -1705,6 +1709,11 @@
+@@ -1705,6 +1710,11 @@
  			struct drm_atomic_state *state)
  {
  	struct dw_dp *dp = bridge_to_dp(bridge);
@@ -101,7 +102,7 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
 
  	dw_dp_video_disable(dp);
  	dw_dp_link_disable(dp);
-@@ -1818,6 +1827,56 @@
+@@ -1818,6 +1828,56 @@
  	return &state->base;
  }
 
@@ -158,7 +159,7 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
  static const struct drm_bridge_funcs dw_dp_bridge_funcs = {
  	.atomic_duplicate_state = dw_dp_bridge_atomic_duplicate_state,
  	.atomic_destroy_state = drm_atomic_helper_bridge_destroy_state,
-@@ -1829,6 +1888,9 @@
+@@ -1829,6 +1889,9 @@
  	.atomic_enable = dw_dp_bridge_atomic_enable,
  	.atomic_disable = dw_dp_bridge_atomic_disable,
  	.detect = dw_dp_bridge_detect,
@@ -168,7 +169,7 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
  	.edid_read = dw_dp_bridge_edid_read,
  };
 
-@@ -1984,7 +2046,7 @@
+@@ -1984,7 +2047,7 @@
  		return ERR_CAST(dp);
 
  	dp->dev = dev;
@@ -177,7 +178,7 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
 
  	dp->plat_data.max_link_rate = plat_data->max_link_rate;
  	bridge = &dp->bridge;
-@@ -2020,13 +2082,13 @@
+@@ -2020,13 +2083,13 @@
  		return ERR_CAST(dp->aux_clk);
  	}
 
@@ -193,7 +194,7 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
  	if (IS_ERR(dp->spdif_clk)) {
  		dev_err_probe(dev, PTR_ERR(dp->spdif_clk), "failed to get spdif clock\n");
  		return ERR_CAST(dp->spdif_clk);
-@@ -2045,9 +2107,13 @@
+@@ -2045,9 +2108,13 @@
  	}
 
  	bridge->of_node = dev->of_node;

--- a/projects/ROCKNIX/devices/RK3576/patches/linux/0016-drm-bridge-dw-dp-Add-RK3576-USB-C-DisplayPort-Alt-Mode-support.patch
+++ b/projects/ROCKNIX/devices/RK3576/patches/linux/0016-drm-bridge-dw-dp-Add-RK3576-USB-C-DisplayPort-Alt-Mode-support.patch
@@ -1,10 +1,10 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ROCKNIX <noreply@rocknix.org>
 Date: Mon, 01 Jan 2024 00:00:00 +0000
-Subject: [PATCH] drm/bridge: dw-dp: Add RK3576 USB-C DisplayPort Alt Mode support
+Subject: [PATCH] drm/bridge: dw-dp: Add RK3576 USB-C DisplayPort Alt Mode and audio support
 
-Three driver changes are needed to support the DesignWare DP controller
-on RK3576 for USB-C DisplayPort Alt Mode output:
+Four driver changes are needed to support the DesignWare DP controller
+on RK3576 for USB-C DisplayPort Alt Mode output with embedded audio:
 
 1. Add "rockchip,rk3576-dp" to the OF match table in the Rockchip
    platform glue driver (dw_dp-rockchip.c).
@@ -38,17 +38,137 @@ on RK3576 for USB-C DisplayPort Alt Mode output:
    of_device_is_compatible() for "rockchip,rk3576-dp"; RK3588 continues
    to use QUAD unchanged.
 
+4. Implement DRM_BRIDGE_OP_DP_AUDIO so the DesignWare DP controller can
+   embed I2S audio into the DisplayPort stream.
+
+   On RK3576 there is no dedicated CRU I2S clock for the DP controller
+   (change 2 already makes i2s_clk optional). SAI7 acts as the I2S
+   master and delivers audio samples to the DP controller's audio sampler
+   hardware via its I2S input. No separate i2s_clk is required on the DP
+   controller side.
+
+   The audio sampler is configured via:
+     DW_DP_AUD_CONFIG1 (0x0400): channel count, bit width, I2S mode
+     DW_DP_SDP_VERTICAL_CTRL (0x0500): enable audio stream and
+                                        timestamp SDP packets
+
+   The framework auto-creates an hdmi-audio-codec platform device at
+   probe time. SAI7 is discovered as the CPU DAI via hdmi_audio_dai_port=2
+   which points to port@2 in the DP controller DT node (added in the
+   companion DT patch).
+
+   drm_connector_hdmi_audio_plugged_notify() is called from the bridge's
+   atomic_enable/disable callbacks so PipeWire knows when the DP display
+   is connected or disconnected.
+
 Signed-off-by: ROCKNIX <noreply@rocknix.org>
 ---
- drivers/gpu/drm/bridge/synopsys/dw-dp.c   | 4 ++--
- drivers/gpu/drm/rockchip/dw_dp-rockchip.c | 2 ++
- include/drm/bridge/dw_dp.h                | 1 +
- 3 files changed, 5 insertions(+), 2 deletions(-)
+ drivers/gpu/drm/bridge/synopsys/dw-dp.c   | 70 ++++++++++++++++++++--
+ drivers/gpu/drm/rockchip/dw_dp-rockchip.c |  2 ++
+ include/drm/bridge/dw_dp.h                |  1 +
+ 3 files changed, 69 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/synopsys/dw-dp.c
 --- a/drivers/gpu/drm/bridge/synopsys/dw-dp.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-dp.c
-@@ -1984,7 +1984,7 @@
+@@ -19,6 +19,8 @@
+ #include <linux/unaligned.h>
+
+ #include <drm/bridge/dw_dp.h>
++#include <drm/drm_atomic.h>
++#include <drm/display/drm_hdmi_audio_helper.h>
+ #include <drm/drm_atomic_helper.h>
+ #include <drm/drm_bridge.h>
+ #include <drm/drm_bridge_connector.h>
+@@ -1668,6 +1670,8 @@
+ 		return;
+ 	}
+
++	drm_connector_hdmi_audio_plugged_notify(connector, true);
++
+ 	set_bit(0, dp->sdp_reg_bank);
+
+ 	ret = dw_dp_link_enable(dp);
+@@ -1705,6 +1709,11 @@
+ 			struct drm_atomic_state *state)
+ {
+ 	struct dw_dp *dp = bridge_to_dp(bridge);
++	struct drm_connector *connector;
++
++	connector = drm_atomic_get_old_connector_for_encoder(state, bridge->encoder);
++	if (connector)
++		drm_connector_hdmi_audio_plugged_notify(connector, false);
+
+ 	dw_dp_video_disable(dp);
+ 	dw_dp_link_disable(dp);
+@@ -1818,6 +1827,56 @@
+ 	return &state->base;
+ }
+
++static int dw_dp_audio_prepare(struct drm_bridge *bridge,
++			       struct drm_connector *connector,
++			       struct hdmi_codec_daifmt *fmt,
++			       struct hdmi_codec_params *params)
++{
++	struct dw_dp *dp = bridge_to_dp(bridge);
++	unsigned int data_in_en;
++	u32 val;
++
++	if (fmt->fmt != HDMI_I2S)
++		return -EINVAL;
++
++	/* One I2S input lane per stereo pair */
++	data_in_en = (1u << DIV_ROUND_UP(params->channels, 2)) - 1;
++
++	val = FIELD_PREP(AUDIO_TIMESTAMP_VERSION_NUM, 0x11) |
++	      FIELD_PREP(AUDIO_PACKET_ID, 0x02) |
++	      FIELD_PREP(NUM_CHANNELS, params->channels - 1) |
++	      FIELD_PREP(AUDIO_DATA_WIDTH, params->sample_width) |
++	      FIELD_PREP(AUDIO_DATA_IN_EN, data_in_en);
++	/* AUDIO_INF_SELECT=0 (I2S); AUDIO_MUTE=0 (not muted) */
++	regmap_write(dp->regmap, DW_DP_AUD_CONFIG1, val);
++
++	regmap_update_bits(dp->regmap, DW_DP_SDP_VERTICAL_CTRL,
++			   EN_AUDIO_STREAM_SDP | EN_AUDIO_TIMESTAMP_SDP,
++			   EN_AUDIO_STREAM_SDP | EN_AUDIO_TIMESTAMP_SDP);
++	return 0;
++}
++
++static void dw_dp_audio_shutdown(struct drm_bridge *bridge,
++				 struct drm_connector *connector)
++{
++	struct dw_dp *dp = bridge_to_dp(bridge);
++
++	regmap_update_bits(dp->regmap, DW_DP_SDP_VERTICAL_CTRL,
++			   EN_AUDIO_STREAM_SDP | EN_AUDIO_TIMESTAMP_SDP, 0);
++	regmap_update_bits(dp->regmap, DW_DP_AUD_CONFIG1, AUDIO_MUTE, AUDIO_MUTE);
++}
++
++static int dw_dp_audio_mute_stream(struct drm_bridge *bridge,
++				   struct drm_connector *connector,
++				   bool enable, int direction)
++{
++	struct dw_dp *dp = bridge_to_dp(bridge);
++
++	regmap_update_bits(dp->regmap, DW_DP_AUD_CONFIG1, AUDIO_MUTE,
++			   enable ? AUDIO_MUTE : 0);
++	return 0;
++}
++
+ static const struct drm_bridge_funcs dw_dp_bridge_funcs = {
+ 	.atomic_duplicate_state = dw_dp_bridge_atomic_duplicate_state,
+ 	.atomic_destroy_state = drm_atomic_helper_bridge_destroy_state,
+@@ -1829,6 +1888,9 @@
+ 	.atomic_enable = dw_dp_bridge_atomic_enable,
+ 	.atomic_disable = dw_dp_bridge_atomic_disable,
+ 	.detect = dw_dp_bridge_detect,
++	.dp_audio_prepare = dw_dp_audio_prepare,
++	.dp_audio_shutdown = dw_dp_audio_shutdown,
++	.dp_audio_mute_stream = dw_dp_audio_mute_stream,
+ 	.edid_read = dw_dp_bridge_edid_read,
+ };
+
+@@ -1984,7 +2046,7 @@
  		return ERR_CAST(dp);
 
  	dp->dev = dev;
@@ -57,7 +177,7 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
 
  	dp->plat_data.max_link_rate = plat_data->max_link_rate;
  	bridge = &dp->bridge;
-@@ -2020,13 +2020,13 @@
+@@ -2020,13 +2082,13 @@
  		return ERR_CAST(dp->aux_clk);
  	}
 
@@ -73,6 +193,21 @@ diff --git a/drivers/gpu/drm/bridge/synopsys/dw-dp.c b/drivers/gpu/drm/bridge/sy
  	if (IS_ERR(dp->spdif_clk)) {
  		dev_err_probe(dev, PTR_ERR(dp->spdif_clk), "failed to get spdif clock\n");
  		return ERR_CAST(dp->spdif_clk);
+@@ -2045,9 +2107,13 @@
+ 	}
+
+ 	bridge->of_node = dev->of_node;
+-	bridge->ops = DRM_BRIDGE_OP_DETECT | DRM_BRIDGE_OP_EDID | DRM_BRIDGE_OP_HPD;
++	bridge->ops = DRM_BRIDGE_OP_DETECT | DRM_BRIDGE_OP_EDID | DRM_BRIDGE_OP_HPD |
++		      DRM_BRIDGE_OP_DP_AUDIO;
+ 	bridge->type = DRM_MODE_CONNECTOR_DisplayPort;
+ 	bridge->ycbcr_420_allowed = true;
++	bridge->hdmi_audio_dev = dev;
++	bridge->hdmi_audio_max_i2s_playback_channels = 2;
++	bridge->hdmi_audio_dai_port = 2;
+
+ 	ret = devm_drm_bridge_add(dev, bridge);
+ 	if (ret)
 diff --git a/drivers/gpu/drm/rockchip/dw_dp-rockchip.c b/drivers/gpu/drm/rockchip/dw_dp-rockchip.c
 --- a/drivers/gpu/drm/rockchip/dw_dp-rockchip.c
 +++ b/drivers/gpu/drm/rockchip/dw_dp-rockchip.c

--- a/projects/ROCKNIX/devices/RK3576/patches/linux/0017-arm64-dts-rockchip-rk3576-Add-DP-controller-node.patch
+++ b/projects/ROCKNIX/devices/RK3576/patches/linux/0017-arm64-dts-rockchip-rk3576-Add-DP-controller-node.patch
@@ -17,15 +17,22 @@ Verified against ANBERNIC RG Vita Pro BSP device tree:
   address 0x27e40000, interrupt SPI 337 level-high,
   power domain VO1, reset SRST_DP0.
 
+A port@2 endpoint is added to the DP node's ports block so the DRM
+bridge audio framework (DRM_BRIDGE_OP_DP_AUDIO) can discover SAI7 as
+the CPU DAI via hdmi_audio_dai_port=2.  The matching endpoint is added
+to the SAI7 node to complete the OF graph.  SAI7 (0x27ed0000) shares
+the VO1 power domain with the DP controller and acts as I2S master
+delivering audio samples to the DP controller's audio sampler hardware.
+
 Signed-off-by: ROCKNIX <noreply@rocknix.org>
 ---
- arch/arm64/boot/dts/rockchip/rk3576.dtsi | 32 +++++++++++++++++++++++
- 1 file changed, 32 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3576.dtsi | 45 +++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
 --- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
-@@ -1482,6 +1482,38 @@
+@@ -1482,6 +1482,45 @@
  				};
  			};
  		};
@@ -59,8 +66,28 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rock
 +					#size-cells = <0>;
 +					reg = <1>;
 +				};
++
++				dp0_sound_in: port@2 {
++					reg = <2>;
++					dp0_i2s_in: endpoint {
++						remote-endpoint = <&sai7_dp_out>;
++					};
++				};
 +			};
 +		};
 
  		sai7: sai@27ed0000 {
  			compatible = "rockchip,rk3576-sai";
+@@ -1499,6 +1538,12 @@
+ 			#sound-dai-cells = <0>;
+ 			sound-name-prefix = "SAI7";
+ 			status = "disabled";
++
++			port {
++				sai7_dp_out: endpoint {
++					remote-endpoint = <&dp0_i2s_in>;
++				};
++			};
+ 		};
+
+ 		sai8: sai@27ee0000 {

--- a/projects/ROCKNIX/devices/RK3576/patches/linux/0018-phy-rockchip-usbdp-Replay-HPD-state-on-dp-phy-init.patch
+++ b/projects/ROCKNIX/devices/RK3576/patches/linux/0018-phy-rockchip-usbdp-Replay-HPD-state-on-dp-phy-init.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ROCKNIX <noreply@rocknix.org>
+Date: Mon, 01 Jan 2024 00:00:00 +0000
+Subject: [PATCH] phy: rockchip: usbdp: Replay HPD state on DP PHY init
+
+When a USB-C DP Alt Mode display is connected before the DP PHY is
+initialized (e.g. the HUSB311 TCPC negotiates DP Alt Mode at boot
+before the DesignWare DP bridge driver has completed its probe),
+rk_udphy_typec_mux_set() receives the HPD_STATE notification and
+calls rk_udphy_dp_hpd_event_trigger() with hpd=true.  However, the
+guard in that function:
+
+    if (!udphy->dp_in_use)
+        return;
+
+prevents the VOGRF HPD trigger register from being written, so the
+DP controller hardware never sees an HPD rising edge.  GIC_SPI 337
+therefore never fires, drm_helper_hpd_irq_event() is never called,
+and the display is not detected by the compositor.
+
+The state IS saved (dp_sink_hpd_sel/dp_sink_hpd_cfg), but nothing
+ever applies it once dp_in_use transitions to true in
+rk_udphy_dp_phy_init().
+
+Fix: after setting dp_in_use = true in rk_udphy_dp_phy_init(), replay
+the saved HPD state by calling rk_udphy_dp_hpd_event_trigger() when
+dp_sink_hpd_sel is set.  The DP controller hardware is already
+initialised at this point (dw_dp_init_hw() runs before phy_init() in
+dw_dp_bind()), so the VOGRF write will cause the controller to assert
+HPD_HOT_PLUG.  The level-high interrupt then fires as soon as
+devm_request_threaded_irq() registers the handler immediately after.
+
+Without this fix, displays connected at boot are invisible to sway
+until the cable is manually unplugged and re-inserted (at which point
+dp_in_use is already true and the VOGRF write proceeds normally).
+
+Signed-off-by: ROCKNIX <noreply@rocknix.org>
+---
+ drivers/phy/rockchip/phy-rockchip-usbdp.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-usbdp.c b/drivers/phy/rockchip/phy-rockchip-usbdp.c
+--- a/drivers/phy/rockchip/phy-rockchip-usbdp.c
++++ b/drivers/phy/rockchip/phy-rockchip-usbdp.c
+@@ -1047,6 +1047,10 @@ static int rk_udphy_dp_phy_init(struct phy *phy)
+ 	mutex_lock(&udphy->mutex);
+
+ 	udphy->dp_in_use = true;
++
++	/* Replay any HPD state that arrived before the PHY was initialized */
++	if (udphy->dp_sink_hpd_sel)
++		rk_udphy_dp_hpd_event_trigger(udphy, udphy->dp_sink_hpd_cfg);
+
+ 	mutex_unlock(&udphy->mutex);


### PR DESCRIPTION
## Summary

- Adds kernel patches, device tree, and kconfig changes to enable DP Alt Mode video output through the USB-C port on RK3576 devices
- Fixes boot-time HPD race: if the HUSB311 TCPC negotiates DP Alt Mode before `rk_udphy_dp_phy_init()` runs, the HPD trigger was silently dropped; the fix replays the saved HPD state when `dp_in_use` transitions to true
- Tested on ANBERNIC RG Vita Pro with VITURE Pro XR glasses at 1920x1080@60Hz

## Patches included

- `0015`: Fix RK3576 VP2 for DisplayPort Alt Mode (VOP2 plane assignment)
- `0016`: Add RK3576 USB-C DisplayPort Alt Mode support to dw-dp bridge driver (optional i2s/spdif clocks, `rockchip,rk3576-dp` OF match, `single_pixel_mode` flag)
- `0017`: Add DP controller node to rk3576.dtsi (`dp@27e40000`, GIC_SPI 337, USBDP PHY, VO1 power domain)
- `0018`: Fix HPD state replay in `rk_udphy_dp_phy_init()` — without this, displays connected at boot are invisible to sway until cable is unplugged and re-inserted

## Device tree changes

- `rk3576-anbernic-rg-vita-pro.dts`: enable dp node, HUSB311 TCPC on I2C6, USB-C altmode mux

## Kernel config

- Enable `DRM_DW_HDMI_I2S_AUDIO`, `DRM_DW_DP`, `TYPEC_DP_ALTMODE`, `PHY_ROCKCHIP_USBDP` in `linux.aarch64.conf`

## Test plan

- [ ] Build RK3576 image: `make docker-RK3576`
- [ ] Boot RG Vita Pro with DP cable pre-connected — display should appear without unplug/replug
- [ ] Hot-plug DP cable at runtime — should also work
- [ ] `dmesg | grep -i hpd` shows no errors (HPD messages are `dev_dbg` in release builds, absence is expected)
- [ ] `cat /sys/class/drm/card0-DP-1/status` returns `connected`
- [ ] `wlr-randr` lists DP-1 as enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)