### PR TITLE
Updated SM8750 020-fan_control

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/020-fan_control
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/020-fan_control
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
 
-# Build thermal sensor path list, skipping PMIC and battery zones
+# Build thermal sensor path list, CPU and GPU zones only
 DEVICE_TEMP_SENSOR=""
 for zone in /sys/devices/virtual/thermal/thermal_zone*/; do
   type=$(cat "${zone}type" 2>/dev/null)

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/020-fan_control
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/020-fan_control
@@ -7,11 +7,10 @@ DEVICE_TEMP_SENSOR=""
 for zone in /sys/devices/virtual/thermal/thermal_zone*/; do
   type=$(cat "${zone}type" 2>/dev/null)
   case "${type}" in
-    *pm8550*|*pmih*|*battery*)
-      continue
+    cpu-*|cpuss-*|gpuss-*)
+      DEVICE_TEMP_SENSOR="${DEVICE_TEMP_SENSOR} ${zone}temp"
       ;;
   esac
-  DEVICE_TEMP_SENSOR="${DEVICE_TEMP_SENSOR} ${zone}temp"
 done
 
 # Build PWM fan path


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )
Updated 020-fan_control to only monitor CPU and GPU temps for fan speed. All thermal zones for other sensors like modem are still visible to system but do not average out device temperature. 

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)
Please squash commits on merge as the file was edited on Github WebUI.
---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
