### PR TITLE
mangohud: fix SM8750 patch content (was patch-within-a-patch)

### DIFF
--- a/projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0001-SM8750-GPU.patch
+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0001-SM8750-GPU.patch
@@ -1,195 +1,165 @@
-From 92297604c46328478594574d48edd9c462e9243f Mon Sep 17 00:00:00 2001
-From: Vesnine <112007744+pablovesnine@users.noreply.github.com>
-Date: Sun, 10 May 2026 20:17:14 +0200
-Subject: [PATCH] mangohud: add SM8750 GPU patch (Adreno 830)
+From 8abf317204f876b19238c21f045b1d54fc77cd80 Mon Sep 17 00:00:00 2001
+From: John Williams <porschemad911@gmail.com>
+Date: Tue, 13 Jan 2026 21:46:12 +1100
+Subject: [PATCH 1/1] SM8750 GPU (Adreno 830)
 
-Enable GPU metrics for SM8750 (Adreno 830 / AYN Odin 3):
-  - GPU load % via drm-engine-gpu fdinfo
-  - GPU clock MHz via /sys/class/devfreq/3d00000.gpu/cur_freq
-  - GPU temp C via gpuss0_thermal hwmon sensor
-
-GPU power (watts) not available: MSM kernel driver does not
-expose a hwmon power/energy interface for the Adreno 830.
-
-Thermal zone: gpuss0_thermal (no underscore before digit,
-unlike SM8550 which uses gpuss_0_thermal).
-
-mangohud: fix patch author metadata for SM8750
-
-mangohud: revert patch author to original (John Williams)
 ---
- .../patches/SM8750/0001-SM8750-GPU.patch      | 162 ++++++++++++++++++
- 1 file changed, 162 insertions(+)
- create mode 100644 projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0001-SM8750-GPU.patch
+ src/gpu_fdinfo.cpp | 68 ++++++++++++++++++++++++++++++++++------------
+ src/gpu_fdinfo.h   |  2 ++
+ 2 files changed, 53 insertions(+), 17 deletions(-)
 
