### PR TITLE
commander - force zink for SM8550 to work around GPU hangs

### DIFF
--- a/projects/ROCKNIX/packages/misc/modules/sources/commander.sh
+++ b/projects/ROCKNIX/packages/misc/modules/sources/commander.sh
@@ -6,6 +6,9 @@
 . /etc/profile
 set_kill set "commander"
 
+# Work around GPU hangs on SM8550
+[[ "${HW_DEVICE}" == "SM8550" ]] && export MESA_LOADER_DRIVER_OVERRIDE="zink"
+
 sway_fullscreen "commander" &
 
 /usr/bin/commander


### PR DESCRIPTION
## Summary

commander - force zink for SM8550 to work around GPU hangs

Thanks to @r3claimer for the suggestion

## Testing

Tested on my Odin 2. For some reason this change also fixes control issues.

## Additional Context

Lock-ups are due to:
```
[   80.985706] platform 3d6a000.gmu: [drm:a6xx_gmu_set_oob] *ERROR* Timeout waiting for GMU OOB set GPU_SET: 0x0
[   80.996109] platform 3d6a000.gmu: [drm:a6xx_gmu_set_oob] *ERROR* Timeout waiting for GMU OOB set GPU_SET: 0x0
[   81.006663] platform 3d6a000.gmu: [drm:a6xx_gmu_set_oob] *ERROR* Timeout waiting for GMU OOB set GPU_SET: 0x0
[   81.016757] platform 3d6a000.gmu: [drm:a6xx_gmu_set_oob] *ERROR* Timeout waiting for GMU OOB set GPU_SET: 0x0
[   81.920219] adreno 3d00000.gpu: [drm:a6xx_irq] *ERROR* gpu fault ring 2 fence 1324 status 00800005 rb 0000/0167 ib1 0000000000000000/0000 ib2 0000000000000000/0000
[   81.920844] msm_dpu ae01000.display-controller: [drm:recover_worker] *ERROR* 67.5.10.1: hangcheck recover!
[   81.920923] msm_dpu ae01000.display-controller: [drm:recover_worker] *ERROR* 67.5.10.1: offending task: commande:gdrv0 (/usr/bin/commander)
[   81.922831] *** gpu fault: ttbr0=000000089a912000 iova=0000000000000000 dir=READ type=TRANSLATION source=CP (3736059565,3736059565,3736059565,3736059565)
[   82.015802] revision: 0 (67.5.10.1)
[   82.015804] rb 0: fence:    2316/2317
[   82.015806] rptr:     0
[   82.015806] rb wptr:  233
[   82.015807] rb 1: fence:    -256/-256
[   82.015809] rptr:     0
[   82.015809] rb wptr:  0
[   82.015810] rb 2: fence:    4898/4900
[   82.015811] rptr:     0
[   82.015812] rb wptr:  521
[   82.015813] rb 3: fence:    -256/-256
[   82.015814] rptr:     0
[   82.015815] rb wptr:  0
[   91.105225] msm_dpu ae01000.display-controller: 67.5.10.1: preemption timed out
```

---

### AI Usage

**Did you use AI tools to help write this code?** NO
