### PR TITLE
mangohud: add SM8750 battery remaining time fix

### DIFF
--- a/projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0002-SM8750-Battery.patch
+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/SM8750/0002-SM8750-Battery.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pablo Vesnine <pablovesnine@users.noreply.github.com>
+Date: Tue, 12 May 2026 13:45:43 +0200
+Subject: [PATCH] SM8750 battery: fix remaining time display
+
+On SM8750 (AYN Odin 3), time_to_empty_avg is reported in seconds.
+Use it directly when available, converting to hours (/ 3600).
+
+Note: power_now on SM8750 reports system-wide rail power (~68W),
+not battery discharge power. current_now * voltage_now gives the
+correct battery discharge wattage (~2W idle).
+---
+ src/battery.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/battery.cpp b/src/battery.cpp
+index 9cf8e5b..de98884 100644
+--- a/src/battery.cpp
++++ b/src/battery.cpp
+@@ -141,6 +141,15 @@
+         string energy_now = syspath + "/energy_now";
+         string voltage_now = syspath + "/voltage_now";
+         string power_now = syspath + "/power_now";
++        string time_to_empty = syspath + "/time_to_empty_avg";
++
++        if (fs::exists(time_to_empty)) {
++            std::string line;
++            std::ifstream input(time_to_empty);
++            if(std::getline(input, line)){
++                return stof(line) / 3600.0f;
++            }
++        }
+ 
+         if (fs::exists(current_now)) {
+             std::ifstream input(current_now);
+-- 
+2.47.3


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Add battery remaining time support for SM8750 (AYN Odin 3). On SM8750, `time_to_empty_avg` is reported in seconds, this patch reads it directly and converts to hours (`/ 3600`). Also notes that `power_now` on this SoC reports abnormal power (~68W), not battery discharge; `current_now * voltage_now` already gives the correct wattage reading and is left unchanged.

## Testing

* **How was this tested?** Built and tested on AYN Odin 3 (SM8750 / Snapdragon 8 Elite).
* **Test results:**
  - Battery wattage display unchanged and reasonably correct

## Additional Context

* Companion to #2694 (SM8750 GPU patch). Follows the same pattern as existing device-specific battery patches (RK3326, SM8550).
* `time_to_empty_avg` path: `/sys/class/power_supply/battery/time_to_empty_avg`
* Raw value observed on device when idle: `54157` (seconds)  ~ 15.04h
* Raw value observed on device when playing Trails in the Sky (Steam ARM / Proton 11 ARM): ~ 3h

Sorry for the phone picture, I don't know how to take Steam ARM screenshots that shows MangoHud overlay, it justs captures the ingame render:

<img width="2089" height="2875" alt="20260512_133433~2" src="https://github.com/user-attachments/assets/92f64573-aa6d-413e-af33-9079d44c065c" />

---

### AI Usage

**Did you use AI tools to help write this code?**  PARTIALLY