-diff --git a/projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0001-SM8750-GPU.patch b/projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0001-SM8750-GPU.patch
-new file mode 100644
-index 0000000000..012ad4726e
---- /dev/null
-+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0001-SM8750-GPU.patch
-@@ -0,0 +1,162 @@
-+From 8abf317204f876b19238c21f045b1d54fc77cd80 Mon Sep 17 00:00:00 2001
-+From: John Williams <porschemad911@gmail.com>
-+Date: Tue, 13 Jan 2026 21:46:12 +1100
-+Subject: [PATCH 1/1] SM8750 GPU (Adreno 830)
+diff --git a/src/gpu_fdinfo.cpp b/src/gpu_fdinfo.cpp
+index 0fdd99e..4a8b7c1 100644
+--- a/src/gpu_fdinfo.cpp
++++ b/src/gpu_fdinfo.cpp
+@@ -55,7 +55,7 @@ void GPU_fdinfo::find_fd()
+                 client_id = val;
+         }
+ 
+-        if (!driver.empty() && driver == module) {
++        if ((module == "msm_dpu" || module == "msm_drm") && driver == "msm") {
+             total++;
+             SPDLOG_TRACE(
+                 "driver = \"{}\", pdev = \"{}\", "
+@@ -63,14 +63,30 @@ void GPU_fdinfo::find_fd()
+                 driver, pdev,
+                 client_id, client_ids.find(client_id) != client_ids.end()
+             );
+-        }
+ 
+-        if (
+-            driver.empty() || client_id.empty() ||
+-            driver != module || pdev != pci_dev ||
+-            client_ids.find(client_id) != client_ids.end()
+-        )
+-            continue;
++            if (
++                driver.empty() || client_id.empty() ||
++                client_ids.find(client_id) != client_ids.end()
++            )
++                continue;
++        } else {
++            if (!driver.empty() && driver == module) {
++                total++;
++                SPDLOG_TRACE(
++                    "driver = \"{}\", pdev = \"{}\", "
++                    "client_id = \"{}\", client_id_exists = \"{}\"",
++                    driver, pdev,
++                    client_id, client_ids.find(client_id) != client_ids.end()
++                );
++            }
 +
-+---
-+ src/gpu_fdinfo.cpp | 68 ++++++++++++++++++++++++++++++++++------------
-+ src/gpu_fdinfo.h   |  2 ++
-+ 2 files changed, 53 insertions(+), 17 deletions(-)
++            if (
++                driver.empty() || client_id.empty() ||
++                driver != module || pdev != pci_dev ||
++                client_ids.find(client_id) != client_ids.end()
++            )
++                continue;
++        }
+ 
+         client_ids.insert(client_id);
+         open_fdinfo_fd(fd_path);
+@@ -175,8 +191,9 @@ void GPU_fdinfo::find_hwmon_sensors()
+ {
+     std::string hwmon;
+ 
+-    if (module == "msm")
+-        hwmon = find_hwmon_sensor_dir("gpu");
++    if (module == "msm_drm" || module == "msm_dpu" )
++        // Adreno 830 (SM8750): gpuss0_thermal (no underscore before digit)
++        hwmon = find_hwmon_sensor_dir("gpuss0_thermal");
+     else if (module == "panfrost" || module == "panthor")
+         hwmon = find_hwmon_sensor_dir("gpu_thermal");
+     else
+@@ -538,6 +555,8 @@ int GPU_fdinfo::get_gpu_clock()
+ {
+     if (module == "panfrost" || module == "panthor")
+         return get_gpu_clock_mali();
++    else if (module == "msm_dpu")
++        return get_kgsl_clock();
+ 
+     if (!gpu_clock_stream.is_open())
+         return 0;
+@@ -637,7 +656,7 @@ float GPU_fdinfo::amdgpu_helper_get_proc_vram() {
+ }
+ 
+ void GPU_fdinfo::init_kgsl() {
+-    const std::string sys_path = "/sys/class/kgsl/kgsl-3d0";
++    const std::string sys_path = "/sys/class/devfreq/3d00000.gpu";
+ 
+     try {
+         if (!fs::exists(sys_path)) {
+@@ -649,7 +668,8 @@ void GPU_fdinfo::init_kgsl() {
+         return;
+     }
+ 
+-    for (std::string metric : {"gpu_busy_percentage", "temp", "clock_mhz" }) {
++    // Only GPU clocks accessible
++    for (std::string metric : {"cur_freq" }) {
+         std::string p = sys_path + "/" + metric;
+ 
+         if (!fs::exists(p)) {
+@@ -658,11 +678,7 @@ void GPU_fdinfo::init_kgsl() {
+         }
+ 
+         SPDLOG_DEBUG("kgsl: {} found", p);
+-
+-        if (metric == "clock_mhz")
+-            gpu_clock_stream.open(p);
+-        else
+-            kgsl_streams[metric].open(p);
++        kgsl_streams[metric].open(p);
+     }
+ }
+ 
+@@ -702,6 +718,24 @@ int GPU_fdinfo::get_kgsl_temp() {
+     return std::round(std::stoi(temp_str) / 1'000.f);
+ }
+ 
++int GPU_fdinfo::get_kgsl_clock() {
++    std::ifstream* s = &kgsl_streams["cur_freq"];
 +
-+diff --git a/src/gpu_fdinfo.cpp b/src/gpu_fdinfo.cpp
-+index 0fdd99e..4a8b7c1 100644
-+--- a/src/gpu_fdinfo.cpp
-++++ b/src/gpu_fdinfo.cpp
-+@@ -55,7 +55,7 @@ void GPU_fdinfo::find_fd()
-+                 client_id = val;
-+         }
-+ 
-+-        if (!driver.empty() && driver == module) {
-++        if ((module == "msm_dpu" || module == "msm_drm") && driver == "msm") {
-+             total++;
-+             SPDLOG_TRACE(
-+                 "driver = \"{}\", pdev = \"{}\", "
-+@@ -63,14 +63,30 @@ void GPU_fdinfo::find_fd()
-+                 driver, pdev,
-+                 client_id, client_ids.find(client_id) != client_ids.end()
-+             );
-+-        }
-+ 
-+-        if (
-+-            driver.empty() || client_id.empty() ||
-+-            driver != module || pdev != pci_dev ||
-+-            client_ids.find(client_id) != client_ids.end()
-+-        )
-+-            continue;
-++            if (
-++                driver.empty() || client_id.empty() ||
-++                client_ids.find(client_id) != client_ids.end()
-++            )
-++                continue;
-++        } else {
-++            if (!driver.empty() && driver == module) {
-++                total++;
-++                SPDLOG_TRACE(
-++                    "driver = \"{}\", pdev = \"{}\", "
-++                    "client_id = \"{}\", client_id_exists = \"{}\"",
-++                    driver, pdev,
-++                    client_id, client_ids.find(client_id) != client_ids.end()
-++                );
-++            }
-++
-++            if (
-++                driver.empty() || client_id.empty() ||
-++                driver != module || pdev != pci_dev ||
-++                client_ids.find(client_id) != client_ids.end()
-++            )
-++                continue;
-++        }
-+ 
-+         client_ids.insert(client_id);
-+         open_fdinfo_fd(fd_path);
-+@@ -175,8 +191,9 @@ void GPU_fdinfo::find_hwmon_sensors()
-+ {
-+     std::string hwmon;
-+ 
-+-    if (module == "msm")
-+-        hwmon = find_hwmon_sensor_dir("gpu");
-++    if (module == "msm_drm" || module == "msm_dpu" )
-++        // Adreno 830 (SM8750): gpuss0_thermal (no underscore before digit)
-++        hwmon = find_hwmon_sensor_dir("gpuss0_thermal");
-+     else if (module == "panfrost" || module == "panthor")
-+         hwmon = find_hwmon_sensor_dir("gpu_thermal");
-+     else
-+@@ -538,6 +555,8 @@ int GPU_fdinfo::get_gpu_clock()
-+ {
-+     if (module == "panfrost" || module == "panthor")
-+         return get_gpu_clock_mali();
-++    else if (module == "msm_dpu")
-++        return get_kgsl_clock();
-+ 
-+     if (!gpu_clock_stream.is_open())
-+         return 0;
-+@@ -637,7 +656,7 @@ float GPU_fdinfo::amdgpu_helper_get_proc_vram() {
-+ }
-+ 
-+ void GPU_fdinfo::init_kgsl() {
-+-    const std::string sys_path = "/sys/class/kgsl/kgsl-3d0";
-++    const std::string sys_path = "/sys/class/devfreq/3d00000.gpu";
-+ 
-+     try {
-+         if (!fs::exists(sys_path)) {
-+@@ -649,7 +668,8 @@ void GPU_fdinfo::init_kgsl() {
-+         return;
-+     }
-+ 
-+-    for (std::string metric : {"gpu_busy_percentage", "temp", "clock_mhz" }) {
-++    // Only GPU clocks accessible
-++    for (std::string metric : {"cur_freq" }) {
-+         std::string p = sys_path + "/" + metric;
-+ 
-+         if (!fs::exists(p)) {
-+@@ -658,11 +678,7 @@ void GPU_fdinfo::init_kgsl() {
-+         }
-+ 
-+         SPDLOG_DEBUG("kgsl: {} found", p);
-+-
-+-        if (metric == "clock_mhz")
-+-            gpu_clock_stream.open(p);
-+-        else
-+-            kgsl_streams[metric].open(p);
-++        kgsl_streams[metric].open(p);
-+     }
-+ }
-+ 
-+@@ -702,6 +718,24 @@ int GPU_fdinfo::get_kgsl_temp() {
-+     return std::round(std::stoi(temp_str) / 1'000.f);
-+ }
-+ 
-++int GPU_fdinfo::get_kgsl_clock() {
-++    std::ifstream* s = &kgsl_streams["cur_freq"];
-++
-++    if (!s->is_open())
-++        return 0;
-++
-++    std::string freq_str;
-++
-++    s->seekg(0);
-++
-++    std::getline(*s, freq_str);
-++
-++    if (freq_str.empty())
-++        return 0;
-++
-++    return std::round(std::stoi(freq_str) / 1'000'000.f);
-++}
-++
-+ void GPU_fdinfo::main_thread()
-+ {
-+     while (!stop_thread) {
-+diff --git a/src/gpu_fdinfo.h b/src/gpu_fdinfo.h
-+index 97e62e5..a5b1d9e 100644
-+--- a/src/gpu_fdinfo.h
-++++ b/src/gpu_fdinfo.h
-+@@ -119,6 +119,7 @@ private:
-+     void init_kgsl();
-+     int get_kgsl_load();
-+     int get_kgsl_temp();
-++    int get_kgsl_clock();
-+ 
-+ public:
-+     GPU_fdinfo(
-+@@ -146,6 +147,7 @@ public:
-+         } else if (module == "msm_dpu") {
-+             // msm driver does not report vram usage
-+             drm_engine_type = "drm-engine-gpu";
-++            init_kgsl();
-+         } else if (module == "msm_drm") {
-+             init_kgsl();
-+         } else if (module == "panfrost") {
-+-- 
-+2.47.3
++    if (!s->is_open())
++        return 0;
 +
++    std::string freq_str;
++
++    s->seekg(0);
++
++    std::getline(*s, freq_str);
++
++    if (freq_str.empty())
++        return 0;
++
++    return std::round(std::stoi(freq_str) / 1'000'000.f);
++}
++
+ void GPU_fdinfo::main_thread()
+ {
+     while (!stop_thread) {
+diff --git a/src/gpu_fdinfo.h b/src/gpu_fdinfo.h
+index 97e62e5..a5b1d9e 100644
+--- a/src/gpu_fdinfo.h
++++ b/src/gpu_fdinfo.h
+@@ -119,6 +119,7 @@ private:
+     void init_kgsl();
+     int get_kgsl_load();
+     int get_kgsl_temp();
++    int get_kgsl_clock();
+ 
+ public:
+     GPU_fdinfo(
+@@ -146,6 +147,7 @@ public:
+         } else if (module == "msm_dpu") {
+             // msm driver does not report vram usage
+             drm_engine_type = "drm-engine-gpu";
++            init_kgsl();
+         } else if (module == "msm_drm") {
+             init_kgsl();
+         } else if (module == "panfrost") {
+-- 
+2.47.3
+
 -- 
 2.54.0
 


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**

Fix the SM8750 MangoHud patch file that was accidentally committed as a `git format-patch` of the ROCKNIX commit that added it, rather than the actual MangoHud source patch. This caused the build system to apply the patch to the `.patch` file itself instead of `src/gpu_fdinfo.cpp`, so MangoHud was being built without Adreno 830 GPU support despite the patch appearing to be present.

Replace with the correct patch by John Williams (`8abf317`) that modifies `src/gpu_fdinfo.cpp` and `src/gpu_fdinfo.h` to add Adreno 830 (SM8750) GPU support.

## Testing

**How was this tested?**
Built locally for SM8750 using `make docker-SM8750 PKG=mangohud` before and after the fix.

**Test results:**
- Before fix: build log showed `patching file projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0001-SM8750-GPU.patch`, the patch was being applied to itself, not to the MangoHud source
- After fix: patch applies correctly to `src/gpu_fdinfo.cpp` and `src/gpu_fdinfo.h`; MangoHud reports Adreno 830 GPU metrics on AYN Odin 3 (SM8750)

## Additional Context

The root cause was a misunderstanding of what `git format-patch` should target: the patch was generated from the ROCKNIX commit that added the file, rather than from the MangoHud upstream commit (`8abf317`) that modifies the source code. The correct patch content was extracted and verified against John Williams' original work.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY
 AI assistance was used to diagnose the patch-within-a-patch issue and extract the correct patch content. The patch itself is John Williams' original work (`8abf317`).