### PR TITLE
linux 7.0 (drm/msm): add dsc support to displayport output

### DIFF
--- a/projects/ROCKNIX/packages/linux/patches/7.0/0011-msm-dp-dsc.patch
+++ b/projects/ROCKNIX/packages/linux/patches/7.0/0011-msm-dp-dsc.patch
@@ -1,0 +1,5820 @@
+From f23b026eeb398d798f39458fe0e2b4518a05b8aa Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Mon, 11 May 2026 15:57:14 -0300
+Subject: [PATCH 01/16] drm/msm/dp: add panel fec and dsc capabilities parsing
+
+---
+ drivers/gpu/drm/msm/dp/dp_panel.c | 74 +++++++++++++++++++++++++++++++
+ drivers/gpu/drm/msm/dp/dp_panel.h | 16 +++++++
+ 2 files changed, 90 insertions(+)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index 891211b23202..ba0c93d9ac5b 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -232,6 +232,69 @@ static u32 msm_dp_panel_get_supported_bpp(struct msm_dp_panel *msm_dp_panel,
+ 	return min_supported_bpp;
+ }
+ 
++static void msm_dp_panel_read_sink_fec_caps(struct msm_dp_panel_private *panel)
++{
++	int rlen;
++	u8 fec_dpcd;
++	rlen = drm_dp_dpcd_readb(panel->aux, DP_FEC_CAPABILITY, &fec_dpcd);
++	if (rlen < 1) {
++		DRM_ERROR("fec capability read failed, rlen=%d\n", rlen);
++		return;
++	}
++
++	panel->msm_dp_panel.fec_cap.supported = (fec_dpcd & DP_FEC_CAPABLE) > 0;
++}
++
++static bool msm_dp_panel_dsc_version_supported(u8 version_major, u8 version_minor)
++{
++	return version_major == 0x1 &&
++				(version_minor == 0x1 || version_minor == 0x2);
++}
++
++static void msm_dp_panel_decode_dsc_dpcd(struct msm_dp_panel_dsc *dsc_cap,
++			const u8 dsc_dpcd[DP_DSC_RECEIVER_CAP_SIZE])
++{
++	if (drm_dp_sink_supports_dsc(dsc_dpcd)) {
++		u8 version = dsc_dpcd[DP_DSC_REV - DP_DSC_SUPPORT];
++
++		dsc_cap->version_major = (version & DP_DSC_MAJOR_MASK) >> DP_DSC_MAJOR_SHIFT;
++		dsc_cap->version_minor = (version & DP_DSC_MINOR_MASK) >> DP_DSC_MINOR_SHIFT;
++
++		dsc_cap->supported =
++				msm_dp_panel_dsc_version_supported(dsc_cap->version_major, dsc_cap->version_minor);
++
++		if (dsc_cap->supported) {
++			int num_bpc, i;
++			dsc_cap->block_pred_en =
++					(dsc_dpcd[DP_DSC_BLK_PREDICTION_SUPPORT - DP_DSC_SUPPORT] &
++							DP_DSC_BLK_PREDICTION_IS_SUPPORTED) > 0;
++			num_bpc = drm_dp_dsc_sink_supported_input_bpcs(dsc_dpcd, dsc_cap->bpc);
++			for (i = num_bpc; i < ARRAY_SIZE(dsc_cap->bpc); i++)
++				dsc_cap->bpc[i] = 0;
++		}
++	}
++}
++
++static void msm_dp_panel_read_sink_dsc_caps(struct msm_dp_panel_private *panel)
++{
++	int rlen;
++	u8 dpcd_rev;
++	u8 dsc_dpcd[DP_DSC_RECEIVER_CAP_SIZE];
++
++	dpcd_rev = panel->msm_dp_panel.dpcd[DP_DPCD_REV];
++
++	if (dpcd_rev >= DP_DPCD_REV_14) {
++		rlen = drm_dp_dpcd_read(panel->aux, DP_DSC_SUPPORT,
++					dsc_dpcd, DP_DSC_RECEIVER_CAP_SIZE);
++		if (rlen < DP_DSC_RECEIVER_CAP_SIZE) {
++			DRM_ERROR("dsc dpcd read failed, rlen=%d\n", rlen);
++			return;
++		}
++
++		msm_dp_panel_decode_dsc_dpcd(&panel->msm_dp_panel.dsc_cap, dsc_dpcd);
++	}
++}
++
+ int msm_dp_panel_read_sink_caps(struct msm_dp_panel *msm_dp_panel,
+ 	struct drm_connector *connector)
+ {
+@@ -289,6 +352,17 @@ int msm_dp_panel_read_sink_caps(struct msm_dp_panel *msm_dp_panel,
+ 		}
+ 	}
+ 
++	memset(&msm_dp_panel->fec_cap, 0, sizeof(msm_dp_panel->fec_cap));
++	msm_dp_panel_read_sink_fec_caps(panel);
++
++	memset(&msm_dp_panel->dsc_cap, 0, sizeof(msm_dp_panel->dsc_cap));
++	if (msm_dp_panel->fec_cap.supported)
++		msm_dp_panel_read_sink_dsc_caps(panel);
++
++	drm_dbg_dp(panel->drm_dev, "fec_cap=%d dsc_cap=%d\n",
++			msm_dp_panel->fec_cap.supported,
++			msm_dp_panel->dsc_cap.supported);
++
+ end:
+ 	return rc;
+ }
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.h b/drivers/gpu/drm/msm/dp/dp_panel.h
+index 177c1328fd99..e036aebece66 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.h
++++ b/drivers/gpu/drm/msm/dp/dp_panel.h
+@@ -27,6 +27,20 @@ struct msm_dp_panel_psr {
+ 	u8 capabilities;
+ };
+ 
++struct msm_dp_panel_fec {
++	bool supported;
++	bool enabled;
++};
++
++struct msm_dp_panel_dsc {
++	bool supported;
++	u8 version_major;
++	u8 version_minor;
++	bool block_pred_en;
++	u8 bpc[3];
++	bool enabled;
++};
++
+ struct msm_dp_panel {
+ 	/* dpcd raw data */
+ 	u8 dpcd[DP_RECEIVER_CAP_SIZE];
+@@ -37,6 +51,8 @@ struct msm_dp_panel {
+ 	struct drm_connector *connector;
+ 	struct msm_dp_display_mode msm_dp_mode;
+ 	struct msm_dp_panel_psr psr_cap;
++	struct msm_dp_panel_fec fec_cap;
++	struct msm_dp_panel_dsc dsc_cap;
+ 	bool video_test;
+ 	bool vsc_sdp_supported;
+ 	u32 hw_revision;
+-- 
+2.54.0
+
+
+From e70609fabb85ea6121b689a022ba1acb8088e036 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Mon, 11 May 2026 18:23:58 -0300
+Subject: [PATCH 02/16] drm/msm/dp: use common msm_dp_mode between panel and
+ display; introduce msm_dp_panel_mode_cfg to indicate mode params including
+ bpp, dsc, and fec state; update msm_dp_panel_get_supported_bpp to
+ msm_dp_panel_get_supported_cfg to report bpp, dsc, and fec state; fix
+ mode_pclk_khz being used with link rate comparison
+
+---
+ drivers/gpu/drm/msm/dp/dp_ctrl.c    |   7 +-
+ drivers/gpu/drm/msm/dp/dp_debug.c   |   6 +-
+ drivers/gpu/drm/msm/dp/dp_display.c |  65 ++++------
+ drivers/gpu/drm/msm/dp/dp_panel.c   | 180 +++++++++++++++++++++++-----
+ drivers/gpu/drm/msm/dp/dp_panel.h   |  17 ++-
+ drivers/gpu/drm/msm/msm_drv.h       |   7 ++
+ 6 files changed, 207 insertions(+), 75 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_ctrl.c b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+index ef298c7d3e5e..a69ba74f5153 100644
+--- a/drivers/gpu/drm/msm/dp/dp_ctrl.c
++++ b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+@@ -404,7 +404,7 @@ static void msm_dp_ctrl_config_ctrl(struct msm_dp_ctrl_private *ctrl)
+ 		config |= DP_CONFIGURATION_CTRL_ASSR;
+ 
+ 	tbd = msm_dp_link_get_test_bits_depth(ctrl->link,
+-			ctrl->panel->msm_dp_mode.bpp);
++			ctrl->panel->msm_dp_mode.mode_cfg.bpp);
+ 
+ 	config |= tbd << DP_CONFIGURATION_CTRL_BPC_SHIFT;
+ 
+@@ -452,7 +452,8 @@ static void msm_dp_ctrl_configure_source_params(struct msm_dp_ctrl_private *ctrl
+ 
+ 	msm_dp_ctrl_config_ctrl(ctrl);
+ 
+-	test_bits_depth = msm_dp_link_get_test_bits_depth(ctrl->link, ctrl->panel->msm_dp_mode.bpp);
++	test_bits_depth = msm_dp_link_get_test_bits_depth(ctrl->link,
++				ctrl->panel->msm_dp_mode.mode_cfg.bpp);
+ 	colorimetry_cfg = msm_dp_link_get_colorimetry_config(ctrl->link);
+ 
+ 	misc_val = msm_dp_read_link(ctrl, REG_DP_MISC1_MISC0);
+@@ -1249,7 +1250,7 @@ static void msm_dp_ctrl_calc_tu_parameters(struct msm_dp_ctrl_private *ctrl,
+ 	in.hactive = drm_mode->hdisplay;
+ 	in.hporch = drm_mode->htotal - drm_mode->hdisplay;
+ 	in.nlanes = ctrl->link->link_params.num_lanes;
+-	in.bpp = ctrl->panel->msm_dp_mode.bpp;
++	in.bpp = ctrl->panel->msm_dp_mode.mode_cfg.bpp;
+ 	in.pixel_enc = ctrl->panel->msm_dp_mode.out_fmt_is_yuv_420 ? 420 : 444;
+ 	in.dsc_en = 0;
+ 	in.async_en = 0;
+diff --git a/drivers/gpu/drm/msm/dp/dp_debug.c b/drivers/gpu/drm/msm/dp/dp_debug.c
+index cf3838fcd154..18fc3b6f7902 100644
+--- a/drivers/gpu/drm/msm/dp/dp_debug.c
++++ b/drivers/gpu/drm/msm/dp/dp_debug.c
+@@ -65,7 +65,11 @@ static int msm_dp_debug_show(struct seq_file *seq, void *p)
+ 	seq_printf(seq, "\t\tpixel clock khz = %d\n",
+ 			drm_mode->clock);
+ 	seq_printf(seq, "\t\tbpp = %d\n",
+-			debug->panel->msm_dp_mode.bpp);
++			debug->panel->msm_dp_mode.mode_cfg.bpp);
++	seq_printf(seq, "\t\tfec = %d\n",
++			debug->panel->msm_dp_mode.mode_cfg.fec_available);
++	seq_printf(seq, "\t\tdsc = %d\n",
++			debug->panel->msm_dp_mode.mode_cfg.dsc);
+ 
+ 	/* Link Information */
+ 	seq_printf(seq, "\tdp_link:\n\t\ttest_requested = %d\n",
+diff --git a/drivers/gpu/drm/msm/dp/dp_display.c b/drivers/gpu/drm/msm/dp/dp_display.c
+index 476848bf8cd1..2ad480ef58df 100644
+--- a/drivers/gpu/drm/msm/dp/dp_display.c
++++ b/drivers/gpu/drm/msm/dp/dp_display.c
+@@ -91,7 +91,6 @@ struct msm_dp_display_private {
+ 	struct msm_dp_panel   *panel;
+ 	struct msm_dp_ctrl    *ctrl;
+ 
+-	struct msm_dp_display_mode msm_dp_mode;
+ 	struct msm_dp msm_dp_display;
+ 
+ 	/* wait for audio signaling */
+@@ -827,20 +826,6 @@ static int msm_dp_init_sub_modules(struct msm_dp_display_private *dp)
+ 	return rc;
+ }
+ 
+-static int msm_dp_display_set_mode(struct msm_dp *msm_dp_display,
+-			       struct msm_dp_display_mode *mode)
+-{
+-	struct msm_dp_display_private *dp;
+-
+-	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
+-
+-	drm_mode_copy(&dp->panel->msm_dp_mode.drm_mode, &mode->drm_mode);
+-	dp->panel->msm_dp_mode.bpp = mode->bpp;
+-	dp->panel->msm_dp_mode.out_fmt_is_yuv_420 = mode->out_fmt_is_yuv_420;
+-	msm_dp_panel_init_panel_info(dp->panel);
+-	return 0;
+-}
+-
+ static int msm_dp_display_enable(struct msm_dp_display_private *dp, bool force_link_train)
+ {
+ 	int rc = 0;
+@@ -934,10 +919,10 @@ enum drm_mode_status msm_dp_bridge_mode_valid(struct drm_bridge *bridge,
+ {
+ 	const u32 num_components = 3, default_bpp = 24;
+ 	struct msm_dp_display_private *msm_dp_display;
+-	struct msm_dp_link_info *link_info;
+-	u32 mode_rate_khz = 0, supported_rate_khz = 0, mode_bpp = 0;
++	u32 mode_bpp;
+ 	struct msm_dp *dp;
+ 	int mode_pclk_khz = mode->clock;
++	struct msm_dp_display_mode_cfg mode_cfg;
+ 
+ 	dp = to_dp_bridge(bridge)->msm_dp_display;
+ 
+@@ -947,7 +932,6 @@ enum drm_mode_status msm_dp_bridge_mode_valid(struct drm_bridge *bridge,
+ 	}
+ 
+ 	msm_dp_display = container_of(dp, struct msm_dp_display_private, msm_dp_display);
+-	link_info = &msm_dp_display->panel->link_info;
+ 
+ 	if ((drm_mode_is_420_only(&dp->connector->display_info, mode) &&
+ 	     msm_dp_display->panel->vsc_sdp_supported) ||
+@@ -961,13 +945,14 @@ enum drm_mode_status msm_dp_bridge_mode_valid(struct drm_bridge *bridge,
+ 	if (!mode_bpp)
+ 		mode_bpp = default_bpp;
+ 
+-	mode_bpp = msm_dp_panel_get_mode_bpp(msm_dp_display->panel,
+-			mode_bpp, mode_pclk_khz);
+-
+-	mode_rate_khz = mode_pclk_khz * mode_bpp;
+-	supported_rate_khz = link_info->num_lanes * link_info->rate * 8;
++	/* Need to use clock not-scaled by yuv/wide-bus for link rate check */
++	mode_cfg = msm_dp_panel_get_mode_cfg(msm_dp_display->panel,
++			mode_bpp,
++			msm_dp_display->panel->dsc_cap.supported ?
++					MSM_MODE_DSC_OPTIONAL : MSM_MODE_DSC_UNAVAILABLE,
++			mode->clock);
+ 
+-	if (mode_rate_khz > supported_rate_khz)
++	if (mode_cfg.bpp == MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE)
+ 		return MODE_BAD;
+ 
+ 	return MODE_OK;
+@@ -1538,7 +1523,7 @@ bool msm_dp_wide_bus_available(const struct msm_dp *msm_dp_display)
+ 
+ 	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
+ 
+-	if (dp->msm_dp_mode.out_fmt_is_yuv_420)
++	if (dp->panel->msm_dp_mode.out_fmt_is_yuv_420)
+ 		return false;
+ 
+ 	return dp->wide_bus_supported;
+@@ -1600,7 +1585,7 @@ void msm_dp_bridge_atomic_enable(struct drm_bridge *drm_bridge,
+ 	bool force_link_train = false;
+ 
+ 	msm_dp_display = container_of(dp, struct msm_dp_display_private, msm_dp_display);
+-	if (!msm_dp_display->msm_dp_mode.drm_mode.clock) {
++	if (!msm_dp_display->panel->msm_dp_mode.drm_mode.clock) {
+ 		DRM_ERROR("invalid params\n");
+ 		return;
+ 	}
+@@ -1621,7 +1606,7 @@ void msm_dp_bridge_atomic_enable(struct drm_bridge *drm_bridge,
+ 		return;
+ 	}
+ 
+-	rc = msm_dp_display_set_mode(dp, &msm_dp_display->msm_dp_mode);
++	rc = msm_dp_panel_init_panel_info(msm_dp_display->panel);
+ 	if (rc) {
+ 		DRM_ERROR("Failed to perform a mode set, rc=%d\n", rc);
+ 		mutex_unlock(&msm_dp_display->event_mutex);
+@@ -1706,35 +1691,37 @@ void msm_dp_bridge_mode_set(struct drm_bridge *drm_bridge,
+ 	struct msm_dp *dp = msm_dp_bridge->msm_dp_display;
+ 	struct msm_dp_display_private *msm_dp_display;
+ 	struct msm_dp_panel *msm_dp_panel;
++	struct msm_dp_display_mode *msm_dp_mode;
+ 
+ 	msm_dp_display = container_of(dp, struct msm_dp_display_private, msm_dp_display);
+ 	msm_dp_panel = msm_dp_display->panel;
++	msm_dp_mode = &msm_dp_display->panel->msm_dp_mode;
+ 
+-	memset(&msm_dp_display->msm_dp_mode, 0x0, sizeof(struct msm_dp_display_mode));
++	memset(msm_dp_mode, 0x0, sizeof(struct msm_dp_display_mode));
+ 
+ 	if (msm_dp_display_check_video_test(dp))
+-		msm_dp_display->msm_dp_mode.bpp = msm_dp_display_get_test_bpp(dp);
++		msm_dp_mode->mode_cfg.bpp = msm_dp_display_get_test_bpp(dp);
+ 	else /* Default num_components per pixel = 3 */
+-		msm_dp_display->msm_dp_mode.bpp = dp->connector->display_info.bpc * 3;
++		msm_dp_mode->mode_cfg.bpp = dp->connector->display_info.bpc * 3;
+ 
+-	if (!msm_dp_display->msm_dp_mode.bpp)
+-		msm_dp_display->msm_dp_mode.bpp = 24; /* Default bpp */
++	if (!msm_dp_mode->mode_cfg.bpp)
++		msm_dp_mode->mode_cfg.bpp = 24; /* Default bpp */
+ 
+-	drm_mode_copy(&msm_dp_display->msm_dp_mode.drm_mode, adjusted_mode);
++	drm_mode_copy(&msm_dp_mode->drm_mode, adjusted_mode);
+ 
+-	msm_dp_display->msm_dp_mode.v_active_low =
+-		!!(msm_dp_display->msm_dp_mode.drm_mode.flags & DRM_MODE_FLAG_NVSYNC);
++	msm_dp_mode->v_active_low =
++		!!(msm_dp_mode->drm_mode.flags & DRM_MODE_FLAG_NVSYNC);
+ 
+-	msm_dp_display->msm_dp_mode.h_active_low =
+-		!!(msm_dp_display->msm_dp_mode.drm_mode.flags & DRM_MODE_FLAG_NHSYNC);
++	msm_dp_mode->h_active_low =
++		!!(msm_dp_mode->drm_mode.flags & DRM_MODE_FLAG_NHSYNC);
+ 
+-	msm_dp_display->msm_dp_mode.out_fmt_is_yuv_420 =
++	msm_dp_mode->out_fmt_is_yuv_420 =
+ 		drm_mode_is_420_only(&dp->connector->display_info, adjusted_mode) &&
+ 		msm_dp_panel->vsc_sdp_supported;
+ 
+ 	/* populate wide_bus_support to different layers */
+ 	msm_dp_display->ctrl->wide_bus_en =
+-		msm_dp_display->msm_dp_mode.out_fmt_is_yuv_420 ? false : msm_dp_display->wide_bus_supported;
++		msm_dp_mode->out_fmt_is_yuv_420 ? false : msm_dp_display->wide_bus_supported;
+ }
+ 
+ void msm_dp_bridge_hpd_enable(struct drm_bridge *bridge)
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index ba0c93d9ac5b..1a551e9ff247 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -11,6 +11,7 @@
+ #include <drm/drm_edid.h>
+ #include <drm/drm_of.h>
+ #include <drm/drm_print.h>
++#include <drm/drm_fixed.h>
+ 
+ #include <linux/io.h>
+ #include <linux/types.h>
+@@ -211,25 +212,136 @@ static int msm_dp_panel_read_dpcd(struct msm_dp_panel *msm_dp_panel)
+ 	return rc;
+ }
+ 
+-static u32 msm_dp_panel_get_supported_bpp(struct msm_dp_panel *msm_dp_panel,
+-		u32 mode_edid_bpp, u32 mode_pclk_khz)
++static u32 msm_dp_panel_calc_link_rate(struct msm_dp_panel *msm_dp_panel,
++			bool fec_en)
+ {
+ 	const struct msm_dp_link_info *link_info;
+-	const u32 max_supported_bpp = 30, min_supported_bpp = 18;
+-	u32 bpp, data_rate_khz;
+-
+-	bpp = min(mode_edid_bpp, max_supported_bpp);
++	s64 rate_fp;
++	s64 fec_overhead_fp;
++	u32 data_rate_khz;
+ 
+ 	link_info = &msm_dp_panel->link_info;
+ 	data_rate_khz = link_info->num_lanes * link_info->rate * 8;
+ 
+-	do {
++	if (fec_en) {
++		fec_overhead_fp = drm_fixp_from_fraction(100000, 97582);
++
++		rate_fp = drm_int2fixp(data_rate_khz);
++		rate_fp = drm_fixp_div(rate_fp, fec_overhead_fp);
++		data_rate_khz = drm_fixp2int(rate_fp);
++	}
++
++	return data_rate_khz;
++}
++
++static u32 msm_dp_panel_get_supported_bpp_no_dsc(
++		u32 mode_edid_bpp,
++		u32 mode_pclk_khz,
++		u32 data_rate_khz)
++{
++	const u32 max_supported_bpp = 30, min_supported_bpp = 18;
++	u32 bpp = min(mode_edid_bpp, max_supported_bpp);
++
++	for (; bpp >= min_supported_bpp; bpp -= 6)
+ 		if (mode_pclk_khz * bpp <= data_rate_khz)
+ 			return bpp;
+-		bpp -= 6;
+-	} while (bpp > min_supported_bpp);
+ 
+-	return min_supported_bpp;
++	return MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
++}
++
++#define MSM_DP_MIN_SUPPORTED_DSC_BPP 24
++static u32 msm_dp_panel_get_supported_bpp_dsc(
++		u32 mode_edid_bpp,
++		u32 mode_pclk_khz,
++		u32 data_rate_khz,
++		u8 bpc[3])
++{
++	const u32 max_supported_bpp = min(mode_edid_bpp, 30);
++	const u32 min_supported_bpp = MSM_DP_MIN_SUPPORTED_DSC_BPP;
++	const u32 num_components = 3;
++	u32 max_bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
++	int i;
++
++	for (i = 0; i < 3; i++) {
++		if (bpc[i]) {
++			u32 bpp = bpc[i] * num_components;
++
++			if (bpp > max_bpp &&
++						bpp >= min_supported_bpp &&
++						bpp <= max_supported_bpp &&
++						mode_pclk_khz * bpp / MSM_DP_DSC_COMP_RATIO <=
++									data_rate_khz)
++				max_bpp = bpp;
++		}
++	}
++
++	return max_bpp;
++}
++
++static struct msm_dp_display_mode_cfg msm_dp_panel_get_cfg_from_bpp(
++	u32 bpp, u32 dsc_bpp, enum msm_mode_dsc_cfg dsc_cfg, bool fec_en)
++{
++	const u32 min_supported_bpp = MSM_DP_MIN_SUPPORTED_DSC_BPP;
++	struct msm_dp_display_mode_cfg cfg = {0};
++
++	cfg.fec_available = fec_en;
++
++	if (!dsc_bpp)
++		dsc_cfg = MSM_MODE_DSC_UNAVAILABLE;
++	else if (!bpp)
++		dsc_cfg = MSM_MODE_DSC_REQUIRED;
++
++	switch (dsc_cfg) {
++	default:
++	case MSM_MODE_DSC_UNAVAILABLE:
++		cfg.bpp = bpp;
++		break;
++	case MSM_MODE_DSC_OPTIONAL:
++	case MSM_MODE_DSC_PREFERRED:
++		/*
++		 * Return "if dsc is preferred" when not requested to be required.
++		 * dsc is preferred if non-dsc bpp is of lower bpp than
++		 * min supported dsc bpp
++		 */
++		dsc_cfg = bpp < min_supported_bpp ?
++					MSM_MODE_DSC_PREFERRED :
++					MSM_MODE_DSC_OPTIONAL;
++		cfg.bpp = bpp;
++		break;
++	case MSM_MODE_DSC_REQUIRED:
++		cfg.bpp = dsc_bpp;
++		break;
++	}
++
++	cfg.dsc = dsc_cfg;
++
++	return cfg;
++}
++
++static struct msm_dp_display_mode_cfg msm_dp_panel_get_supported_cfg(
++		struct msm_dp_panel *msm_dp_panel,
++		u32 mode_edid_bpp,
++		enum msm_mode_dsc_cfg dsc_cfg,
++		u32 mode_pclk_khz)
++{
++	u32 bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
++	u32 dsc_bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
++	u32 data_rate_khz;
++	bool fec_en;
++
++	fec_en = msm_dp_panel->fec_cap.supported;
++	data_rate_khz = msm_dp_panel_calc_link_rate(msm_dp_panel, fec_en);
++
++	if (dsc_cfg < MSM_MODE_DSC_REQUIRED)
++		bpp = msm_dp_panel_get_supported_bpp_no_dsc(
++					mode_edid_bpp, mode_pclk_khz, data_rate_khz);
++
++	if (dsc_cfg > MSM_MODE_DSC_UNAVAILABLE)
++		dsc_bpp = msm_dp_panel_get_supported_bpp_dsc(
++					mode_edid_bpp, mode_pclk_khz, data_rate_khz,
++					msm_dp_panel->dsc_cap.bpc);
++
++	return msm_dp_panel_get_cfg_from_bpp(bpp, dsc_bpp, dsc_cfg, fec_en);
+ }
+ 
+ static void msm_dp_panel_read_sink_fec_caps(struct msm_dp_panel_private *panel)
+@@ -367,27 +479,30 @@ int msm_dp_panel_read_sink_caps(struct msm_dp_panel *msm_dp_panel,
+ 	return rc;
+ }
+ 
+-u32 msm_dp_panel_get_mode_bpp(struct msm_dp_panel *msm_dp_panel,
+-		u32 mode_edid_bpp, u32 mode_pclk_khz)
++struct msm_dp_display_mode_cfg msm_dp_panel_get_mode_cfg(
++		struct msm_dp_panel *msm_dp_panel,
++		u32 mode_edid_bpp,
++		enum msm_mode_dsc_cfg dsc_cfg,
++		u32 mode_pclk_khz)
+ {
+ 	struct msm_dp_panel_private *panel;
+-	u32 bpp;
++	struct msm_dp_display_mode_cfg cfg = {0};
+ 
+ 	if (!msm_dp_panel || !mode_edid_bpp || !mode_pclk_khz) {
+ 		DRM_ERROR("invalid input\n");
+-		return 0;
++		return cfg;
+ 	}
+ 
+ 	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
+ 
+-	if (msm_dp_panel->video_test)
+-		bpp = msm_dp_link_bit_depth_to_bpp(
++	if (msm_dp_panel->video_test) {
++		cfg.bpp = msm_dp_link_bit_depth_to_bpp(
+ 				panel->link->test_video.test_bit_depth);
+-	else
+-		bpp = msm_dp_panel_get_supported_bpp(msm_dp_panel, mode_edid_bpp,
+-				mode_pclk_khz);
+-
+-	return bpp;
++		return cfg;
++	} else {
++		return msm_dp_panel_get_supported_cfg(msm_dp_panel, mode_edid_bpp,
++				dsc_cfg, mode_pclk_khz);
++	}
+ }
+ 
+ int msm_dp_panel_get_modes(struct msm_dp_panel *msm_dp_panel,
+@@ -659,7 +774,7 @@ static int msm_dp_panel_setup_vsc_sdp_yuv_420(struct msm_dp_panel *msm_dp_panel)
+ 	vsc_sdp_data.colorimetry = DP_COLORIMETRY_DEFAULT;
+ 
+ 	/* VSC SDP Payload for DB17 */
+-	vsc_sdp_data.bpc = msm_dp_mode->bpp / 3;
++	vsc_sdp_data.bpc = msm_dp_mode->mode_cfg.bpp / 3;
+ 	vsc_sdp_data.dynamic_range = DP_DYNAMIC_RANGE_CTA;
+ 
+ 	/* VSC SDP Payload for DB18 */
+@@ -756,9 +871,11 @@ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en)
+ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ {
+ 	struct drm_display_mode *drm_mode;
++	struct msm_dp_display_mode_cfg *mode_cfg;
+ 	struct msm_dp_panel_private *panel;
+ 
+ 	drm_mode = &msm_dp_panel->msm_dp_mode.drm_mode;
++	mode_cfg = &msm_dp_panel->msm_dp_mode.mode_cfg;
+ 
+ 	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
+ 
+@@ -781,13 +898,18 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 			drm_mode->vsync_end - drm_mode->vsync_start);
+ 	drm_dbg_dp(panel->drm_dev, "pixel clock (KHz)=(%d)\n",
+ 				drm_mode->clock);
+-	drm_dbg_dp(panel->drm_dev, "bpp = %d\n", msm_dp_panel->msm_dp_mode.bpp);
+-
+-	msm_dp_panel->msm_dp_mode.bpp = msm_dp_panel_get_mode_bpp(msm_dp_panel, msm_dp_panel->msm_dp_mode.bpp,
+-						      msm_dp_panel->msm_dp_mode.drm_mode.clock);
+-
+-	drm_dbg_dp(panel->drm_dev, "updated bpp = %d\n",
+-				msm_dp_panel->msm_dp_mode.bpp);
++	drm_dbg_dp(panel->drm_dev, "bpp = %d\n", mode_cfg->bpp);
++
++	*mode_cfg = msm_dp_panel_get_mode_cfg(
++						      msm_dp_panel,
++						      mode_cfg->bpp,
++						      mode_cfg->dsc,
++						      drm_mode->clock);
++
++	drm_dbg_dp(panel->drm_dev, "updated_bpp=%d fec=%d dsc=%d\n",
++				mode_cfg->bpp,
++				mode_cfg->fec_available,
++				mode_cfg->dsc);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.h b/drivers/gpu/drm/msm/dp/dp_panel.h
+index e036aebece66..5304d3d38c3e 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.h
++++ b/drivers/gpu/drm/msm/dp/dp_panel.h
+@@ -11,12 +11,23 @@
+ 
+ #include "dp_aux.h"
+ #include "dp_link.h"
++#include "msm_drv.h"
+ 
+ struct edid;
+ 
++#define MSM_DP_DSC_COMP_RATIO 3
++
++#define MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE 0
++
++struct msm_dp_display_mode_cfg {
++	u32 bpp;
++	bool fec_available;
++	enum msm_mode_dsc_cfg dsc;
++};
++
+ struct msm_dp_display_mode {
+ 	struct drm_display_mode drm_mode;
+-	u32 bpp;
++	struct msm_dp_display_mode_cfg mode_cfg;
+ 	u32 h_active_low;
+ 	u32 v_active_low;
+ 	bool out_fmt_is_yuv_420;
+@@ -65,8 +76,8 @@ int msm_dp_panel_deinit(struct msm_dp_panel *msm_dp_panel);
+ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en);
+ int msm_dp_panel_read_sink_caps(struct msm_dp_panel *msm_dp_panel,
+ 		struct drm_connector *connector);
+-u32 msm_dp_panel_get_mode_bpp(struct msm_dp_panel *msm_dp_panel, u32 mode_max_bpp,
+-			u32 mode_pclk_khz);
++struct msm_dp_display_mode_cfg msm_dp_panel_get_mode_cfg(struct msm_dp_panel *msm_dp_panel,
++			u32 mode_max_bpp, enum msm_mode_dsc_cfg dsc_cfg, u32 mode_pclk_khz);
+ int msm_dp_panel_get_modes(struct msm_dp_panel *msm_dp_panel,
+ 		struct drm_connector *connector);
+ void msm_dp_panel_handle_sink_request(struct msm_dp_panel *msm_dp_panel);
+diff --git a/drivers/gpu/drm/msm/msm_drv.h b/drivers/gpu/drm/msm/msm_drv.h
+index 6d847d593f1a..028d7ba22957 100644
+--- a/drivers/gpu/drm/msm/msm_drv.h
++++ b/drivers/gpu/drm/msm/msm_drv.h
+@@ -70,6 +70,13 @@ enum msm_dsi_controller {
+ 
+ #define MSM_GPU_MAX_RINGS 4
+ 
++enum msm_mode_dsc_cfg {
++	MSM_MODE_DSC_UNAVAILABLE,
++	MSM_MODE_DSC_OPTIONAL,
++	MSM_MODE_DSC_PREFERRED,
++	MSM_MODE_DSC_REQUIRED,
++};
++
+ struct msm_drm_private {
+ 
+ 	struct drm_device *dev;
+-- 
+2.54.0
+
+
+From 127f377bdc5d5f390098b1ca867f5cb03cd33c76 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 17:43:16 -0300
+Subject: [PATCH 03/16] drm/msm/dp: add dsc params init to panel
+
+---
+ drivers/gpu/drm/msm/dp/dp_panel.c | 294 +++++++++++++++++++++++++++++-
+ drivers/gpu/drm/msm/dp/dp_panel.h |  18 ++
+ 2 files changed, 305 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index 1a551e9ff247..6da11edd46bc 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -12,6 +12,7 @@
+ #include <drm/drm_of.h>
+ #include <drm/drm_print.h>
+ #include <drm/drm_fixed.h>
++#include <drm/display/drm_dsc_helper.h>
+ 
+ #include <linux/io.h>
+ #include <linux/types.h>
+@@ -391,19 +392,19 @@ static void msm_dp_panel_read_sink_dsc_caps(struct msm_dp_panel_private *panel)
+ {
+ 	int rlen;
+ 	u8 dpcd_rev;
+-	u8 dsc_dpcd[DP_DSC_RECEIVER_CAP_SIZE];
+ 
+ 	dpcd_rev = panel->msm_dp_panel.dpcd[DP_DPCD_REV];
+ 
+ 	if (dpcd_rev >= DP_DPCD_REV_14) {
+ 		rlen = drm_dp_dpcd_read(panel->aux, DP_DSC_SUPPORT,
+-					dsc_dpcd, DP_DSC_RECEIVER_CAP_SIZE);
++					panel->msm_dp_panel.dsc_dpcd, DP_DSC_RECEIVER_CAP_SIZE);
+ 		if (rlen < DP_DSC_RECEIVER_CAP_SIZE) {
+ 			DRM_ERROR("dsc dpcd read failed, rlen=%d\n", rlen);
+ 			return;
+ 		}
+ 
+-		msm_dp_panel_decode_dsc_dpcd(&panel->msm_dp_panel.dsc_cap, dsc_dpcd);
++		msm_dp_panel_decode_dsc_dpcd(&panel->msm_dp_panel.dsc_cap,
++					panel->msm_dp_panel.dsc_dpcd);
+ 	}
+ }
+ 
+@@ -868,14 +869,270 @@ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en)
+ 	return 0;
+ }
+ 
++struct msm_dp_dsc_slices_per_line {
++	u32 min_ppr;
++	u32 max_ppr;
++	u8 num_slices;
++};
++
++struct msm_dp_dsc_slice_caps_bit_map {
++	u32 num_slices;
++	u32 bit_index;
++};
++
++static const struct msm_dp_dsc_slices_per_line slice_per_line_tbl[] = {
++	{0,     340,    1   },
++	{340,   680,    2   },
++	{680,   1360,   4   },
++	{1360,  3200,   8   },
++	{3200,  4800,   12  },
++	{4800,  6400,   16  },
++	{6400,  8000,   20  },
++	{8000,  9600,   24  }
++};
++
++static const u32 peak_throughput_mode_0_tbl[] = {
++	0,
++	340,
++	400,
++	450,
++	500,
++	550,
++	600,
++	650,
++	700,
++	750,
++	800,
++	850,
++	900,
++	950,
++	1000,
++};
++
++static const struct msm_dp_dsc_slice_caps_bit_map slice_caps_bit_map_tbl[] = {
++	{1, 0},
++	{2, 1},
++	{4, 3},
++	{6, 4},
++	{8, 5},
++	{10, 6},
++	{12, 7},
++	{16, 0},
++	{20, 1},
++	{24, 2},
++};
++
++static bool msm_dp_panel_check_slice_support(u32 num_slices, u32 slice_caps_1,
++		u32 slice_caps_2)
++{
++	const struct msm_dp_dsc_slice_caps_bit_map *bcap;
++	u32 slice_caps;
++	int i;
++
++	if (num_slices <= 12)
++		slice_caps = slice_caps_1;
++	else
++		slice_caps = slice_caps_2;
++
++	for (i = 0; i < ARRAY_SIZE(slice_caps_bit_map_tbl); i++) {
++		bcap = &slice_caps_bit_map_tbl[i];
++
++		if (bcap->num_slices == num_slices)
++			return !!(slice_caps & (1 << bcap->bit_index));
++	}
++
++	return false;
++}
++
++static int msm_dp_panel_dsc_prepare(struct msm_dp_panel_private *panel)
++{
++	struct msm_dp_panel *msm_dp_panel = &panel->msm_dp_panel;
++	struct msm_dp_display_mode *msm_dp_mode = &msm_dp_panel->msm_dp_mode;
++	struct drm_display_mode *drm_mode = &msm_dp_mode->drm_mode;
++	struct drm_dsc_config *drm_dsc = &msm_dp_mode->drm_dsc;
++	struct msm_dp_dsc_cfg *msm_dp_dsc = &msm_dp_mode->msm_dp_dsc;
++
++	int slice_per_line_tbl_i;
++	const struct msm_dp_dsc_slices_per_line *rec;
++	u32 peak_throughput;
++	u32 max_slice_width;
++	u32 slice_width;
++	u32 ppr_per_slice;
++	u32 slice_caps_1;
++	u32 slice_caps_2;
++
++	u32 ppr = drm_mode->clock / 1000;
++	u32 ppr_max_index = msm_dp_panel->dsc_dpcd[DP_DSC_PEAK_THROUGHPUT - DP_DSC_SUPPORT];
++	ppr_max_index = (ppr_max_index & DP_DSC_THROUGHPUT_MODE_0_MASK) >>
++				DP_DSC_THROUGHPUT_MODE_0_SHIFT;
++
++	drm_dsc->dsc_version_major = msm_dp_panel->dsc_cap.version_major;
++	drm_dsc->dsc_version_minor = msm_dp_panel->dsc_cap.version_minor;
++
++	msm_dp_dsc->slice_per_pkt = 0;
++
++	for (slice_per_line_tbl_i = 0;
++				slice_per_line_tbl_i < ARRAY_SIZE(slice_per_line_tbl);
++				slice_per_line_tbl_i++) {
++		rec = &slice_per_line_tbl[slice_per_line_tbl_i];
++		if ((ppr > rec->min_ppr) && (ppr <= rec->max_ppr)) {
++			msm_dp_dsc->slice_per_pkt = rec->num_slices;
++			slice_per_line_tbl_i++;
++			break;
++		}
++	}
++
++	if (!msm_dp_dsc->slice_per_pkt)
++		return -EINVAL;
++
++	if (ppr_max_index <= DP_DSC_THROUGHPUT_MODE_0_UNSUPPORTED ||
++				ppr_max_index >= DP_DSC_THROUGHPUT_MODE_0_170) {
++		drm_dbg_dp(panel->drm_dev,
++					"Throughput mode 0 0x%x not supported\n", ppr_max_index);
++		return -EINVAL;
++	}
++
++	peak_throughput = peak_throughput_mode_0_tbl[ppr_max_index];
++
++	if (!msm_dp_panel->dsc_cap.num_dsc)
++		return -EINVAL;
++
++	max_slice_width = msm_dp_panel->dsc_dpcd[DP_DSC_MAX_SLICE_WIDTH - DP_DSC_SUPPORT] *
++				DP_DSC_SLICE_WIDTH_MULTIPLIER;
++	max_slice_width = min(max_slice_width, drm_mode->hdisplay / msm_dp_panel->dsc_cap.num_dsc);
++
++	slice_width = (drm_mode->hdisplay /
++				msm_dp_dsc->slice_per_pkt);
++	ppr_per_slice = ppr / msm_dp_dsc->slice_per_pkt;
++
++	slice_caps_1 = msm_dp_panel->dsc_dpcd[DP_DSC_SLICE_CAP_1 - DP_DSC_SUPPORT];
++	slice_caps_2 = msm_dp_panel->dsc_dpcd[DP_DSC_SLICE_CAP_2 - DP_DSC_SUPPORT];
++
++	/*
++	 * There are 3 conditions to check for sink support:
++	 * 1. The slice width cannot exceed the maximum.
++	 * 2. The ppr per slice cannot exceed the maximum.
++	 * 3. The number of slices must be explicitly supported.
++	 */
++	while (slice_width > max_slice_width ||
++			ppr_per_slice > peak_throughput ||
++			!msm_dp_panel_check_slice_support(
++					msm_dp_dsc->slice_per_pkt,
++					slice_caps_1, slice_caps_2)) {
++		if (slice_per_line_tbl_i == ARRAY_SIZE(slice_per_line_tbl))
++			return -EINVAL;
++
++		rec = &slice_per_line_tbl[slice_per_line_tbl_i];
++		msm_dp_dsc->slice_per_pkt = rec->num_slices;
++		slice_width = (drm_mode->hdisplay /
++				msm_dp_dsc->slice_per_pkt);
++		ppr_per_slice = ppr / msm_dp_dsc->slice_per_pkt;
++
++		slice_per_line_tbl_i++;
++	}
++
++	drm_dsc->block_pred_enable = msm_dp_panel->dsc_cap.block_pred_en;
++
++	drm_dsc->pic_width = drm_mode->hdisplay;
++	drm_dsc->pic_height = drm_mode->vdisplay;
++	drm_dsc->slice_width = slice_width;
++
++	if (drm_dsc->pic_height % 108 == 0)
++		drm_dsc->slice_height = 108;
++	else if (drm_dsc->pic_height % 16 == 0)
++		drm_dsc->slice_height = 16;
++	else if (drm_dsc->pic_height % 12 == 0)
++		drm_dsc->slice_height = 12;
++	else
++		drm_dsc->slice_height = 15;
++
++	drm_dsc->bits_per_component = (msm_dp_mode->mode_cfg.bpp / 3);
++	drm_dsc->bits_per_pixel = (msm_dp_mode->mode_cfg.bpp / MSM_DP_DSC_COMP_RATIO) << 4;
++	drm_dsc->slice_count = DIV_ROUND_UP(drm_mode->hdisplay, slice_width);
++
++	return 0;
++}
++
++static int msm_populate_dsc_params(struct device *dev, struct drm_dsc_config *dsc)
++{
++	int ret;
++	u32 bpp;
++
++	dsc->convert_rgb = 1;
++
++	drm_dsc_set_const_params(dsc);
++	drm_dsc_set_rc_buf_thresh(dsc);
++
++	if (!msm_dp_panel_dsc_version_supported(dsc->dsc_version_major, dsc->dsc_version_minor))
++		return -EINVAL;
++
++	bpp = dsc->bits_per_pixel >> 4;
++	ret = drm_dsc_setup_rc_params(dsc,
++				dsc->dsc_version_minor == 1 || bpp == 8 || bpp == 12
++						? DRM_DSC_1_1_PRE_SCR : DRM_DSC_1_2_444);
++	if (ret) {
++		DRM_DEV_ERROR(dev, "could not find DSC RC parameters\n");
++		return ret;
++	}
++
++	dsc->initial_scale_value = drm_dsc_initial_scale_value(dsc);
++	dsc->line_buf_depth = dsc->bits_per_component + 1;
++
++	return drm_dsc_compute_rc_parameters(dsc);
++}
++
++static int msm_dp_populate_dsc_private_params(struct msm_dp_display_mode *msm_dp_mode)
++{
++	struct drm_display_mode *drm_mode = &msm_dp_mode->drm_mode;
++	struct drm_dsc_config *drm_dsc = &msm_dp_mode->drm_dsc;
++	struct msm_dp_dsc_cfg *msm_dp_dsc = &msm_dp_mode->msm_dp_dsc;
++	u32 intf_width = drm_mode->hdisplay;
++	u32 slice_per_pkt;
++	u32 slice_per_intf;
++	u32 bpp;
++	u32 bytes_in_slice;
++	u32 total_bytes_per_intf;
++
++	if (!drm_dsc->slice_width ||
++			!drm_dsc->slice_height ||
++			intf_width < drm_dsc->slice_width) {
++		DRM_ERROR("invalid input, intf_width=%d slice_width=%d\n",
++			intf_width, drm_dsc->slice_width);
++		return -EINVAL;
++	}
++
++	slice_per_pkt = msm_dp_dsc->slice_per_pkt;
++	slice_per_intf = DIV_ROUND_UP(intf_width,
++				drm_dsc->slice_width);
++
++	/*
++	 * If slice_per_pkt is greater than slice_per_intf then default to 1.
++	 * This can happen during partial update.
++	 */
++	if (slice_per_pkt > slice_per_intf)
++		slice_per_pkt = 1;
++
++	bpp = drm_dsc->bits_per_pixel >> 4;
++	bytes_in_slice = DIV_ROUND_UP(drm_dsc->slice_width * bpp, 8);
++	total_bytes_per_intf = bytes_in_slice * slice_per_intf;
++
++	msm_dp_dsc->bytes_per_pkt = bytes_in_slice * slice_per_pkt;
++	msm_dp_dsc->eol_byte_num = total_bytes_per_intf % 3;
++	msm_dp_dsc->pclk_per_line = DIV_ROUND_UP(total_bytes_per_intf, 6) - 1;
++
++	return 0;
++}
++
+ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ {
+ 	struct drm_display_mode *drm_mode;
+ 	struct msm_dp_display_mode_cfg *mode_cfg;
+ 	struct msm_dp_panel_private *panel;
++	struct msm_dp_display_mode *msm_dp_mode = &msm_dp_panel->msm_dp_mode;
++	int rc;
+ 
+-	drm_mode = &msm_dp_panel->msm_dp_mode.drm_mode;
+-	mode_cfg = &msm_dp_panel->msm_dp_mode.mode_cfg;
++	drm_mode = &msm_dp_mode->drm_mode;
++	mode_cfg = &msm_dp_mode->mode_cfg;
+ 
+ 	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
+ 
+@@ -906,10 +1163,33 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 						      mode_cfg->dsc,
+ 						      drm_mode->clock);
+ 
++	msm_dp_panel->fec_cap.enabled = mode_cfg->fec_available;
++	msm_dp_panel->dsc_cap.enabled = mode_cfg->dsc == MSM_MODE_DSC_REQUIRED;
++
+ 	drm_dbg_dp(panel->drm_dev, "updated_bpp=%d fec=%d dsc=%d\n",
+ 				mode_cfg->bpp,
+-				mode_cfg->fec_available,
+-				mode_cfg->dsc);
++				msm_dp_panel->fec_cap.enabled,
++				msm_dp_panel->dsc_cap.enabled);
++
++	if (msm_dp_panel->dsc_cap.enabled) {
++		if ((rc = msm_dp_panel_dsc_prepare(panel))) {
++			drm_dbg_dp(panel->drm_dev,
++					"prepare dsc basic params failed\n");
++			return rc;
++		}
++
++		if ((rc = msm_populate_dsc_params(panel->dev, &msm_dp_mode->drm_dsc))) {
++			drm_dbg_dp(panel->drm_dev,
++					"failed populating dsc params\n");
++			return rc;
++		}
++
++		if ((rc = msm_dp_populate_dsc_private_params(msm_dp_mode))) {
++			drm_dbg_dp(panel->drm_dev,
++					"failed populating other dsc params\n");
++			return rc;
++		}
++	}
+ 
+ 	return 0;
+ }
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.h b/drivers/gpu/drm/msm/dp/dp_panel.h
+index 5304d3d38c3e..361e7de74bed 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.h
++++ b/drivers/gpu/drm/msm/dp/dp_panel.h
+@@ -25,9 +25,25 @@ struct msm_dp_display_mode_cfg {
+ 	enum msm_mode_dsc_cfg dsc;
+ };
+ 
++/**
++ * struct msm_dp_dsc_cfg - defines dsc configuration
++ * @slice_per_pkt:           Number of slices per packet.
++ * @bytes_per_pkt:           Number of bytes in DSI packet
++ * @eol_byte_num:            Valid bytes at the end of line.
++ * @pclk_per_line:           Compressed width.
++ */
++struct msm_dp_dsc_cfg {
++	u32 slice_per_pkt;
++	u32 bytes_per_pkt;
++	u32 eol_byte_num;
++	u32 pclk_per_line;
++};
++
+ struct msm_dp_display_mode {
+ 	struct drm_display_mode drm_mode;
+ 	struct msm_dp_display_mode_cfg mode_cfg;
++	struct drm_dsc_config drm_dsc;
++	struct msm_dp_dsc_cfg msm_dp_dsc;
+ 	u32 h_active_low;
+ 	u32 v_active_low;
+ 	bool out_fmt_is_yuv_420;
+@@ -50,11 +66,13 @@ struct msm_dp_panel_dsc {
+ 	bool block_pred_en;
+ 	u8 bpc[3];
+ 	bool enabled;
++	u32 num_dsc;
+ };
+ 
+ struct msm_dp_panel {
+ 	/* dpcd raw data */
+ 	u8 dpcd[DP_RECEIVER_CAP_SIZE];
++	u8 dsc_dpcd[DP_DSC_RECEIVER_CAP_SIZE];
+ 	u8 downstream_ports[DP_MAX_DOWNSTREAM_PORTS];
+ 
+ 	struct msm_dp_link_info link_info;
+-- 
+2.54.0
+
+
+From f84ab5863ca0ca8c4447cb4033dd63402e6ef926 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 17:44:27 -0300
+Subject: [PATCH 04/16] drm/msm/dp: add fec/dsc/dto interfacing to ctrl
+
+---
+ drivers/gpu/drm/msm/dp/dp_ctrl.c  | 302 +++++++++++++++++++++++++++++-
+ drivers/gpu/drm/msm/dp/dp_panel.c | 102 +++++++++-
+ drivers/gpu/drm/msm/dp/dp_panel.h |  32 +++-
+ drivers/gpu/drm/msm/dp/dp_reg.h   |  35 ++++
+ 4 files changed, 454 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_ctrl.c b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+index a69ba74f5153..7900c02c999e 100644
+--- a/drivers/gpu/drm/msm/dp/dp_ctrl.c
++++ b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+@@ -17,6 +17,7 @@
+ #include <linux/string_choices.h>
+ 
+ #include <drm/display/drm_dp_helper.h>
++#include <drm/display/drm_dsc_helper.h>
+ #include <drm/drm_device.h>
+ #include <drm/drm_fixed.h>
+ #include <drm/drm_print.h>
+@@ -307,6 +308,37 @@ static void msm_dp_ctrl_psr_mainlink_disable(struct msm_dp_ctrl_private *ctrl)
+ 	msm_dp_write_link(ctrl, REG_DP_MAINLINK_CTRL, val);
+ }
+ 
++static void msm_dp_ctrl_mainlink_levels(struct msm_dp_ctrl_private *ctrl)
++{
++	u32 mainlink_levels, safe_to_exit_level = 14;
++	u8 lane_cnt = ctrl->link->link_params.num_lanes;
++
++	switch (lane_cnt) {
++	case 1:
++		safe_to_exit_level = 14;
++		break;
++	case 2:
++		safe_to_exit_level = 8;
++		break;
++	case 4:
++		safe_to_exit_level = 5;
++		break;
++	default:
++		drm_dbg_dp(ctrl->drm_dev, "setting the default safe_to_exit_level=%u\n",
++				safe_to_exit_level);
++		break;
++	}
++
++	mainlink_levels = msm_dp_read_link(ctrl, REG_DP_MAINLINK_LEVELS);
++	mainlink_levels &= 0xFE0;
++	mainlink_levels |= safe_to_exit_level;
++
++	drm_dbg_dp(ctrl->drm_dev, "mainlink_level=0x%x, safe_to_exit_level=0x%x\n",
++		mainlink_levels, safe_to_exit_level);
++
++	msm_dp_write_link(ctrl, REG_DP_MAINLINK_LEVELS, mainlink_levels);
++}
++
+ static void msm_dp_ctrl_mainlink_enable(struct msm_dp_ctrl_private *ctrl)
+ {
+ 	u32 mainlink_ctrl;
+@@ -403,8 +435,15 @@ static void msm_dp_ctrl_config_ctrl(struct msm_dp_ctrl_private *ctrl)
+ 	if (drm_dp_alternate_scrambler_reset_cap(dpcd))
+ 		config |= DP_CONFIGURATION_CTRL_ASSR;
+ 
+-	tbd = msm_dp_link_get_test_bits_depth(ctrl->link,
+-			ctrl->panel->msm_dp_mode.mode_cfg.bpp);
++	/*
++	 * since dsc encoder output byte stream to dp controller,
++	 * 8 bits bpc should be used as long as dsc enabled
++	 */
++	if (ctrl->panel->dsc_cap.enabled)
++		tbd =  DP_TEST_BIT_DEPTH_8 >> DP_TEST_BIT_DEPTH_SHIFT;
++	else
++		tbd = msm_dp_link_get_test_bits_depth(ctrl->link,
++				ctrl->panel->msm_dp_mode.mode_cfg.bpp);
+ 
+ 	config |= tbd << DP_CONFIGURATION_CTRL_BPC_SHIFT;
+ 
+@@ -429,6 +468,52 @@ static void msm_dp_ctrl_config_ctrl(struct msm_dp_ctrl_private *ctrl)
+ 	msm_dp_write_link(ctrl, REG_DP_CONFIGURATION_CTRL, config);
+ }
+ 
++static void msm_dp_ctrl_fec_config(struct msm_dp_ctrl_private *ctrl, bool enable)
++{
++	u32 reg;
++
++	reg = msm_dp_read_link(ctrl, REG_DP_MAINLINK_CTRL);
++
++	/*
++	 * fec_en = BIT(12)
++	 * fec_seq_mode = BIT(22)
++	 * sde_flush = BIT(23) | BIT(24)
++	 * fb_boundary_sel = BIT(25)
++	 */
++	if (enable)
++		reg |= BIT(12) | BIT(22) | BIT(23) | BIT(24) | BIT(25);
++	else
++		reg &= ~BIT(12);
++
++	msm_dp_write_link(ctrl, REG_DP_MAINLINK_CTRL, reg);
++	/* make sure mainlink configuration is updated with fec sequence */
++	wmb();
++}
++
++static void msm_dp_ctrl_config_dsc_dto(struct msm_dp_ctrl_private *ctrl, bool enable)
++{
++	u32 reg = 0;
++	struct msm_dp_dsc_cfg *msm_dp_dsc = &ctrl->panel->msm_dp_mode.msm_dp_dsc;
++
++	if (enable) {
++		u32 eol_byte_num = msm_dp_dsc->eol_byte_num;
++		u32 slice_per_pkt = msm_dp_dsc->slice_per_pkt - 1;
++		u32 bytes_per_pkt = msm_dp_dsc->bytes_per_pkt / msm_dp_dsc->slice_per_pkt;
++		u32 be_in_lane = 10;
++
++		reg = BIT(0);
++		reg |= eol_byte_num << 3;
++		reg |= slice_per_pkt << 5;
++		reg |= bytes_per_pkt << 16;
++		reg |= be_in_lane << 10;
++
++		msm_dp_panel_config_dsc_dto(ctrl->panel);
++	}
++	msm_dp_write_link(ctrl, REG_DP_COMPRESSION_MODE_CTRL, reg);
++
++	drm_dbg_dp(ctrl->drm_dev, "compression:0x%x\n", reg);
++}
++
+ static void msm_dp_ctrl_lane_mapping(struct msm_dp_ctrl_private *ctrl)
+ {
+ 	u32 *lane_map = ctrl->link->lane_map;
+@@ -448,13 +533,14 @@ static void msm_dp_ctrl_configure_source_params(struct msm_dp_ctrl_private *ctrl
+ 	u32 colorimetry_cfg, test_bits_depth, misc_val;
+ 
+ 	msm_dp_ctrl_lane_mapping(ctrl);
++	msm_dp_ctrl_mainlink_levels(ctrl);
+ 	msm_dp_setup_peripheral_flush(ctrl);
+ 
+ 	msm_dp_ctrl_config_ctrl(ctrl);
+ 
+ 	test_bits_depth = msm_dp_link_get_test_bits_depth(ctrl->link,
+ 				ctrl->panel->msm_dp_mode.mode_cfg.bpp);
+-	colorimetry_cfg = msm_dp_link_get_colorimetry_config(ctrl->link);
++	colorimetry_cfg = msm_dp_panel_get_colorimetry_config(ctrl->panel);
+ 
+ 	misc_val = msm_dp_read_link(ctrl, REG_DP_MISC1_MISC0);
+ 
+@@ -1252,11 +1338,11 @@ static void msm_dp_ctrl_calc_tu_parameters(struct msm_dp_ctrl_private *ctrl,
+ 	in.nlanes = ctrl->link->link_params.num_lanes;
+ 	in.bpp = ctrl->panel->msm_dp_mode.mode_cfg.bpp;
+ 	in.pixel_enc = ctrl->panel->msm_dp_mode.out_fmt_is_yuv_420 ? 420 : 444;
+-	in.dsc_en = 0;
++	in.dsc_en = ctrl->panel->dsc_cap.enabled;
+ 	in.async_en = 0;
+-	in.fec_en = 0;
+-	in.num_of_dsc_slices = 0;
+-	in.compress_ratio = 100;
++	in.fec_en = ctrl->panel->fec_cap.enabled;
++	in.num_of_dsc_slices = ctrl->panel->msm_dp_mode.drm_dsc.slice_count;
++	in.compress_ratio = 100 * MSM_DP_DSC_COMP_RATIO;
+ 
+ 	_dp_ctrl_calc_tu(ctrl, &in, tu_table);
+ }
+@@ -1676,16 +1762,75 @@ static int msm_dp_ctrl_link_train(struct msm_dp_ctrl_private *ctrl,
+ 	return ret;
+ }
+ 
++static void msm_dp_ctrl_sink_fec_enable(struct msm_dp_ctrl_private *ctrl,
++			bool enable)
++{
++	int rlen;
++
++	rlen = drm_dp_dpcd_writeb(ctrl->aux, DP_FEC_CONFIGURATION,
++				enable ? 0x07 : 0x00);
++	if (rlen < 1)
++		DRM_ERROR("failed to set sink fec enable\n");
++}
++
++static void msm_dp_ctrl_host_fec_start(struct msm_dp_ctrl_private *ctrl)
++{
++	u8 fec_sts = 0;
++	int i, max_retries = 3;
++	bool fec_en = ctrl->panel->fec_cap.enabled;
++	bool fec_en_detected;
++
++	/* Need to try to enable multiple times due to BS symbols collisions */
++	for (i = 0; i < max_retries; i++) {
++		msm_dp_ctrl_fec_config(ctrl, fec_en);
++
++		/* wait for controller to start fec sequence */
++		usleep_range(900, 1000);
++
++		/* read back FEC status and check if it is enabled */
++		drm_dp_dpcd_readb(ctrl->aux, DP_FEC_STATUS, &fec_sts);
++		fec_en_detected = !!(fec_sts & DP_FEC_DECODE_EN_DETECTED);
++
++		if (fec_en_detected == fec_en)
++			break;
++	}
++
++	drm_dbg_dp(ctrl->drm_dev, "retries %d, fec_en_detected %d\n",
++				i, fec_en_detected);
++
++	if (fec_en_detected != fec_en)
++		DRM_ERROR("failed to set sink fec\n");
++}
++
++static void msm_dp_ctrl_host_fec_stop(struct msm_dp_ctrl_private *ctrl)
++{
++	msm_dp_ctrl_fec_config(ctrl, false);
++}
++
++static void msm_dp_ctrl_sink_dsc_enable(struct msm_dp_ctrl_private *ctrl)
++{
++	int rlen;
++	u32 dsc_enable;
++
++	dsc_enable = !!ctrl->panel->dsc_cap.enabled;
++	rlen = drm_dp_dpcd_writeb(ctrl->aux, DP_DSC_ENABLE, dsc_enable);
++	if (rlen < 1)
++		DRM_ERROR("failed to set sink dsc\n");
++}
++
+ static int msm_dp_ctrl_setup_main_link(struct msm_dp_ctrl_private *ctrl,
+ 			int *training_step)
+ {
+ 	int ret = 0;
+ 
+ 	msm_dp_ctrl_mainlink_enable(ctrl);
++	msm_dp_ctrl_mainlink_levels(ctrl);
+ 
+ 	if (ctrl->link->sink_request & DP_TEST_LINK_PHY_TEST_PATTERN)
+ 		return ret;
+ 
++	msm_dp_ctrl_sink_fec_enable(ctrl, ctrl->panel->fec_cap.enabled);
++
+ 	/*
+ 	 * As part of previous calls, DP controller state might have
+ 	 * transitioned to PUSH_IDLE. In order to start transmitting
+@@ -2473,6 +2618,135 @@ static void msm_dp_ctrl_config_msa(struct msm_dp_ctrl_private *ctrl,
+ 	msm_dp_write_link(ctrl, REG_DP_SOFTWARE_NVID, nvid);
+ }
+ 
++static inline u8 msm_dp_ecc_get_g0_value(u8 data)
++{
++	u8 c[4];
++	u8 g[4];
++	u8 ret_data = 0;
++	u8 i;
++
++	for (i = 0; i < 4; i++)
++		c[i] = (data >> i) & 0x01;
++
++	g[0] = c[3];
++	g[1] = c[0] ^ c[3];
++	g[2] = c[1];
++	g[3] = c[2];
++
++	for (i = 0; i < 4; i++)
++		ret_data = ((g[i] & 0x01) << i) | ret_data;
++
++	return ret_data;
++}
++
++static inline u8 msm_dp_ecc_get_g1_value(u8 data)
++{
++	u8 c[4];
++	u8 g[4];
++	u8 ret_data = 0;
++	u8 i;
++
++	for (i = 0; i < 4; i++)
++		c[i] = (data >> i) & 0x01;
++
++	g[0] = c[0] ^ c[3];
++	g[1] = c[0] ^ c[1] ^ c[3];
++	g[2] = c[1] ^ c[2];
++	g[3] = c[2] ^ c[3];
++
++	for (i = 0; i < 4; i++)
++		ret_data = ((g[i] & 0x01) << i) | ret_data;
++
++	return ret_data;
++}
++
++static inline u8 msm_dp_header_get_parity(u32 data)
++{
++	u8 x0 = 0;
++	u8 x1 = 0;
++	u8 ci = 0;
++	u8 iData = 0;
++	u8 i = 0;
++	u8 parity_byte;
++	u8 num_byte = (data > 0xFF) ? 8 : 2;
++
++	for (i = 0; i < num_byte; i++) {
++		iData = (data >> (i * 4)) & 0xF;
++
++		ci = iData ^ x1;
++		x1 = x0 ^ msm_dp_ecc_get_g1_value(ci);
++		x0 = msm_dp_ecc_get_g0_value(ci);
++	}
++
++	parity_byte = x1 | (x0 << 4);
++
++	return parity_byte;
++}
++
++static void msm_dp_ctrl_dsc_commit_pps(struct msm_dp_ctrl_private *ctrl)
++{
++	int i, index_4;
++
++	struct drm_dsc_picture_parameter_set dsc_pps = {0};
++	u8 *pps = (u8 *)&dsc_pps;
++	u32 pps_len;
++	u32 pps_word[32];
++	u32 pps_word_len;
++	u8 parity[32] = {0};
++	u8 parity_len;
++	u32 parity_word[8];
++	u32 parity_word_len;
++
++	drm_dsc_pps_payload_pack(&dsc_pps, &ctrl->panel->msm_dp_mode.drm_dsc);
++	pps_len = offsetof(struct drm_dsc_picture_parameter_set, native_422_420);
++
++	pps_word_len = pps_len >> 2;
++	parity_len = pps_word_len;
++	parity_word_len = parity_len >> 2;
++
++	for (i = 0; i < pps_word_len; i++) {
++		index_4 = i << 2;
++		pps_word[i] = pps[index_4 + 0] << 0 |
++				pps[index_4 + 1] << 8 |
++				pps[index_4 + 2] << 16 |
++				pps[index_4 + 3] << 24;
++
++		parity[i] = msm_dp_header_get_parity(pps_word[i]);
++	}
++
++	for (i = 0; i < parity_word_len; i++) {
++		index_4 = i << 2;
++		parity_word[i] = parity[index_4 + 0] << 0 |
++				   parity[index_4 + 1] << 8 |
++				   parity[index_4 + 2] << 16 |
++				   parity[index_4 + 3] << 24;
++	}
++
++	msm_dp_write_link(ctrl, REG_DP_PPS_HB_0_3, 0x7F1000);
++	msm_dp_write_link(ctrl, REG_DP_PPS_PB_0_3, 0xA22300);
++
++	for (i = 0; i < parity_word_len; i++)
++		msm_dp_write_link(ctrl, REG_DP_PPS_PB_4_7 + (i << 2),
++				parity_word[i]);
++
++	for (i = 0; i < pps_word_len; i++)
++		msm_dp_write_link(ctrl, REG_DP_PPS_PPS_0_3 + (i << 2),
++				pps_word[i]);
++}
++
++static void msm_dp_ctrl_pps_flush(struct msm_dp_ctrl_private *ctrl)
++{
++	u32 dp_flush = msm_dp_read_link(ctrl, MMSS_DP_FLUSH);
++
++	/* DP_PPS_FLUSH */
++	dp_flush &= ~BIT(2);
++	dp_flush |= BIT(0);
++
++	msm_dp_write_link(ctrl, MMSS_DP_FLUSH, dp_flush);
++
++	msm_dp_ctrl_enable_sdp(ctrl);
++}
++
+ int msm_dp_ctrl_on_stream(struct msm_dp_ctrl *msm_dp_ctrl, bool force_link_train)
+ {
+ 	int ret = 0;
+@@ -2543,10 +2817,14 @@ int msm_dp_ctrl_on_stream(struct msm_dp_ctrl *msm_dp_ctrl, bool force_link_train
+ 		pixel_rate_orig,
+ 		ctrl->panel->msm_dp_mode.out_fmt_is_yuv_420);
+ 
+-	msm_dp_panel_clear_dsc_dto(ctrl->panel);
++	msm_dp_ctrl_config_dsc_dto(ctrl, ctrl->panel->dsc_cap.enabled);
++	msm_dp_ctrl_dsc_commit_pps(ctrl);
++	msm_dp_ctrl_pps_flush(ctrl);
+ 
+ 	msm_dp_ctrl_setup_tr_unit(ctrl);
+ 
++	msm_dp_panel_override_ack_dto(ctrl->panel, true);
++
+ 	msm_dp_write_link(ctrl, REG_DP_STATE_CTRL, DP_STATE_CTRL_SEND_VIDEO);
+ 
+ 	ret = msm_dp_ctrl_wait4video_ready(ctrl);
+@@ -2557,6 +2835,10 @@ int msm_dp_ctrl_on_stream(struct msm_dp_ctrl *msm_dp_ctrl, bool force_link_train
+ 	drm_dbg_dp(ctrl->drm_dev,
+ 		"mainlink %s\n", mainlink_ready ? "READY" : "NOT READY");
+ 
++	/* wait for link training completion before fec config as per spec */
++	msm_dp_ctrl_host_fec_start(ctrl);
++	msm_dp_ctrl_sink_dsc_enable(ctrl);
++
+ end:
+ 	return ret;
+ }
+@@ -2626,6 +2908,10 @@ void msm_dp_ctrl_off(struct msm_dp_ctrl *msm_dp_ctrl)
+ 
+ 	msm_dp_panel_disable_vsc_sdp(ctrl->panel);
+ 
++	msm_dp_ctrl_host_fec_stop(ctrl);
++	msm_dp_ctrl_config_dsc_dto(ctrl, false);
++	msm_dp_panel_override_ack_dto(ctrl->panel, false);
++
+ 	msm_dp_ctrl_mainlink_disable(ctrl);
+ 
+ 	msm_dp_ctrl_reset(&ctrl->msm_dp_ctrl);
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index 6da11edd46bc..c754c5c924ad 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -656,14 +656,6 @@ void msm_dp_panel_tpg_config(struct msm_dp_panel *msm_dp_panel, bool enable)
+ 	msm_dp_panel_tpg_enable(msm_dp_panel, &panel->msm_dp_panel.msm_dp_mode.drm_mode);
+ }
+ 
+-void msm_dp_panel_clear_dsc_dto(struct msm_dp_panel *msm_dp_panel)
+-{
+-	struct msm_dp_panel_private *panel =
+-		container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
+-
+-	msm_dp_write_p0(panel, MMSS_DP_DSC_DTO, 0x0);
+-}
+-
+ static void msm_dp_panel_send_vsc_sdp(struct msm_dp_panel_private *panel, struct dp_sdp *vsc_sdp)
+ {
+ 	u32 header[2];
+@@ -1194,6 +1186,100 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 	return 0;
+ }
+ 
++u8 msm_dp_panel_get_colorimetry_config(struct msm_dp_panel *msm_dp_panel)
++{
++	u8 colorimetry;
++	u32 colorspace;
++	u32 cc;
++	struct msm_dp_panel_private *panel;
++
++	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
++
++	cc = msm_dp_link_get_colorimetry_config(panel->link);
++	/*
++	 * If there is a non-zero value then compliance test-case
++	 * is going on, otherwise we can honor the colorspace setting
++	 */
++	if (cc)
++		return cc;
++
++	colorspace = msm_dp_panel->connector->state->colorspace;
++	switch (colorspace) {
++	case DRM_MODE_COLORIMETRY_DCI_P3_RGB_D65:
++	case DRM_MODE_COLORIMETRY_DCI_P3_RGB_THEATER:
++		colorimetry = 0x7;
++		break;
++	case DRM_MODE_COLORIMETRY_RGB_WIDE_FIXED:
++		colorimetry = 0x3;
++		break;
++	case DRM_MODE_COLORIMETRY_RGB_WIDE_FLOAT:
++		colorimetry = 0xb;
++		break;
++	case DRM_MODE_COLORIMETRY_OPRGB:
++		colorimetry = 0xc;
++		break;
++	default:
++		colorimetry = 0;
++	}
++
++	return colorimetry;
++}
++void msm_dp_panel_config_dsc_dto(struct msm_dp_panel *msm_dp_panel)
++{
++	struct msm_dp_panel_private *panel;
++	struct msm_dp_dsc_cfg *msm_dp_dsc;
++	struct msm_dp_display_mode_cfg *mode_cfg;
++	u32 reg;
++
++	bool dto_en = true;
++	u32 dto_n;
++	u32 dto_d;
++	u32 dto_count;
++
++	if (!msm_dp_panel) {
++		DRM_ERROR("invalid input\n");
++		return;
++	}
++
++	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
++	msm_dp_dsc = &msm_dp_panel->msm_dp_mode.msm_dp_dsc;
++	mode_cfg = &msm_dp_panel->msm_dp_mode.mode_cfg;
++
++	dto_count = msm_dp_dsc->pclk_per_line;
++	msm_dp_panel_get_dto_params(mode_cfg->bpp, mode_cfg->bpp / MSM_DP_DSC_COMP_RATIO, &dto_n, &dto_d);
++
++	msm_dp_write_p0(panel, MMSS_DP_DSC_DTO_COUNT, dto_count);
++	reg = msm_dp_read_p0(panel, MMSS_DP_DSC_DTO);
++	if (dto_en) {
++		reg |= BIT(0);
++		reg |= BIT(3);
++		reg |= (dto_n << 8);
++		reg |= (dto_d << 16);
++	}
++	msm_dp_write_p0(panel, MMSS_DP_DSC_DTO, reg);
++}
++
++void msm_dp_panel_override_ack_dto(struct msm_dp_panel *msm_dp_panel, bool not_ack)
++{
++	struct msm_dp_panel_private *panel;
++	u32 dsc_dto;
++
++	if (!msm_dp_panel) {
++		DRM_ERROR("invalid input\n");
++		return;
++	}
++
++	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
++
++	dsc_dto = msm_dp_read_p0(panel, MMSS_DP_DSC_DTO);
++	if (not_ack)
++		dsc_dto &= ~BIT(1);
++	else
++		dsc_dto = BIT(1);
++
++	msm_dp_write_p0(panel, MMSS_DP_DSC_DTO, dsc_dto);
++}
++
+ struct msm_dp_panel *msm_dp_panel_get(struct device *dev, struct drm_dp_aux *aux,
+ 			      struct msm_dp_link *link,
+ 			      void __iomem *link_base,
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.h b/drivers/gpu/drm/msm/dp/dp_panel.h
+index 361e7de74bed..ce6f1d7e9ebe 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.h
++++ b/drivers/gpu/drm/msm/dp/dp_panel.h
+@@ -101,11 +101,41 @@ int msm_dp_panel_get_modes(struct msm_dp_panel *msm_dp_panel,
+ void msm_dp_panel_handle_sink_request(struct msm_dp_panel *msm_dp_panel);
+ void msm_dp_panel_tpg_config(struct msm_dp_panel *msm_dp_panel, bool enable);
+ 
+-void msm_dp_panel_clear_dsc_dto(struct msm_dp_panel *msm_dp_panel);
++u8 msm_dp_panel_get_colorimetry_config(struct msm_dp_panel *msm_dp_panel);
++void msm_dp_panel_config_dsc_dto(struct msm_dp_panel *msm_dp_panel);
++void msm_dp_panel_override_ack_dto(struct msm_dp_panel *msm_dp_panel, bool not_ack);
+ 
+ void msm_dp_panel_enable_vsc_sdp(struct msm_dp_panel *msm_dp_panel, struct dp_sdp *vsc_sdp);
+ void msm_dp_panel_disable_vsc_sdp(struct msm_dp_panel *msm_dp_panel);
+ 
++/**
++ * msm_dp_panel_get_dto_params() - get numerator and denominator for dsc bpp config
++ * @src_bpp: uncompressed bits per pixel
++ * @tgt_bpp: compressed bits per pixel
++ * @num: returning numerator
++ * @denom: returning denominator
++ */
++static inline void msm_dp_panel_get_dto_params(u32 src_bpp, u32 tgt_bpp, u32 *num, u32 *denom)
++{
++	if ((tgt_bpp == 12) && (src_bpp == 24)) {
++		*num = 1;
++		*denom = 2;
++	} else if ((tgt_bpp == 15) && (src_bpp == 30)) {
++		*num = 5;
++		*denom = 8;
++	} else if ((tgt_bpp == 8) && ((src_bpp == 24) || (src_bpp == 30))) {
++		*num = 1;
++		*denom = 3;
++	} else if ((tgt_bpp == 10) && (src_bpp == 30)) {
++		*num = 5;
++		*denom = 12;
++	} else {
++		DRM_ERROR("dto params not found for sbpp=%d tbpp=%d\n", src_bpp, tgt_bpp);
++		*num = 0;
++		*denom = 1;
++	}
++}
++
+ /**
+  * is_link_rate_valid() - validates the link rate
+  * @bw_code: link rate requested by the sink
+diff --git a/drivers/gpu/drm/msm/dp/dp_reg.h b/drivers/gpu/drm/msm/dp/dp_reg.h
+index 7c44d4e2cf13..7e3c71db4c92 100644
+--- a/drivers/gpu/drm/msm/dp/dp_reg.h
++++ b/drivers/gpu/drm/msm/dp/dp_reg.h
+@@ -221,6 +221,37 @@
+ #define MMSS_DP_PSR_CRC_B			(0x00000158)
+ 
+ #define REG_DP_COMPRESSION_MODE_CTRL		(0x00000180)
++#define REG_DP_PPS_HB_0_3				(0x00000184)
++#define REG_DP_PPS_PB_0_3				(0x00000188)
++#define REG_DP_PPS_PB_4_7				(0x0000018C)
++#define REG_DP_PPS_PB_8_11				(0x00000190)
++#define REG_DP_PPS_PB_12_15				(0x00000194)
++#define REG_DP_PPS_PB_16_19				(0x00000198)
++#define REG_DP_PPS_PB_20_23				(0x0000019C)
++#define REG_DP_PPS_PB_24_27				(0x000001A0)
++#define REG_DP_PPS_PB_28_31				(0x000001A4)
++#define REG_DP_PPS_PPS_0_3				(0x000001A8)
++#define REG_DP_PPS_PPS_4_7				(0x000001AC)
++#define REG_DP_PPS_PPS_8_11				(0x000001B0)
++#define REG_DP_PPS_PPS_12_15			(0x000001B4)
++#define REG_DP_PPS_PPS_16_19			(0x000001B8)
++#define REG_DP_PPS_PPS_20_23			(0x000001BC)
++#define REG_DP_PPS_PPS_24_27			(0x000001C0)
++#define REG_DP_PPS_PPS_28_31			(0x000001C4)
++#define REG_DP_PPS_PPS_32_35			(0x000001C8)
++#define REG_DP_PPS_PPS_36_39			(0x000001CC)
++#define REG_DP_PPS_PPS_40_43			(0x000001D0)
++#define REG_DP_PPS_PPS_44_47			(0x000001D4)
++#define REG_DP_PPS_PPS_48_51			(0x000001D8)
++#define REG_DP_PPS_PPS_52_55			(0x000001DC)
++#define REG_DP_PPS_PPS_56_59			(0x000001E0)
++#define REG_DP_PPS_PPS_60_63			(0x000001E4)
++#define REG_DP_PPS_PPS_64_67			(0x000001E8)
++#define REG_DP_PPS_PPS_68_71			(0x000001EC)
++#define REG_DP_PPS_PPS_72_75			(0x000001F0)
++#define REG_DP_PPS_PPS_76_79			(0x000001F4)
++#define REG_DP_PPS_PPS_80_83			(0x000001F8)
++#define REG_DP_PPS_PPS_84_87			(0x000001FC)
+ 
+ #define MMSS_DP_AUDIO_CFG			(0x00000200)
+ #define MMSS_DP_AUDIO_STATUS			(0x00000204)
+@@ -268,6 +299,9 @@
+ #define MMSS_DP_AUDIO_INFOFRAME_1		(0x000002AC)
+ #define MMSS_DP_AUDIO_INFOFRAME_2		(0x000002B0)
+ 
++#define MMSS_DP_FLUSH				(0x000002F8)
++#define MMSS_DP1_FLUSH				(0x000002FC)
++
+ #define MMSS_DP_GENERIC0_0			(0x00000300)
+ #define MMSS_DP_GENERIC0_1			(0x00000304)
+ #define MMSS_DP_GENERIC0_2			(0x00000308)
+@@ -326,6 +360,7 @@
+ 
+ #define MMSS_DP_TPG_MAIN_CONTROL		(0x00000060)
+ #define MMSS_DP_DSC_DTO				(0x0000007C)
++#define MMSS_DP_DSC_DTO_COUNT			(0x00000084)
+ #define DP_TPG_CHECKERED_RECT_PATTERN		(0x00000100)
+ 
+ #define MMSS_DP_TPG_VIDEO_CONFIG		(0x00000064)
+-- 
+2.54.0
+
+
+From 71c11ada5a4535a8324dd818f77bc3e0caceee73 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 01:27:05 -0300
+Subject: [PATCH 05/16] drm/msm/dpu: allow dsc enc alloc on odd index
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_rm.c | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_rm.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_rm.c
+index 7e77d88f8959..5ac5cb0daba2 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_rm.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_rm.c
+@@ -526,25 +526,28 @@ static int _dpu_rm_dsc_alloc(struct dpu_rm *rm,
+ 	int dsc_idx;
+ 	int ret;
+ 
+-	for (dsc_idx = 0; dsc_idx < ARRAY_SIZE(rm->dsc_blks) &&
++	pp_idx = _dpu_rm_pingpong_next_index(global_state, pp_idx, crtc_id);
++
++	for (dsc_idx = pp_idx & 0x01; dsc_idx < ARRAY_SIZE(rm->dsc_blks) &&
+ 	     num_dsc < top->num_dsc; dsc_idx++) {
++		if (pp_idx < 0)
++			return -ENAVAIL;
++
+ 		if (!rm->dsc_blks[dsc_idx])
+ 			continue;
+ 
+ 		if (reserved_by_other(global_state->dsc_to_crtc_id, dsc_idx, crtc_id))
+ 			continue;
+ 
+-		pp_idx = _dpu_rm_pingpong_next_index(global_state, pp_idx, crtc_id);
+-		if (pp_idx < 0)
+-			return -ENAVAIL;
+-
+ 		ret = _dpu_rm_pingpong_dsc_check(dsc_idx, pp_idx);
+ 		if (ret)
+-			return -ENAVAIL;
++			continue;
+ 
+ 		global_state->dsc_to_crtc_id[dsc_idx] = crtc_id;
+ 		num_dsc++;
+ 		pp_idx++;
++
++		pp_idx = _dpu_rm_pingpong_next_index(global_state, pp_idx, crtc_id);
+ 	}
+ 
+ 	if (num_dsc < top->num_dsc) {
+-- 
+2.54.0
+
+
+From 1abd90b233c11390f129268ff015abed2ad89586 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 02:56:27 -0300
+Subject: [PATCH 06/16] drm/msm: add extra_width and pclk_per_line handling to
+ dpu phys vid encoders
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c   | 32 +++++++++
+ drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.h   |  4 ++
+ .../drm/msm/disp/dpu1/dpu_encoder_phys_vid.c  | 12 +++-
+ drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c   | 34 ++++++++--
+ drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.h   |  2 +
+ drivers/gpu/drm/msm/dp/dp_display.c           | 67 +++++++++++++++++++
+ drivers/gpu/drm/msm/msm_drv.h                 | 12 ++++
+ 7 files changed, 155 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+index 2756c5702f34..82f1b06b50ae 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+@@ -305,6 +305,38 @@ bool dpu_encoder_is_dsc_enabled(const struct drm_encoder *drm_enc)
+ 	return dpu_enc->dsc ? true : false;
+ }
+ 
++/**
++ * dpu_encoder_get_extra_width - get extra_width for the given encoder.
++ * @drm_enc:    Pointer to previously created drm encoder structure
++ */
++u32 dpu_encoder_get_extra_width(const struct drm_encoder *drm_enc)
++{
++	struct msm_drm_private *priv = drm_enc->dev->dev_private;
++	struct dpu_encoder_virt *dpu_enc = to_dpu_encoder_virt(drm_enc);
++	int index = dpu_enc->disp_info.h_tile_instance[0];
++
++	if (dpu_enc->disp_info.intf_type == INTF_DP)
++		return msm_dp_dsc_get_extra_width(priv->kms->dp[index]);
++
++	return 0;
++}
++
++/**
++ * dpu_encoder_get_pclk_per_line - get pclk_per_line for the given encoder.
++ * @drm_enc:    Pointer to previously created drm encoder structure
++ */
++u32 dpu_encoder_get_pclk_per_line(const struct drm_encoder *drm_enc)
++{
++	struct msm_drm_private *priv = drm_enc->dev->dev_private;
++	struct dpu_encoder_virt *dpu_enc = to_dpu_encoder_virt(drm_enc);
++	int index = dpu_enc->disp_info.h_tile_instance[0];
++
++	if (dpu_enc->disp_info.intf_type == INTF_DP)
++		return msm_dp_dsc_get_pclk_per_line(priv->kms->dp[index]);
++
++	return 0;
++}
++
+ /**
+  * dpu_encoder_get_crc_values_cnt - get number of physical encoders contained
+  *	in virtual encoder that can collect CRC values
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.h b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.h
+index ca1ca2e51d7e..758714583e78 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.h
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.h
+@@ -74,6 +74,10 @@ bool dpu_encoder_is_widebus_enabled(const struct drm_encoder *drm_enc);
+ 
+ bool dpu_encoder_is_dsc_enabled(const struct drm_encoder *drm_enc);
+ 
++u32 dpu_encoder_get_extra_width(const struct drm_encoder *drm_enc);
++
++u32 dpu_encoder_get_pclk_per_line(const struct drm_encoder *drm_enc);
++
+ int dpu_encoder_get_crc_values_cnt(const struct drm_encoder *drm_enc);
+ 
+ void dpu_encoder_setup_misr(const struct drm_encoder *drm_encoder);
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder_phys_vid.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder_phys_vid.c
+index 0ba777bda253..65a2450dad41 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder_phys_vid.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder_phys_vid.c
+@@ -10,6 +10,7 @@
+ #include "dpu_formats.h"
+ #include "dpu_trace.h"
+ #include "disp/msm_disp_snapshot.h"
++#include "msm_dsc_helper.h"
+ 
+ #include <drm/display/drm_dsc_helper.h>
+ #include <drm/drm_managed.h>
+@@ -113,12 +114,20 @@ static void drm_mode_to_intf_timing_params(
+ 	 * for DP, divide the horizonal parameters by 2 when
+ 	 * widebus is enabled
+ 	 */
+-	if (phys_enc->hw_intf->cap->type == INTF_DP && timing->wide_bus_en) {
++	if (phys_enc->hw_intf->cap->type == INTF_DP &&
++				(timing->wide_bus_en || timing->compression_en)) {
+ 		timing->width = timing->width >> 1;
+ 		timing->xres = timing->xres >> 1;
+ 		timing->h_back_porch = timing->h_back_porch >> 1;
+ 		timing->h_front_porch = timing->h_front_porch >> 1;
+ 		timing->hsync_pulse_width = timing->hsync_pulse_width >> 1;
++
++		if (timing->compression_en) {
++			u32 extra_width = dpu_encoder_get_extra_width(phys_enc->parent);
++			timing->pclk_per_line = dpu_encoder_get_pclk_per_line(phys_enc->parent);
++			timing->width += extra_width;
++			timing->h_back_porch += extra_width;
++		}
+ 	}
+ 
+ 	/*
+@@ -136,6 +145,7 @@ static void drm_mode_to_intf_timing_params(
+ 		timing->width = timing->width * drm_dsc_get_bpp_int(dsc) /
+ 				(dsc->bits_per_component * 3);
+ 		timing->xres = timing->width;
++		timing->dce_bytes_per_line = msm_dsc_get_bytes_per_line(dsc);
+ 	}
+ }
+ 
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c
+index 7e620f590984..99800dd2675b 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c
+@@ -173,16 +173,31 @@ static void dpu_hw_intf_setup_timing_engine(struct dpu_hw_intf *intf,
+ 	data_width = p->width;
+ 
+ 	/*
+-	 * If widebus is enabled, data is valid for only half the active window
+-	 * since the data rate is doubled in this mode. But for the compression
+-	 * mode in DP case, the p->width is already adjusted in
+-	 * drm_mode_to_intf_timing_params()
++	 * If widebus is disabled:
++	 * For uncompressed stream, the data is valid for the entire active
++	 * window period.
++	 * For compressed stream, data is valid for a shorter time period
++	 * inside the active window depending on the compression ratio.
++	 *
++	 * If widebus is enabled:
++	 * For uncompressed stream, data is valid for only half the active
++	 * window, since the data rate is doubled in this mode.
++	 * For compressed stream, data validity window needs to be adjusted for
++	 * compression ratio and then further halved.
++	 *
++	 * For the compression mode in DP case, the p->width is already
++	 * adjusted in drm_mode_to_intf_timing_params().
+ 	 */
+-	if (p->wide_bus_en && !dp_intf)
++	if (p->compression_en && !dp_intf) {
++		if (p->wide_bus_en)
++			data_width = DIV_ROUND_UP(p->dce_bytes_per_line, 6);
++		else
++			data_width = DIV_ROUND_UP(p->dce_bytes_per_line, 3);
++	} else if (p->wide_bus_en && !dp_intf) {
+ 		data_width = p->width >> 1;
++	}
+ 
+-	/* TODO: handle DSC+DP case, we only handle DSC+DSI case so far */
+-	if (p->compression_en && !dp_intf &&
++	if (p->compression_en &&
+ 	    intf->mdss_ver->core_major_ver >= 7)
+ 		intf_cfg2 |= INTF_CFG2_DCE_DATA_COMPRESS;
+ 
+@@ -205,6 +220,11 @@ static void dpu_hw_intf_setup_timing_engine(struct dpu_hw_intf *intf,
+ 		display_hctl = active_hctl;
+ 
+ 		intf_cfg |= INTF_CFG_ACTIVE_H_EN | INTF_CFG_ACTIVE_V_EN;
++
++		if (p->compression_en) {
++			active_data_hctl = (hsync_start_x + p->pclk_per_line) << 16 | hsync_start_x;
++			display_data_hctl = active_data_hctl;
++		}
+ 	}
+ 
+ 	den_polarity = 0;
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.h b/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.h
+index f6ef2c21b66d..5d854e7d7a58 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.h
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.h
+@@ -35,6 +35,8 @@ struct dpu_hw_intf_timing_params {
+ 
+ 	bool wide_bus_en;
+ 	bool compression_en;
++	u32 dce_bytes_per_line;
++	u32 pclk_per_line;
+ };
+ 
+ struct dpu_hw_intf_prog_fetch {
+diff --git a/drivers/gpu/drm/msm/dp/dp_display.c b/drivers/gpu/drm/msm/dp/dp_display.c
+index 2ad480ef58df..bbfe6f2aad38 100644
+--- a/drivers/gpu/drm/msm/dp/dp_display.c
++++ b/drivers/gpu/drm/msm/dp/dp_display.c
+@@ -15,6 +15,7 @@
+ #include <drm/display/drm_dp_aux_bus.h>
+ #include <drm/display/drm_hdmi_audio_helper.h>
+ #include <drm/drm_edid.h>
++#include <drm/drm_fixed.h>
+ 
+ #include "msm_drv.h"
+ #include "msm_kms.h"
+@@ -1529,6 +1530,72 @@ bool msm_dp_wide_bus_available(const struct msm_dp *msm_dp_display)
+ 	return dp->wide_bus_supported;
+ }
+ 
++u32 msm_dp_dsc_get_extra_width(const struct msm_dp *msm_dp_display)
++{
++	struct msm_dp_display_private *dp;
++
++	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
++
++	struct msm_dp_display_mode *msm_dp_mode = &dp->panel->msm_dp_mode;
++	struct drm_dsc_config *drm_dsc = &msm_dp_mode->drm_dsc;
++	struct msm_dp_dsc_cfg *msm_dp_dsc = &msm_dp_mode->msm_dp_dsc;
++	struct msm_dp_display_mode_cfg *mode_cfg = &msm_dp_mode->mode_cfg;
++	unsigned int dto_n = 0, dto_d = 0, remainder;
++	int ack_required, last_few_ack_required, accum_ack;
++	int last_few_pclk, last_few_pclk_required;
++	int start, temp, line_width = drm_dsc->pic_width / 2;
++	s64 temp1_fp, temp2_fp;
++
++	msm_dp_panel_get_dto_params(mode_cfg->bpp, mode_cfg->bpp / MSM_DP_DSC_COMP_RATIO, &dto_n, &dto_d);
++
++	ack_required = msm_dp_dsc->pclk_per_line + 1;
++
++	/* number of pclk cycles left outside of the complete DTO set */
++	last_few_pclk = line_width % dto_d;
++
++	/* number of pclk cycles outside of the complete dto */
++	temp1_fp = drm_fixp_from_fraction(line_width, dto_d);
++	temp2_fp = drm_fixp_from_fraction(dto_n, 1);
++	temp1_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++	temp = drm_fixp2int(temp1_fp);
++	last_few_ack_required = ack_required - temp;
++
++	/*
++	 * check how many more pclk is needed to
++	 * accommodate the last few ack required
++	 */
++	remainder = dto_n;
++	accum_ack = 0;
++	last_few_pclk_required = 0;
++	while (accum_ack < last_few_ack_required) {
++		last_few_pclk_required++;
++
++		if (remainder >= dto_n)
++			start = remainder;
++		else
++			start = remainder + dto_d;
++
++		remainder = start - dto_n;
++		if (remainder < dto_n)
++			accum_ack++;
++	}
++
++	/* if fewer pclk than required */
++	if (last_few_pclk < last_few_pclk_required)
++		return last_few_pclk_required - last_few_pclk;
++
++	return 0;
++}
++
++u32 msm_dp_dsc_get_pclk_per_line(const struct msm_dp *msm_dp_display)
++{
++	struct msm_dp_display_private *dp;
++
++	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
++
++	return dp->panel->msm_dp_mode.msm_dp_dsc.pclk_per_line;
++}
++
+ void msm_dp_display_debugfs_init(struct msm_dp *msm_dp_display, struct dentry *root, bool is_edp)
+ {
+ 	struct msm_dp_display_private *dp;
+diff --git a/drivers/gpu/drm/msm/msm_drv.h b/drivers/gpu/drm/msm/msm_drv.h
+index 028d7ba22957..43506c159b39 100644
+--- a/drivers/gpu/drm/msm/msm_drv.h
++++ b/drivers/gpu/drm/msm/msm_drv.h
+@@ -369,6 +369,8 @@ bool msm_dp_is_yuv_420_enabled(const struct msm_dp *dp_display,
+ bool msm_dp_needs_periph_flush(const struct msm_dp *dp_display,
+ 			       const struct drm_display_mode *mode);
+ bool msm_dp_wide_bus_available(const struct msm_dp *dp_display);
++u32 msm_dp_dsc_get_extra_width(const struct msm_dp *msm_dp_display);
++u32 msm_dp_dsc_get_pclk_per_line(const struct msm_dp *dp_display);
+ 
+ #else
+ static inline int __init msm_dp_register(void)
+@@ -407,6 +409,16 @@ static inline bool msm_dp_wide_bus_available(const struct msm_dp *dp_display)
+ 	return false;
+ }
+ 
++static inline u32 msm_dp_dsc_get_extra_width(const struct msm_dp *msm_dp_display)
++{
++	return 0;
++}
++
++static inline u32 msm_dp_dsc_get_pclk_per_line(const struct msm_dp *dp_display)
++{
++	return 0;
++}
++
+ #endif
+ 
+ #ifdef CONFIG_DRM_MSM_MDP4
+-- 
+2.54.0
+
+
+From a222b61ec5c79d7d9f859ac370ee22f01b13e597 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 03:46:33 -0300
+Subject: [PATCH 07/16] drm/msm: connect dpu dsc handling to dp display
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c | 38 +++++++++++-
+ drivers/gpu/drm/msm/dp/dp_display.c         | 68 +++++++++++++++++----
+ drivers/gpu/drm/msm/dp/dp_panel.c           |  3 +
+ drivers/gpu/drm/msm/dsi/dsi.c               |  9 +++
+ drivers/gpu/drm/msm/msm_drv.h               | 27 ++++++++
+ 5 files changed, 130 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+index 82f1b06b50ae..f6d002750c88 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+@@ -683,10 +683,37 @@ struct drm_dsc_config *dpu_encoder_get_dsc_config(struct drm_encoder *drm_enc)
+ 
+ 	if (dpu_enc->disp_info.intf_type == INTF_DSI)
+ 		return msm_dsi_get_dsc_config(priv->kms->dsi[index]);
++	else if (dpu_enc->disp_info.intf_type == INTF_DP)
++		return msm_dp_get_dsc_config(priv->kms->dp[index]);
+ 
+ 	return NULL;
+ }
+ 
++static enum msm_mode_dsc_cfg dpu_encoder_get_mode_dsc_cfg(struct drm_encoder *drm_enc,
++			const struct drm_display_mode *mode)
++{
++	struct msm_drm_private *priv = drm_enc->dev->dev_private;
++	struct dpu_encoder_virt *dpu_enc = to_dpu_encoder_virt(drm_enc);
++	int index = dpu_enc->disp_info.h_tile_instance[0];
++
++	if (dpu_enc->disp_info.intf_type == INTF_DSI)
++		return msm_dsi_get_mode_dsc_cfg(priv->kms->dsi[index], mode);
++	else if (dpu_enc->disp_info.intf_type == INTF_DP)
++		return msm_dp_get_mode_dsc_cfg(priv->kms->dp[index], mode);
++
++	return 0;
++}
++
++static void dpu_encoder_set_dsc_enable(struct drm_encoder *drm_enc, int num_dsc)
++{
++	struct msm_drm_private *priv = drm_enc->dev->dev_private;
++	struct dpu_encoder_virt *dpu_enc = to_dpu_encoder_virt(drm_enc);
++	int index = dpu_enc->disp_info.h_tile_instance[0];
++
++	if (dpu_enc->disp_info.intf_type == INTF_DP)
++		msm_dp_set_dsc_enable(priv->kms->dp[index], num_dsc);
++}
++
+ void dpu_encoder_update_topology(struct drm_encoder *drm_enc,
+ 				 struct msm_display_topology *topology,
+ 				 struct drm_atomic_state *state,
+@@ -699,7 +726,7 @@ void dpu_encoder_update_topology(struct drm_encoder *drm_enc,
+ 	struct drm_connector *connector;
+ 	struct drm_connector_state *conn_state;
+ 	struct drm_framebuffer *fb;
+-	struct drm_dsc_config *dsc;
++	enum msm_mode_dsc_cfg dsc_cfg;
+ 
+ 	int i;
+ 
+@@ -707,10 +734,10 @@ void dpu_encoder_update_topology(struct drm_encoder *drm_enc,
+ 		if (dpu_enc->phys_encs[i])
+ 			topology->num_intf++;
+ 
+-	dsc = dpu_encoder_get_dsc_config(drm_enc);
++	dsc_cfg = dpu_encoder_get_mode_dsc_cfg(drm_enc, adj_mode);
+ 
+ 	/* We only support 2 DSC mode (with 2 LM and 1 INTF) */
+-	if (dsc) {
++	if (dsc_cfg >= MSM_MODE_DSC_PREFERRED) {
+ 		/*
+ 		 * Use 2 DSC encoders, 2 layer mixers and 1 or 2 interfaces
+ 		 * when Display Stream Compression (DSC) is enabled,
+@@ -1279,6 +1306,8 @@ static void dpu_encoder_virt_atomic_mode_set(struct drm_encoder *drm_enc,
+ 		}
+ 	}
+ 
++	dpu_encoder_set_dsc_enable(drm_enc, num_dsc);
++
+ 	dpu_enc->dsc_mask = dsc_mask;
+ 
+ 	if ((dpu_enc->disp_info.intf_type == INTF_WB && conn_state->writeback_job) ||
+@@ -1712,6 +1741,9 @@ static void _dpu_encoder_trigger_flush(struct drm_encoder *drm_enc,
+ 	if (extra_flush_bits && ctl->ops.update_pending_flush)
+ 		ctl->ops.update_pending_flush(ctl, extra_flush_bits);
+ 
++	if (ctl->ops.update_pending_flush_periph && dpu_encoder_needs_periph_flush(phys))
++		ctl->ops.update_pending_flush_periph(ctl, phys->hw_intf->idx);
++
+ 	ctl->ops.trigger_flush(ctl);
+ 
+ 	if (ctl->ops.get_pending_flush)
+diff --git a/drivers/gpu/drm/msm/dp/dp_display.c b/drivers/gpu/drm/msm/dp/dp_display.c
+index bbfe6f2aad38..87d31f4c6868 100644
+--- a/drivers/gpu/drm/msm/dp/dp_display.c
++++ b/drivers/gpu/drm/msm/dp/dp_display.c
+@@ -934,7 +934,7 @@ enum drm_mode_status msm_dp_bridge_mode_valid(struct drm_bridge *bridge,
+ 
+ 	msm_dp_display = container_of(dp, struct msm_dp_display_private, msm_dp_display);
+ 
+-	if ((drm_mode_is_420_only(&dp->connector->display_info, mode) &&
++	if ((drm_mode_is_420_only(info, mode) &&
+ 	     msm_dp_display->panel->vsc_sdp_supported) ||
+ 	     msm_dp_wide_bus_available(dp))
+ 		mode_pclk_khz /= 2;
+@@ -942,7 +942,7 @@ enum drm_mode_status msm_dp_bridge_mode_valid(struct drm_bridge *bridge,
+ 	if (mode_pclk_khz > DP_MAX_PIXEL_CLK_KHZ)
+ 		return MODE_CLOCK_HIGH;
+ 
+-	mode_bpp = dp->connector->display_info.bpc * num_components;
++	mode_bpp = info->bpc * num_components;
+ 	if (!mode_bpp)
+ 		mode_bpp = default_bpp;
+ 
+@@ -1515,7 +1515,11 @@ bool msm_dp_is_yuv_420_enabled(const struct msm_dp *msm_dp_display,
+ bool msm_dp_needs_periph_flush(const struct msm_dp *msm_dp_display,
+ 			       const struct drm_display_mode *mode)
+ {
+-	return msm_dp_is_yuv_420_enabled(msm_dp_display, mode);
++	struct msm_dp_display_private *dp;
++	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
++
++	return msm_dp_is_yuv_420_enabled(msm_dp_display, mode) ||
++				dp->panel->dsc_cap.enabled;
+ }
+ 
+ bool msm_dp_wide_bus_available(const struct msm_dp *msm_dp_display)
+@@ -1530,6 +1534,50 @@ bool msm_dp_wide_bus_available(const struct msm_dp *msm_dp_display)
+ 	return dp->wide_bus_supported;
+ }
+ 
++struct drm_dsc_config *msm_dp_get_dsc_config(struct msm_dp *msm_dp_display)
++{
++	struct msm_dp_display_private *dp;
++
++	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
++
++	if (dp->panel->dsc_cap.enabled)
++		return &dp->panel->msm_dp_mode.drm_dsc;
++
++	return NULL;
++}
++
++enum msm_mode_dsc_cfg msm_dp_get_mode_dsc_cfg(struct msm_dp *msm_dp_display,
++			const struct drm_display_mode *mode)
++{
++	const u32 num_components = 3, default_bpp = 24;
++	struct msm_dp_display_private *dp;
++	u32 mode_bpp;
++	struct msm_dp_display_mode_cfg mode_cfg;
++
++	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
++
++	if (!dp->panel->dsc_cap.supported)
++		return MSM_MODE_DSC_UNAVAILABLE;
++
++	mode_bpp = msm_dp_display->connector->display_info.bpc * num_components;
++	if (!mode_bpp)
++		mode_bpp = default_bpp;
++
++	mode_cfg = msm_dp_panel_get_mode_cfg(dp->panel,
++			mode_bpp, MSM_MODE_DSC_OPTIONAL, mode->clock);
++	return mode_cfg.dsc;
++}
++
++void msm_dp_set_dsc_enable(struct msm_dp *msm_dp_display, int num_dsc)
++{
++	struct msm_dp_display_private *dp;
++
++	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
++
++	dp->panel->dsc_cap.enabled = num_dsc > 0;
++	dp->panel->dsc_cap.num_dsc = num_dsc;
++}
++
+ u32 msm_dp_dsc_get_extra_width(const struct msm_dp *msm_dp_display)
+ {
+ 	struct msm_dp_display_private *dp;
+@@ -1673,15 +1721,6 @@ void msm_dp_bridge_atomic_enable(struct drm_bridge *drm_bridge,
+ 		return;
+ 	}
+ 
+-	rc = msm_dp_panel_init_panel_info(msm_dp_display->panel);
+-	if (rc) {
+-		DRM_ERROR("Failed to perform a mode set, rc=%d\n", rc);
+-		mutex_unlock(&msm_dp_display->event_mutex);
+-		return;
+-	}
+-
+-	hpd_state =  msm_dp_display->hpd_state;
+-
+ 	if (hpd_state == ST_DISPLAY_OFF) {
+ 		msm_dp_display_host_phy_init(msm_dp_display);
+ 		force_link_train = true;
+@@ -1759,6 +1798,7 @@ void msm_dp_bridge_mode_set(struct drm_bridge *drm_bridge,
+ 	struct msm_dp_display_private *msm_dp_display;
+ 	struct msm_dp_panel *msm_dp_panel;
+ 	struct msm_dp_display_mode *msm_dp_mode;
++	int rc;
+ 
+ 	msm_dp_display = container_of(dp, struct msm_dp_display_private, msm_dp_display);
+ 	msm_dp_panel = msm_dp_display->panel;
+@@ -1789,6 +1829,10 @@ void msm_dp_bridge_mode_set(struct drm_bridge *drm_bridge,
+ 	/* populate wide_bus_support to different layers */
+ 	msm_dp_display->ctrl->wide_bus_en =
+ 		msm_dp_mode->out_fmt_is_yuv_420 ? false : msm_dp_display->wide_bus_supported;
++
++	rc = msm_dp_panel_init_panel_info(msm_dp_display->panel);
++	if (rc)
++		DRM_ERROR("Failed to perform a mode set, rc=%d\n", rc);
+ }
+ 
+ void msm_dp_bridge_hpd_enable(struct drm_bridge *bridge)
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index c754c5c924ad..38c456848653 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -1149,6 +1149,9 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 				drm_mode->clock);
+ 	drm_dbg_dp(panel->drm_dev, "bpp = %d\n", mode_cfg->bpp);
+ 
++	mode_cfg->dsc = msm_dp_panel->dsc_cap.enabled ?
++				MSM_MODE_DSC_REQUIRED : MSM_MODE_DSC_UNAVAILABLE;
++
+ 	*mode_cfg = msm_dp_panel_get_mode_cfg(
+ 						      msm_dp_panel,
+ 						      mode_cfg->bpp,
+diff --git a/drivers/gpu/drm/msm/dsi/dsi.c b/drivers/gpu/drm/msm/dsi/dsi.c
+index d8bb40ef820e..6dab53b46050 100644
+--- a/drivers/gpu/drm/msm/dsi/dsi.c
++++ b/drivers/gpu/drm/msm/dsi/dsi.c
+@@ -17,6 +17,15 @@ struct drm_dsc_config *msm_dsi_get_dsc_config(struct msm_dsi *msm_dsi)
+ 	return msm_dsi_host_get_dsc_config(msm_dsi->host);
+ }
+ 
++enum msm_mode_dsc_cfg msm_dsi_get_mode_dsc_cfg(struct msm_dsi *msm_dsi,
++			const struct drm_display_mode *mode)
++{
++	if (msm_dsi_get_dsc_config(msm_dsi))
++		return MSM_MODE_DSC_REQUIRED;
++
++	return MSM_MODE_DSC_UNAVAILABLE;
++}
++
+ bool msm_dsi_wide_bus_enabled(struct msm_dsi *msm_dsi)
+ {
+ 	return msm_dsi_host_is_wide_bus_enabled(msm_dsi->host);
+diff --git a/drivers/gpu/drm/msm/msm_drv.h b/drivers/gpu/drm/msm/msm_drv.h
+index 43506c159b39..453e8bec2b18 100644
+--- a/drivers/gpu/drm/msm/msm_drv.h
++++ b/drivers/gpu/drm/msm/msm_drv.h
+@@ -312,6 +312,8 @@ bool msm_dsi_is_bonded_dsi(struct msm_dsi *msm_dsi);
+ bool msm_dsi_is_master_dsi(struct msm_dsi *msm_dsi);
+ bool msm_dsi_wide_bus_enabled(struct msm_dsi *msm_dsi);
+ struct drm_dsc_config *msm_dsi_get_dsc_config(struct msm_dsi *msm_dsi);
++enum msm_mode_dsc_cfg msm_dsi_get_mode_dsc_cfg(struct msm_dsi *msm_dsi,
++			const struct drm_display_mode *mode);
+ const char *msm_dsi_get_te_source(struct msm_dsi *msm_dsi);
+ #else
+ static inline void __init msm_dsi_register(void)
+@@ -351,6 +353,12 @@ static inline struct drm_dsc_config *msm_dsi_get_dsc_config(struct msm_dsi *msm_
+ 	return NULL;
+ }
+ 
++static inline enum msm_mode_dsc_cfg msm_dsi_get_mode_dsc_cfg(struct msm_dsi *msm_dsi,
++			const struct drm_display_mode *mode)
++{
++	return 0;
++}
++
+ static inline const char *msm_dsi_get_te_source(struct msm_dsi *msm_dsi)
+ {
+ 	return NULL;
+@@ -369,6 +377,10 @@ bool msm_dp_is_yuv_420_enabled(const struct msm_dp *dp_display,
+ bool msm_dp_needs_periph_flush(const struct msm_dp *dp_display,
+ 			       const struct drm_display_mode *mode);
+ bool msm_dp_wide_bus_available(const struct msm_dp *dp_display);
++struct drm_dsc_config *msm_dp_get_dsc_config(struct msm_dp *msm_dp);
++enum msm_mode_dsc_cfg msm_dp_get_mode_dsc_cfg(struct msm_dp *msm_dp,
++			const struct drm_display_mode *mode);
++void msm_dp_set_dsc_enable(struct msm_dp *msm_dp, int num_dsc);
+ u32 msm_dp_dsc_get_extra_width(const struct msm_dp *msm_dp_display);
+ u32 msm_dp_dsc_get_pclk_per_line(const struct msm_dp *dp_display);
+ 
+@@ -409,6 +421,21 @@ static inline bool msm_dp_wide_bus_available(const struct msm_dp *dp_display)
+ 	return false;
+ }
+ 
++static inline struct drm_dsc_config *msm_dp_get_dsc_config(struct msm_dp *msm_dp)
++{
++	return NULL;
++}
++
++static inline enum msm_mode_dsc_cfg msm_dp_get_mode_dsc_cfg(struct msm_dp *msm_dp,
++			const struct drm_display_mode *mode)
++{
++	return 0;
++}
++
++static inline void msm_dp_set_dsc_enable(struct msm_dp *msm_dp, int num_dsc)
++{
++}
++
+ static inline u32 msm_dp_dsc_get_extra_width(const struct msm_dp *msm_dp_display)
+ {
+ 	return 0;
+-- 
+2.54.0
+
+
+From 576d2e85c0863aae890fe02256bf1b54d8319cea Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 11:22:24 -0300
+Subject: [PATCH 08/16] drm/msm/dpu: move dsc prep to enable from kickoff
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c | 200 ++++++++++----------
+ 1 file changed, 100 insertions(+), 100 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+index f6d002750c88..c60401afdbf6 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+@@ -1353,6 +1353,103 @@ static void dpu_encoder_virt_atomic_mode_set(struct drm_encoder *drm_enc,
+ 	}
+ }
+ 
++static u32
++dpu_encoder_dsc_initial_line_calc(struct drm_dsc_config *dsc,
++				  u32 enc_ip_width)
++{
++	int ssm_delay, total_pixels, soft_slice_per_enc;
++
++	soft_slice_per_enc = enc_ip_width / dsc->slice_width;
++
++	/*
++	 * minimum number of initial line pixels is a sum of:
++	 * 1. sub-stream multiplexer delay (83 groups for 8bpc,
++	 *    91 for 10 bpc) * 3
++	 * 2. for two soft slice cases, add extra sub-stream multiplexer * 3
++	 * 3. the initial xmit delay
++	 * 4. total pipeline delay through the "lock step" of encoder (47)
++	 * 5. 6 additional pixels as the output of the rate buffer is
++	 *    48 bits wide
++	 */
++	ssm_delay = ((dsc->bits_per_component < 10) ? 84 : 92);
++	total_pixels = ssm_delay * 3 + dsc->initial_xmit_delay + 47;
++	if (soft_slice_per_enc > 1)
++		total_pixels += (ssm_delay * 3);
++	return DIV_ROUND_UP(total_pixels, dsc->slice_width);
++}
++
++static void dpu_encoder_dsc_pipe_cfg(struct dpu_hw_ctl *ctl,
++				     struct dpu_hw_dsc *hw_dsc,
++				     struct dpu_hw_pingpong *hw_pp,
++				     struct drm_dsc_config *dsc,
++				     u32 common_mode,
++				     u32 initial_lines)
++{
++	if (hw_dsc->ops.dsc_config)
++		hw_dsc->ops.dsc_config(hw_dsc, dsc, common_mode, initial_lines);
++
++	if (hw_dsc->ops.dsc_config_thresh)
++		hw_dsc->ops.dsc_config_thresh(hw_dsc, dsc);
++
++	if (hw_pp->ops.setup_dsc)
++		hw_pp->ops.setup_dsc(hw_pp);
++
++	if (hw_dsc->ops.dsc_bind_pingpong_blk)
++		hw_dsc->ops.dsc_bind_pingpong_blk(hw_dsc, hw_pp->idx);
++
++	if (hw_pp->ops.enable_dsc)
++		hw_pp->ops.enable_dsc(hw_pp);
++
++	if (ctl->ops.update_pending_flush_dsc)
++		ctl->ops.update_pending_flush_dsc(ctl, hw_dsc->idx);
++}
++
++static void dpu_encoder_prep_dsc(struct dpu_encoder_virt *dpu_enc,
++				 struct drm_dsc_config *dsc)
++{
++	struct dpu_encoder_phys *enc_master = dpu_enc->cur_master;
++	struct dpu_hw_ctl *ctl = enc_master->hw_ctl;
++	struct dpu_hw_dsc *hw_dsc[MAX_CHANNELS_PER_ENC];
++	struct dpu_hw_pingpong *hw_pp[MAX_CHANNELS_PER_ENC];
++	int this_frame_slices;
++	int intf_ip_w, enc_ip_w;
++	int dsc_common_mode;
++	int pic_width;
++	u32 initial_lines;
++	int num_dsc = 0;
++	int i;
++
++	for (i = 0; i < MAX_CHANNELS_PER_ENC; i++) {
++		hw_pp[i] = dpu_enc->hw_pp[i];
++		hw_dsc[i] = dpu_enc->hw_dsc[i];
++
++		if (!hw_pp[i] || !hw_dsc[i])
++			break;
++
++		num_dsc++;
++	}
++
++	pic_width = dsc->pic_width;
++
++	dsc_common_mode = 0;
++	if (num_dsc > 1)
++		dsc_common_mode |= DSC_MODE_SPLIT_PANEL;
++	if (dpu_encoder_use_dsc_merge(enc_master->parent))
++		dsc_common_mode |= DSC_MODE_MULTIPLEX;
++	if (enc_master->intf_mode == INTF_MODE_VIDEO)
++		dsc_common_mode |= DSC_MODE_VIDEO;
++
++	this_frame_slices = pic_width / dsc->slice_width;
++	intf_ip_w = this_frame_slices * dsc->slice_width;
++
++	enc_ip_w = intf_ip_w / num_dsc;
++	initial_lines = dpu_encoder_dsc_initial_line_calc(dsc, enc_ip_w);
++
++	for (i = 0; i < num_dsc; i++)
++		dpu_encoder_dsc_pipe_cfg(ctl, hw_dsc[i], hw_pp[i],
++					 dsc, dsc_common_mode, initial_lines);
++}
++
+ static void _dpu_encoder_virt_enable_helper(struct drm_encoder *drm_enc)
+ {
+ 	struct dpu_encoder_virt *dpu_enc = NULL;
+@@ -1388,6 +1485,9 @@ static void _dpu_encoder_virt_enable_helper(struct drm_encoder *drm_enc)
+ 			_dpu_encoder_setup_dither(dpu_enc->hw_pp[i], bpc);
+ 		}
+ 	}
++
++	if (dpu_enc->dsc)
++		dpu_encoder_prep_dsc(dpu_enc, dpu_enc->dsc);
+ }
+ 
+ /**
+@@ -2046,103 +2146,6 @@ int dpu_encoder_vsync_time(struct drm_encoder *drm_enc, ktime_t *wakeup_time)
+ 	return 0;
+ }
+ 
+-static u32
+-dpu_encoder_dsc_initial_line_calc(struct drm_dsc_config *dsc,
+-				  u32 enc_ip_width)
+-{
+-	int ssm_delay, total_pixels, soft_slice_per_enc;
+-
+-	soft_slice_per_enc = enc_ip_width / dsc->slice_width;
+-
+-	/*
+-	 * minimum number of initial line pixels is a sum of:
+-	 * 1. sub-stream multiplexer delay (83 groups for 8bpc,
+-	 *    91 for 10 bpc) * 3
+-	 * 2. for two soft slice cases, add extra sub-stream multiplexer * 3
+-	 * 3. the initial xmit delay
+-	 * 4. total pipeline delay through the "lock step" of encoder (47)
+-	 * 5. 6 additional pixels as the output of the rate buffer is
+-	 *    48 bits wide
+-	 */
+-	ssm_delay = ((dsc->bits_per_component < 10) ? 84 : 92);
+-	total_pixels = ssm_delay * 3 + dsc->initial_xmit_delay + 47;
+-	if (soft_slice_per_enc > 1)
+-		total_pixels += (ssm_delay * 3);
+-	return DIV_ROUND_UP(total_pixels, dsc->slice_width);
+-}
+-
+-static void dpu_encoder_dsc_pipe_cfg(struct dpu_hw_ctl *ctl,
+-				     struct dpu_hw_dsc *hw_dsc,
+-				     struct dpu_hw_pingpong *hw_pp,
+-				     struct drm_dsc_config *dsc,
+-				     u32 common_mode,
+-				     u32 initial_lines)
+-{
+-	if (hw_dsc->ops.dsc_config)
+-		hw_dsc->ops.dsc_config(hw_dsc, dsc, common_mode, initial_lines);
+-
+-	if (hw_dsc->ops.dsc_config_thresh)
+-		hw_dsc->ops.dsc_config_thresh(hw_dsc, dsc);
+-
+-	if (hw_pp->ops.setup_dsc)
+-		hw_pp->ops.setup_dsc(hw_pp);
+-
+-	if (hw_dsc->ops.dsc_bind_pingpong_blk)
+-		hw_dsc->ops.dsc_bind_pingpong_blk(hw_dsc, hw_pp->idx);
+-
+-	if (hw_pp->ops.enable_dsc)
+-		hw_pp->ops.enable_dsc(hw_pp);
+-
+-	if (ctl->ops.update_pending_flush_dsc)
+-		ctl->ops.update_pending_flush_dsc(ctl, hw_dsc->idx);
+-}
+-
+-static void dpu_encoder_prep_dsc(struct dpu_encoder_virt *dpu_enc,
+-				 struct drm_dsc_config *dsc)
+-{
+-	struct dpu_encoder_phys *enc_master = dpu_enc->cur_master;
+-	struct dpu_hw_ctl *ctl = enc_master->hw_ctl;
+-	struct dpu_hw_dsc *hw_dsc[MAX_CHANNELS_PER_ENC];
+-	struct dpu_hw_pingpong *hw_pp[MAX_CHANNELS_PER_ENC];
+-	int this_frame_slices;
+-	int intf_ip_w, enc_ip_w;
+-	int dsc_common_mode;
+-	int pic_width;
+-	u32 initial_lines;
+-	int num_dsc = 0;
+-	int i;
+-
+-	for (i = 0; i < MAX_CHANNELS_PER_ENC; i++) {
+-		hw_pp[i] = dpu_enc->hw_pp[i];
+-		hw_dsc[i] = dpu_enc->hw_dsc[i];
+-
+-		if (!hw_pp[i] || !hw_dsc[i])
+-			break;
+-
+-		num_dsc++;
+-	}
+-
+-	pic_width = dsc->pic_width;
+-
+-	dsc_common_mode = 0;
+-	if (num_dsc > 1)
+-		dsc_common_mode |= DSC_MODE_SPLIT_PANEL;
+-	if (dpu_encoder_use_dsc_merge(enc_master->parent))
+-		dsc_common_mode |= DSC_MODE_MULTIPLEX;
+-	if (enc_master->intf_mode == INTF_MODE_VIDEO)
+-		dsc_common_mode |= DSC_MODE_VIDEO;
+-
+-	this_frame_slices = pic_width / dsc->slice_width;
+-	intf_ip_w = this_frame_slices * dsc->slice_width;
+-
+-	enc_ip_w = intf_ip_w / num_dsc;
+-	initial_lines = dpu_encoder_dsc_initial_line_calc(dsc, enc_ip_w);
+-
+-	for (i = 0; i < num_dsc; i++)
+-		dpu_encoder_dsc_pipe_cfg(ctl, hw_dsc[i], hw_pp[i],
+-					 dsc, dsc_common_mode, initial_lines);
+-}
+-
+ /**
+  * dpu_encoder_prepare_for_kickoff - schedule double buffer flip of the ctl
+  *	path (i.e. ctl flush and start) at next appropriate time.
+@@ -2181,9 +2184,6 @@ void dpu_encoder_prepare_for_kickoff(struct drm_encoder *drm_enc)
+ 			dpu_encoder_helper_hw_reset(dpu_enc->phys_encs[i]);
+ 		}
+ 	}
+-
+-	if (dpu_enc->dsc)
+-		dpu_encoder_prep_dsc(dpu_enc, dpu_enc->dsc);
+ }
+ 
+ /**
+-- 
+2.54.0
+
+
+From e6a679baf46acd8cbe7bfe35c4dd601899d0acaf Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 11:33:02 -0300
+Subject: [PATCH 09/16] drm/msm/dpu: support single dsc enc alloc when possible
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.c    |  4 ++--
+ drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c | 14 +++++++++-----
+ 2 files changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.c
+index f8d8c2d7f9d6..ffe464a67719 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.c
+@@ -1408,8 +1408,8 @@ static struct msm_display_topology dpu_crtc_get_topology(
+ 
+ 	if (topology.num_intf == 2 && !topology.cwb_enabled)
+ 		topology.num_lm = 2;
+-	else if (topology.num_dsc == 2)
+-		topology.num_lm = 2;
++	else if (topology.num_dsc)
++		topology.num_lm = topology.num_dsc;
+ 	else if (dpu_kms->catalog->caps->has_3d_merge)
+ 		topology.num_lm = (mode->hdisplay > MAX_HDISPLAY_SPLIT) ? 2 : 1;
+ 	else
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+index c60401afdbf6..df66dcd90111 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+@@ -736,7 +736,6 @@ void dpu_encoder_update_topology(struct drm_encoder *drm_enc,
+ 
+ 	dsc_cfg = dpu_encoder_get_mode_dsc_cfg(drm_enc, adj_mode);
+ 
+-	/* We only support 2 DSC mode (with 2 LM and 1 INTF) */
+ 	if (dsc_cfg >= MSM_MODE_DSC_PREFERRED) {
+ 		/*
+ 		 * Use 2 DSC encoders, 2 layer mixers and 1 or 2 interfaces
+@@ -745,12 +744,17 @@ void dpu_encoder_update_topology(struct drm_encoder *drm_enc,
+ 		 * This is power-optimal and can drive up to (including) 4k
+ 		 * screens.
+ 		 */
+-		WARN(topology->num_intf > 2,
+-		     "DSC topology cannot support more than 2 interfaces\n");
+-		if (topology->num_intf >= 2 || dpu_kms->catalog->dsc_count >= 2)
++		if ((topology->num_intf == 2 ||
++					adj_mode->hdisplay > dpu_kms->catalog->caps->max_mixer_width) &&
++							dpu_kms->catalog->dsc_count >= 2)
+ 			topology->num_dsc = 2;
+-		else
++		else if (topology->num_intf == 1 &&
++					adj_mode->hdisplay <= dpu_kms->catalog->caps->max_mixer_width)
+ 			topology->num_dsc = 1;
++		else
++			WARN(1,
++					"dsc not supported for configuration num_intf=%d hdisplay=%d\n",
++					topology->num_intf, adj_mode->hdisplay);
+ 	}
+ 
+ 	connector = drm_atomic_get_new_connector_for_encoder(state, drm_enc);
+-- 
+2.54.0
+
+
+From 2fc80ddb163c95d67248bbc8a4d4cca4be5b46da Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 17:34:33 -0300
+Subject: [PATCH 10/16] drm/msm/dpu: update intf cmd cfg
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c
+index 99800dd2675b..30f4e853b592 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_hw_intf.c
+@@ -598,9 +598,13 @@ static void dpu_hw_intf_program_intf_cmd_cfg(struct dpu_hw_intf *intf,
+ 
+ 	if (cmd_mode_cfg->data_compress)
+ 		intf_cfg2 |= INTF_CFG2_DCE_DATA_COMPRESS;
++	else
++		intf_cfg2 &= ~INTF_CFG2_DCE_DATA_COMPRESS;
+ 
+ 	if (cmd_mode_cfg->wide_bus_en)
+ 		intf_cfg2 |= INTF_CFG2_DATABUS_WIDEN;
++	else
++		intf_cfg2 &= ~INTF_CFG2_DATABUS_WIDEN;
+ 
+ 	DPU_REG_WRITE(&intf->hw, INTF_CONFIG2, intf_cfg2);
+ }
+-- 
+2.54.0
+
+
+From 5b5123f9345afca1306e5d02fc6faea62834dcf3 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 17:35:25 -0300
+Subject: [PATCH 11/16] drm/msm/dpu: remove unused field from crtc
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.h | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.h b/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.h
+index 94392b9b9245..11c24cd9f1d0 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.h
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_crtc.h
+@@ -200,8 +200,6 @@ struct dpu_crtc {
+  * @new_perf: new performance state being requested
+  * @num_mixers    : Number of mixers in use
+  * @mixers        : List of active mixers
+- * @num_ctls      : Number of ctl paths in use
+- * @hw_ctls       : List of active ctl paths
+  * @crc_source    : CRC source
+  * @crc_frame_skip_count: Number of frames skipped before getting CRC
+  */
+@@ -220,9 +218,6 @@ struct dpu_crtc_state {
+ 	u32 num_mixers;
+ 	struct dpu_crtc_mixer mixers[CRTC_DUAL_MIXERS];
+ 
+-	u32 num_ctls;
+-	struct dpu_hw_ctl *hw_ctls[CRTC_DUAL_MIXERS];
+-
+ 	enum dpu_crtc_crc_source crc_source;
+ 	int crc_frame_skip_count;
+ };
+-- 
+2.54.0
+
+
+From 419bbae47d3e9fdd6f365eca899f6587425309b1 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 12:53:09 -0300
+Subject: [PATCH 12/16] drm/msm/dp: update tu calc
+
+---
+ drivers/gpu/drm/msm/Makefile        |   1 +
+ drivers/gpu/drm/msm/dp/dp_ctrl.c    | 798 +------------------------
+ drivers/gpu/drm/msm/dp/dp_tu_calc.c | 894 ++++++++++++++++++++++++++++
+ drivers/gpu/drm/msm/dp/dp_tu_calc.h |  40 ++
+ 4 files changed, 937 insertions(+), 796 deletions(-)
+ create mode 100644 drivers/gpu/drm/msm/dp/dp_tu_calc.c
+ create mode 100644 drivers/gpu/drm/msm/dp/dp_tu_calc.h
+
+diff --git a/drivers/gpu/drm/msm/Makefile b/drivers/gpu/drm/msm/Makefile
+index 8b94c5f1cb68..955044db1fbc 100644
+--- a/drivers/gpu/drm/msm/Makefile
++++ b/drivers/gpu/drm/msm/Makefile
+@@ -138,6 +138,7 @@ msm-$(CONFIG_DRM_MSM_KMS_FBDEV) += msm_fbdev.o
+ 
+ msm-display-$(CONFIG_DRM_MSM_DP)+= dp/dp_aux.o \
+ 	dp/dp_ctrl.o \
++	dp/dp_tu_calc.o \
+ 	dp/dp_debug.o \
+ 	dp/dp_display.o \
+ 	dp/dp_drm.o \
+diff --git a/drivers/gpu/drm/msm/dp/dp_ctrl.c b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+index 7900c02c999e..7169a4bc4a93 100644
+--- a/drivers/gpu/drm/msm/dp/dp_ctrl.c
++++ b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+@@ -25,6 +25,7 @@
+ #include "dp_reg.h"
+ #include "dp_ctrl.h"
+ #include "dp_link.h"
++#include "dp_tu_calc.h"
+ 
+ #define POLLING_SLEEP_US			1000
+ #define POLLING_TIMEOUT_US			10000
+@@ -81,35 +82,6 @@ enum {
+ 	DP_TRAINING_2,
+ };
+ 
+-struct msm_dp_tu_calc_input {
+-	u64 lclk;        /* 162, 270, 540 and 810 */
+-	u64 pclk_khz;    /* in KHz */
+-	u64 hactive;     /* active h-width */
+-	u64 hporch;      /* bp + fp + pulse */
+-	int nlanes;      /* no.of.lanes */
+-	int bpp;         /* bits */
+-	int pixel_enc;   /* 444, 420, 422 */
+-	int dsc_en;     /* dsc on/off */
+-	int async_en;   /* async mode */
+-	int fec_en;     /* fec */
+-	int compress_ratio; /* 2:1 = 200, 3:1 = 300, 3.75:1 = 375 */
+-	int num_of_dsc_slices; /* number of slices per line */
+-};
+-
+-struct msm_dp_vc_tu_mapping_table {
+-	u32 vic;
+-	u8 lanes;
+-	u8 lrate; /* DP_LINK_RATE -> 162(6), 270(10), 540(20), 810 (30) */
+-	u8 bpp;
+-	u8 valid_boundary_link;
+-	u16 delay_start_link;
+-	bool boundary_moderation_en;
+-	u8 valid_lower_boundary_link;
+-	u8 upper_boundary_count;
+-	u8 lower_boundary_count;
+-	u8 tu_size_minus1;
+-};
+-
+ struct msm_dp_ctrl_private {
+ 	struct msm_dp_ctrl msm_dp_ctrl;
+ 	struct drm_device *drm_dev;
+@@ -557,772 +529,6 @@ static void msm_dp_ctrl_configure_source_params(struct msm_dp_ctrl_private *ctrl
+ 	msm_dp_panel_timing_cfg(ctrl->panel, ctrl->msm_dp_ctrl.wide_bus_en);
+ }
+ 
+-/*
+- * The structure and few functions present below are IP/Hardware
+- * specific implementation. Most of the implementation will not
+- * have coding comments
+- */
+-struct tu_algo_data {
+-	s64 lclk_fp;
+-	s64 pclk_fp;
+-	s64 lwidth;
+-	s64 lwidth_fp;
+-	s64 hbp_relative_to_pclk;
+-	s64 hbp_relative_to_pclk_fp;
+-	int nlanes;
+-	int bpp;
+-	int pixelEnc;
+-	int dsc_en;
+-	int async_en;
+-	int bpc;
+-
+-	uint delay_start_link_extra_pixclk;
+-	int extra_buffer_margin;
+-	s64 ratio_fp;
+-	s64 original_ratio_fp;
+-
+-	s64 err_fp;
+-	s64 n_err_fp;
+-	s64 n_n_err_fp;
+-	int tu_size;
+-	int tu_size_desired;
+-	int tu_size_minus1;
+-
+-	int valid_boundary_link;
+-	s64 resulting_valid_fp;
+-	s64 total_valid_fp;
+-	s64 effective_valid_fp;
+-	s64 effective_valid_recorded_fp;
+-	int n_tus;
+-	int n_tus_per_lane;
+-	int paired_tus;
+-	int remainder_tus;
+-	int remainder_tus_upper;
+-	int remainder_tus_lower;
+-	int extra_bytes;
+-	int filler_size;
+-	int delay_start_link;
+-
+-	int extra_pclk_cycles;
+-	int extra_pclk_cycles_in_link_clk;
+-	s64 ratio_by_tu_fp;
+-	s64 average_valid2_fp;
+-	int new_valid_boundary_link;
+-	int remainder_symbols_exist;
+-	int n_symbols;
+-	s64 n_remainder_symbols_per_lane_fp;
+-	s64 last_partial_tu_fp;
+-	s64 TU_ratio_err_fp;
+-
+-	int n_tus_incl_last_incomplete_tu;
+-	int extra_pclk_cycles_tmp;
+-	int extra_pclk_cycles_in_link_clk_tmp;
+-	int extra_required_bytes_new_tmp;
+-	int filler_size_tmp;
+-	int lower_filler_size_tmp;
+-	int delay_start_link_tmp;
+-
+-	bool boundary_moderation_en;
+-	int boundary_mod_lower_err;
+-	int upper_boundary_count;
+-	int lower_boundary_count;
+-	int i_upper_boundary_count;
+-	int i_lower_boundary_count;
+-	int valid_lower_boundary_link;
+-	int even_distribution_BF;
+-	int even_distribution_legacy;
+-	int even_distribution;
+-	int min_hblank_violated;
+-	s64 delay_start_time_fp;
+-	s64 hbp_time_fp;
+-	s64 hactive_time_fp;
+-	s64 diff_abs_fp;
+-
+-	s64 ratio;
+-};
+-
+-static int _tu_param_compare(s64 a, s64 b)
+-{
+-	u32 a_sign;
+-	u32 b_sign;
+-	s64 a_temp, b_temp, minus_1;
+-
+-	if (a == b)
+-		return 0;
+-
+-	minus_1 = drm_fixp_from_fraction(-1, 1);
+-
+-	a_sign = (a >> 32) & 0x80000000 ? 1 : 0;
+-
+-	b_sign = (b >> 32) & 0x80000000 ? 1 : 0;
+-
+-	if (a_sign > b_sign)
+-		return 2;
+-	else if (b_sign > a_sign)
+-		return 1;
+-
+-	if (!a_sign && !b_sign) { /* positive */
+-		if (a > b)
+-			return 1;
+-		else
+-			return 2;
+-	} else { /* negative */
+-		a_temp = drm_fixp_mul(a, minus_1);
+-		b_temp = drm_fixp_mul(b, minus_1);
+-
+-		if (a_temp > b_temp)
+-			return 2;
+-		else
+-			return 1;
+-	}
+-}
+-
+-static void msm_dp_panel_update_tu_timings(struct msm_dp_tu_calc_input *in,
+-					struct tu_algo_data *tu)
+-{
+-	int nlanes = in->nlanes;
+-	int dsc_num_slices = in->num_of_dsc_slices;
+-	int dsc_num_bytes  = 0;
+-	int numerator;
+-	s64 pclk_dsc_fp;
+-	s64 dwidth_dsc_fp;
+-	s64 hbp_dsc_fp;
+-
+-	int tot_num_eoc_symbols = 0;
+-	int tot_num_hor_bytes   = 0;
+-	int tot_num_dummy_bytes = 0;
+-	int dwidth_dsc_bytes    = 0;
+-	int  eoc_bytes           = 0;
+-
+-	s64 temp1_fp, temp2_fp, temp3_fp;
+-
+-	tu->lclk_fp              = drm_fixp_from_fraction(in->lclk, 1);
+-	tu->pclk_fp              = drm_fixp_from_fraction(in->pclk_khz, 1000);
+-	tu->lwidth               = in->hactive;
+-	tu->hbp_relative_to_pclk = in->hporch;
+-	tu->nlanes               = in->nlanes;
+-	tu->bpp                  = in->bpp;
+-	tu->pixelEnc             = in->pixel_enc;
+-	tu->dsc_en               = in->dsc_en;
+-	tu->async_en             = in->async_en;
+-	tu->lwidth_fp            = drm_fixp_from_fraction(in->hactive, 1);
+-	tu->hbp_relative_to_pclk_fp = drm_fixp_from_fraction(in->hporch, 1);
+-
+-	if (tu->pixelEnc == 420) {
+-		temp1_fp = drm_fixp_from_fraction(2, 1);
+-		tu->pclk_fp = drm_fixp_div(tu->pclk_fp, temp1_fp);
+-		tu->lwidth_fp = drm_fixp_div(tu->lwidth_fp, temp1_fp);
+-		tu->hbp_relative_to_pclk_fp =
+-				drm_fixp_div(tu->hbp_relative_to_pclk_fp, 2);
+-	}
+-
+-	if (tu->pixelEnc == 422) {
+-		switch (tu->bpp) {
+-		case 24:
+-			tu->bpp = 16;
+-			tu->bpc = 8;
+-			break;
+-		case 30:
+-			tu->bpp = 20;
+-			tu->bpc = 10;
+-			break;
+-		default:
+-			tu->bpp = 16;
+-			tu->bpc = 8;
+-			break;
+-		}
+-	} else {
+-		tu->bpc = tu->bpp/3;
+-	}
+-
+-	if (!in->dsc_en)
+-		goto fec_check;
+-
+-	temp1_fp = drm_fixp_from_fraction(in->compress_ratio, 100);
+-	temp2_fp = drm_fixp_from_fraction(in->bpp, 1);
+-	temp3_fp = drm_fixp_div(temp2_fp, temp1_fp);
+-	temp2_fp = drm_fixp_mul(tu->lwidth_fp, temp3_fp);
+-
+-	temp1_fp = drm_fixp_from_fraction(8, 1);
+-	temp3_fp = drm_fixp_div(temp2_fp, temp1_fp);
+-
+-	numerator = drm_fixp2int(temp3_fp);
+-
+-	dsc_num_bytes  = numerator / dsc_num_slices;
+-	eoc_bytes           = dsc_num_bytes % nlanes;
+-	tot_num_eoc_symbols = nlanes * dsc_num_slices;
+-	tot_num_hor_bytes   = dsc_num_bytes * dsc_num_slices;
+-	tot_num_dummy_bytes = (nlanes - eoc_bytes) * dsc_num_slices;
+-
+-	if (dsc_num_bytes == 0)
+-		pr_info("incorrect no of bytes per slice=%d\n", dsc_num_bytes);
+-
+-	dwidth_dsc_bytes = (tot_num_hor_bytes +
+-				tot_num_eoc_symbols +
+-				(eoc_bytes == 0 ? 0 : tot_num_dummy_bytes));
+-
+-	dwidth_dsc_fp = drm_fixp_from_fraction(dwidth_dsc_bytes, 3);
+-
+-	temp2_fp = drm_fixp_mul(tu->pclk_fp, dwidth_dsc_fp);
+-	temp1_fp = drm_fixp_div(temp2_fp, tu->lwidth_fp);
+-	pclk_dsc_fp = temp1_fp;
+-
+-	temp1_fp = drm_fixp_div(pclk_dsc_fp, tu->pclk_fp);
+-	temp2_fp = drm_fixp_mul(tu->hbp_relative_to_pclk_fp, temp1_fp);
+-	hbp_dsc_fp = temp2_fp;
+-
+-	/* output */
+-	tu->pclk_fp = pclk_dsc_fp;
+-	tu->lwidth_fp = dwidth_dsc_fp;
+-	tu->hbp_relative_to_pclk_fp = hbp_dsc_fp;
+-
+-fec_check:
+-	if (in->fec_en) {
+-		temp1_fp = drm_fixp_from_fraction(976, 1000); /* 0.976 */
+-		tu->lclk_fp = drm_fixp_mul(tu->lclk_fp, temp1_fp);
+-	}
+-}
+-
+-static void _tu_valid_boundary_calc(struct tu_algo_data *tu)
+-{
+-	s64 temp1_fp, temp2_fp, temp, temp1, temp2;
+-	int compare_result_1, compare_result_2, compare_result_3;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
+-	temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
+-
+-	tu->new_valid_boundary_link = drm_fixp2int_ceil(temp2_fp);
+-
+-	temp = (tu->i_upper_boundary_count *
+-				tu->new_valid_boundary_link +
+-				tu->i_lower_boundary_count *
+-				(tu->new_valid_boundary_link-1));
+-	tu->average_valid2_fp = drm_fixp_from_fraction(temp,
+-					(tu->i_upper_boundary_count +
+-					tu->i_lower_boundary_count));
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
+-	temp2_fp = tu->lwidth_fp;
+-	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
+-	temp2_fp = drm_fixp_div(temp1_fp, tu->average_valid2_fp);
+-	tu->n_tus = drm_fixp2int(temp2_fp);
+-	if ((temp2_fp & 0xFFFFFFFF) > 0xFFFFF000)
+-		tu->n_tus += 1;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->n_tus, 1);
+-	temp2_fp = drm_fixp_mul(temp1_fp, tu->average_valid2_fp);
+-	temp1_fp = drm_fixp_from_fraction(tu->n_symbols, 1);
+-	temp2_fp = temp1_fp - temp2_fp;
+-	temp1_fp = drm_fixp_from_fraction(tu->nlanes, 1);
+-	temp2_fp = drm_fixp_div(temp2_fp, temp1_fp);
+-	tu->n_remainder_symbols_per_lane_fp = temp2_fp;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
+-	tu->last_partial_tu_fp =
+-			drm_fixp_div(tu->n_remainder_symbols_per_lane_fp,
+-					temp1_fp);
+-
+-	if (tu->n_remainder_symbols_per_lane_fp != 0)
+-		tu->remainder_symbols_exist = 1;
+-	else
+-		tu->remainder_symbols_exist = 0;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->n_tus, tu->nlanes);
+-	tu->n_tus_per_lane = drm_fixp2int(temp1_fp);
+-
+-	tu->paired_tus = (int)((tu->n_tus_per_lane) /
+-					(tu->i_upper_boundary_count +
+-					 tu->i_lower_boundary_count));
+-
+-	tu->remainder_tus = tu->n_tus_per_lane - tu->paired_tus *
+-						(tu->i_upper_boundary_count +
+-						tu->i_lower_boundary_count);
+-
+-	if ((tu->remainder_tus - tu->i_upper_boundary_count) > 0) {
+-		tu->remainder_tus_upper = tu->i_upper_boundary_count;
+-		tu->remainder_tus_lower = tu->remainder_tus -
+-						tu->i_upper_boundary_count;
+-	} else {
+-		tu->remainder_tus_upper = tu->remainder_tus;
+-		tu->remainder_tus_lower = 0;
+-	}
+-
+-	temp = tu->paired_tus * (tu->i_upper_boundary_count *
+-				tu->new_valid_boundary_link +
+-				tu->i_lower_boundary_count *
+-				(tu->new_valid_boundary_link - 1)) +
+-				(tu->remainder_tus_upper *
+-				 tu->new_valid_boundary_link) +
+-				(tu->remainder_tus_lower *
+-				(tu->new_valid_boundary_link - 1));
+-	tu->total_valid_fp = drm_fixp_from_fraction(temp, 1);
+-
+-	if (tu->remainder_symbols_exist) {
+-		temp1_fp = tu->total_valid_fp +
+-				tu->n_remainder_symbols_per_lane_fp;
+-		temp2_fp = drm_fixp_from_fraction(tu->n_tus_per_lane, 1);
+-		temp2_fp = temp2_fp + tu->last_partial_tu_fp;
+-		temp1_fp = drm_fixp_div(temp1_fp, temp2_fp);
+-	} else {
+-		temp2_fp = drm_fixp_from_fraction(tu->n_tus_per_lane, 1);
+-		temp1_fp = drm_fixp_div(tu->total_valid_fp, temp2_fp);
+-	}
+-	tu->effective_valid_fp = temp1_fp;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
+-	temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
+-	tu->n_n_err_fp = tu->effective_valid_fp - temp2_fp;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
+-	temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
+-	tu->n_err_fp = tu->average_valid2_fp - temp2_fp;
+-
+-	tu->even_distribution = tu->n_tus % tu->nlanes == 0 ? 1 : 0;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
+-	temp2_fp = tu->lwidth_fp;
+-	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
+-	temp2_fp = drm_fixp_div(temp1_fp, tu->average_valid2_fp);
+-
+-	if (temp2_fp)
+-		tu->n_tus_incl_last_incomplete_tu = drm_fixp2int_ceil(temp2_fp);
+-	else
+-		tu->n_tus_incl_last_incomplete_tu = 0;
+-
+-	temp1 = 0;
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
+-	temp2_fp = drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
+-	temp1_fp = tu->average_valid2_fp - temp2_fp;
+-	temp2_fp = drm_fixp_from_fraction(tu->n_tus_incl_last_incomplete_tu, 1);
+-	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
+-
+-	if (temp1_fp)
+-		temp1 = drm_fixp2int_ceil(temp1_fp);
+-
+-	temp = tu->i_upper_boundary_count * tu->nlanes;
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
+-	temp2_fp = drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
+-	temp1_fp = drm_fixp_from_fraction(tu->new_valid_boundary_link, 1);
+-	temp2_fp = temp1_fp - temp2_fp;
+-	temp1_fp = drm_fixp_from_fraction(temp, 1);
+-	temp2_fp = drm_fixp_mul(temp1_fp, temp2_fp);
+-
+-	if (temp2_fp)
+-		temp2 = drm_fixp2int_ceil(temp2_fp);
+-	else
+-		temp2 = 0;
+-	tu->extra_required_bytes_new_tmp = (int)(temp1 + temp2);
+-
+-	temp1_fp = drm_fixp_from_fraction(8, tu->bpp);
+-	temp2_fp = drm_fixp_from_fraction(
+-	tu->extra_required_bytes_new_tmp, 1);
+-	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
+-
+-	if (temp1_fp)
+-		tu->extra_pclk_cycles_tmp = drm_fixp2int_ceil(temp1_fp);
+-	else
+-		tu->extra_pclk_cycles_tmp = 0;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->extra_pclk_cycles_tmp, 1);
+-	temp2_fp = drm_fixp_div(tu->lclk_fp, tu->pclk_fp);
+-	temp1_fp = drm_fixp_mul(temp1_fp, temp2_fp);
+-
+-	if (temp1_fp)
+-		tu->extra_pclk_cycles_in_link_clk_tmp =
+-						drm_fixp2int_ceil(temp1_fp);
+-	else
+-		tu->extra_pclk_cycles_in_link_clk_tmp = 0;
+-
+-	tu->filler_size_tmp = tu->tu_size - tu->new_valid_boundary_link;
+-
+-	tu->lower_filler_size_tmp = tu->filler_size_tmp + 1;
+-
+-	tu->delay_start_link_tmp = tu->extra_pclk_cycles_in_link_clk_tmp +
+-					tu->lower_filler_size_tmp +
+-					tu->extra_buffer_margin;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->delay_start_link_tmp, 1);
+-	tu->delay_start_time_fp = drm_fixp_div(temp1_fp, tu->lclk_fp);
+-
+-	compare_result_1 = _tu_param_compare(tu->n_n_err_fp, tu->diff_abs_fp);
+-	if (compare_result_1 == 2)
+-		compare_result_1 = 1;
+-	else
+-		compare_result_1 = 0;
+-
+-	compare_result_2 = _tu_param_compare(tu->n_n_err_fp, tu->err_fp);
+-	if (compare_result_2 == 2)
+-		compare_result_2 = 1;
+-	else
+-		compare_result_2 = 0;
+-
+-	compare_result_3 = _tu_param_compare(tu->hbp_time_fp,
+-					tu->delay_start_time_fp);
+-	if (compare_result_3 == 2)
+-		compare_result_3 = 0;
+-	else
+-		compare_result_3 = 1;
+-
+-	if (((tu->even_distribution == 1) ||
+-			((tu->even_distribution_BF == 0) &&
+-			(tu->even_distribution_legacy == 0))) &&
+-			tu->n_err_fp >= 0 && tu->n_n_err_fp >= 0 &&
+-			compare_result_2 &&
+-			(compare_result_1 || (tu->min_hblank_violated == 1)) &&
+-			(tu->new_valid_boundary_link - 1) > 0 &&
+-			compare_result_3 &&
+-			(tu->delay_start_link_tmp <= 1023)) {
+-		tu->upper_boundary_count = tu->i_upper_boundary_count;
+-		tu->lower_boundary_count = tu->i_lower_boundary_count;
+-		tu->err_fp = tu->n_n_err_fp;
+-		tu->boundary_moderation_en = true;
+-		tu->tu_size_desired = tu->tu_size;
+-		tu->valid_boundary_link = tu->new_valid_boundary_link;
+-		tu->effective_valid_recorded_fp = tu->effective_valid_fp;
+-		tu->even_distribution_BF = 1;
+-		tu->delay_start_link = tu->delay_start_link_tmp;
+-	} else if (tu->boundary_mod_lower_err == 0) {
+-		compare_result_1 = _tu_param_compare(tu->n_n_err_fp,
+-							tu->diff_abs_fp);
+-		if (compare_result_1 == 2)
+-			tu->boundary_mod_lower_err = 1;
+-	}
+-}
+-
+-static void _dp_ctrl_calc_tu(struct msm_dp_ctrl_private *ctrl,
+-				struct msm_dp_tu_calc_input *in,
+-				struct msm_dp_vc_tu_mapping_table *tu_table)
+-{
+-	struct tu_algo_data *tu;
+-	int compare_result_1, compare_result_2;
+-	u64 temp = 0;
+-	s64 temp_fp = 0, temp1_fp = 0, temp2_fp = 0;
+-
+-	s64 LCLK_FAST_SKEW_fp = drm_fixp_from_fraction(6, 10000); /* 0.0006 */
+-	s64 const_p49_fp = drm_fixp_from_fraction(49, 100); /* 0.49 */
+-	s64 const_p56_fp = drm_fixp_from_fraction(56, 100); /* 0.56 */
+-	s64 RATIO_SCALE_fp = drm_fixp_from_fraction(1001, 1000);
+-
+-	u8 DP_BRUTE_FORCE = 1;
+-	s64 BRUTE_FORCE_THRESHOLD_fp = drm_fixp_from_fraction(1, 10); /* 0.1 */
+-	uint EXTRA_PIXCLK_CYCLE_DELAY = 4;
+-	uint HBLANK_MARGIN = 4;
+-
+-	tu = kzalloc_obj(*tu);
+-	if (!tu)
+-		return;
+-
+-	msm_dp_panel_update_tu_timings(in, tu);
+-
+-	tu->err_fp = drm_fixp_from_fraction(1000, 1); /* 1000 */
+-
+-	temp1_fp = drm_fixp_from_fraction(4, 1);
+-	temp2_fp = drm_fixp_mul(temp1_fp, tu->lclk_fp);
+-	temp_fp = drm_fixp_div(temp2_fp, tu->pclk_fp);
+-	tu->extra_buffer_margin = drm_fixp2int_ceil(temp_fp);
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
+-	temp2_fp = drm_fixp_mul(tu->pclk_fp, temp1_fp);
+-	temp1_fp = drm_fixp_from_fraction(tu->nlanes, 1);
+-	temp2_fp = drm_fixp_div(temp2_fp, temp1_fp);
+-	tu->ratio_fp = drm_fixp_div(temp2_fp, tu->lclk_fp);
+-
+-	tu->original_ratio_fp = tu->ratio_fp;
+-	tu->boundary_moderation_en = false;
+-	tu->upper_boundary_count = 0;
+-	tu->lower_boundary_count = 0;
+-	tu->i_upper_boundary_count = 0;
+-	tu->i_lower_boundary_count = 0;
+-	tu->valid_lower_boundary_link = 0;
+-	tu->even_distribution_BF = 0;
+-	tu->even_distribution_legacy = 0;
+-	tu->even_distribution = 0;
+-	tu->delay_start_time_fp = 0;
+-
+-	tu->err_fp = drm_fixp_from_fraction(1000, 1);
+-	tu->n_err_fp = 0;
+-	tu->n_n_err_fp = 0;
+-
+-	tu->ratio = drm_fixp2int(tu->ratio_fp);
+-	temp1_fp = drm_fixp_from_fraction(tu->nlanes, 1);
+-	div64_u64_rem(tu->lwidth_fp, temp1_fp, &temp2_fp);
+-	if (temp2_fp != 0 &&
+-			!tu->ratio && tu->dsc_en == 0) {
+-		tu->ratio_fp = drm_fixp_mul(tu->ratio_fp, RATIO_SCALE_fp);
+-		tu->ratio = drm_fixp2int(tu->ratio_fp);
+-		if (tu->ratio)
+-			tu->ratio_fp = drm_fixp_from_fraction(1, 1);
+-	}
+-
+-	if (tu->ratio > 1)
+-		tu->ratio = 1;
+-
+-	if (tu->ratio == 1)
+-		goto tu_size_calc;
+-
+-	compare_result_1 = _tu_param_compare(tu->ratio_fp, const_p49_fp);
+-	if (!compare_result_1 || compare_result_1 == 1)
+-		compare_result_1 = 1;
+-	else
+-		compare_result_1 = 0;
+-
+-	compare_result_2 = _tu_param_compare(tu->ratio_fp, const_p56_fp);
+-	if (!compare_result_2 || compare_result_2 == 2)
+-		compare_result_2 = 1;
+-	else
+-		compare_result_2 = 0;
+-
+-	if (tu->dsc_en && compare_result_1 && compare_result_2) {
+-		HBLANK_MARGIN += 4;
+-		drm_dbg_dp(ctrl->drm_dev,
+-			"increase HBLANK_MARGIN to %d\n", HBLANK_MARGIN);
+-	}
+-
+-tu_size_calc:
+-	for (tu->tu_size = 32; tu->tu_size <= 64; tu->tu_size++) {
+-		temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
+-		temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
+-		temp = drm_fixp2int_ceil(temp2_fp);
+-		temp1_fp = drm_fixp_from_fraction(temp, 1);
+-		tu->n_err_fp = temp1_fp - temp2_fp;
+-
+-		if (tu->n_err_fp < tu->err_fp) {
+-			tu->err_fp = tu->n_err_fp;
+-			tu->tu_size_desired = tu->tu_size;
+-		}
+-	}
+-
+-	tu->tu_size_minus1 = tu->tu_size_desired - 1;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size_desired, 1);
+-	temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
+-	tu->valid_boundary_link = drm_fixp2int_ceil(temp2_fp);
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
+-	temp2_fp = tu->lwidth_fp;
+-	temp2_fp = drm_fixp_mul(temp2_fp, temp1_fp);
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->valid_boundary_link, 1);
+-	temp2_fp = drm_fixp_div(temp2_fp, temp1_fp);
+-	tu->n_tus = drm_fixp2int(temp2_fp);
+-	if ((temp2_fp & 0xFFFFFFFF) > 0xFFFFF000)
+-		tu->n_tus += 1;
+-
+-	tu->even_distribution_legacy = tu->n_tus % tu->nlanes == 0 ? 1 : 0;
+-
+-	drm_dbg_dp(ctrl->drm_dev,
+-			"n_sym = %d, num_of_tus = %d\n",
+-			tu->valid_boundary_link, tu->n_tus);
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size_desired, 1);
+-	temp2_fp = drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
+-	temp1_fp = drm_fixp_from_fraction(tu->valid_boundary_link, 1);
+-	temp2_fp = temp1_fp - temp2_fp;
+-	temp1_fp = drm_fixp_from_fraction(tu->n_tus + 1, 1);
+-	temp2_fp = drm_fixp_mul(temp1_fp, temp2_fp);
+-
+-	temp = drm_fixp2int(temp2_fp);
+-	if (temp && temp2_fp)
+-		tu->extra_bytes = drm_fixp2int_ceil(temp2_fp);
+-	else
+-		tu->extra_bytes = 0;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->extra_bytes, 1);
+-	temp2_fp = drm_fixp_from_fraction(8, tu->bpp);
+-	temp1_fp = drm_fixp_mul(temp1_fp, temp2_fp);
+-
+-	if (temp && temp1_fp)
+-		tu->extra_pclk_cycles = drm_fixp2int_ceil(temp1_fp);
+-	else
+-		tu->extra_pclk_cycles = drm_fixp2int(temp1_fp);
+-
+-	temp1_fp = drm_fixp_div(tu->lclk_fp, tu->pclk_fp);
+-	temp2_fp = drm_fixp_from_fraction(tu->extra_pclk_cycles, 1);
+-	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
+-
+-	if (temp1_fp)
+-		tu->extra_pclk_cycles_in_link_clk = drm_fixp2int_ceil(temp1_fp);
+-	else
+-		tu->extra_pclk_cycles_in_link_clk = drm_fixp2int(temp1_fp);
+-
+-	tu->filler_size = tu->tu_size_desired - tu->valid_boundary_link;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size_desired, 1);
+-	tu->ratio_by_tu_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
+-
+-	tu->delay_start_link = tu->extra_pclk_cycles_in_link_clk +
+-				tu->filler_size + tu->extra_buffer_margin;
+-
+-	tu->resulting_valid_fp =
+-			drm_fixp_from_fraction(tu->valid_boundary_link, 1);
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->tu_size_desired, 1);
+-	temp2_fp = drm_fixp_div(tu->resulting_valid_fp, temp1_fp);
+-	tu->TU_ratio_err_fp = temp2_fp - tu->original_ratio_fp;
+-
+-	temp1_fp = drm_fixp_from_fraction(HBLANK_MARGIN, 1);
+-	temp1_fp = tu->hbp_relative_to_pclk_fp - temp1_fp;
+-	tu->hbp_time_fp = drm_fixp_div(temp1_fp, tu->pclk_fp);
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->delay_start_link, 1);
+-	tu->delay_start_time_fp = drm_fixp_div(temp1_fp, tu->lclk_fp);
+-
+-	compare_result_1 = _tu_param_compare(tu->hbp_time_fp,
+-					tu->delay_start_time_fp);
+-	if (compare_result_1 == 2) /* if (hbp_time_fp < delay_start_time_fp) */
+-		tu->min_hblank_violated = 1;
+-
+-	tu->hactive_time_fp = drm_fixp_div(tu->lwidth_fp, tu->pclk_fp);
+-
+-	compare_result_2 = _tu_param_compare(tu->hactive_time_fp,
+-						tu->delay_start_time_fp);
+-	if (compare_result_2 == 2)
+-		tu->min_hblank_violated = 1;
+-
+-	tu->delay_start_time_fp = 0;
+-
+-	/* brute force */
+-
+-	tu->delay_start_link_extra_pixclk = EXTRA_PIXCLK_CYCLE_DELAY;
+-	tu->diff_abs_fp = tu->resulting_valid_fp - tu->ratio_by_tu_fp;
+-
+-	temp = drm_fixp2int(tu->diff_abs_fp);
+-	if (!temp && tu->diff_abs_fp <= 0xffff)
+-		tu->diff_abs_fp = 0;
+-
+-	/* if(diff_abs < 0) diff_abs *= -1 */
+-	if (tu->diff_abs_fp < 0)
+-		tu->diff_abs_fp = drm_fixp_mul(tu->diff_abs_fp, -1);
+-
+-	tu->boundary_mod_lower_err = 0;
+-	if ((tu->diff_abs_fp != 0 &&
+-			((tu->diff_abs_fp > BRUTE_FORCE_THRESHOLD_fp) ||
+-			 (tu->even_distribution_legacy == 0) ||
+-			 (DP_BRUTE_FORCE == 1))) ||
+-			(tu->min_hblank_violated == 1)) {
+-		do {
+-			tu->err_fp = drm_fixp_from_fraction(1000, 1);
+-
+-			temp1_fp = drm_fixp_div(tu->lclk_fp, tu->pclk_fp);
+-			temp2_fp = drm_fixp_from_fraction(
+-					tu->delay_start_link_extra_pixclk, 1);
+-			temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
+-
+-			if (temp1_fp)
+-				tu->extra_buffer_margin =
+-					drm_fixp2int_ceil(temp1_fp);
+-			else
+-				tu->extra_buffer_margin = 0;
+-
+-			temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
+-			temp1_fp = drm_fixp_mul(tu->lwidth_fp, temp1_fp);
+-
+-			if (temp1_fp)
+-				tu->n_symbols = drm_fixp2int_ceil(temp1_fp);
+-			else
+-				tu->n_symbols = 0;
+-
+-			for (tu->tu_size = 32; tu->tu_size <= 64; tu->tu_size++) {
+-				for (tu->i_upper_boundary_count = 1;
+-					tu->i_upper_boundary_count <= 15;
+-					tu->i_upper_boundary_count++) {
+-					for (tu->i_lower_boundary_count = 1;
+-						tu->i_lower_boundary_count <= 15;
+-						tu->i_lower_boundary_count++) {
+-						_tu_valid_boundary_calc(tu);
+-					}
+-				}
+-			}
+-			tu->delay_start_link_extra_pixclk--;
+-		} while (tu->boundary_moderation_en != true &&
+-			tu->boundary_mod_lower_err == 1 &&
+-			tu->delay_start_link_extra_pixclk != 0);
+-
+-		if (tu->boundary_moderation_en == true) {
+-			temp1_fp = drm_fixp_from_fraction(
+-					(tu->upper_boundary_count *
+-					tu->valid_boundary_link +
+-					tu->lower_boundary_count *
+-					(tu->valid_boundary_link - 1)), 1);
+-			temp2_fp = drm_fixp_from_fraction(
+-					(tu->upper_boundary_count +
+-					tu->lower_boundary_count), 1);
+-			tu->resulting_valid_fp =
+-					drm_fixp_div(temp1_fp, temp2_fp);
+-
+-			temp1_fp = drm_fixp_from_fraction(
+-					tu->tu_size_desired, 1);
+-			tu->ratio_by_tu_fp =
+-				drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
+-
+-			tu->valid_lower_boundary_link =
+-				tu->valid_boundary_link - 1;
+-
+-			temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
+-			temp1_fp = drm_fixp_mul(tu->lwidth_fp, temp1_fp);
+-			temp2_fp = drm_fixp_div(temp1_fp,
+-						tu->resulting_valid_fp);
+-			tu->n_tus = drm_fixp2int(temp2_fp);
+-
+-			tu->tu_size_minus1 = tu->tu_size_desired - 1;
+-			tu->even_distribution_BF = 1;
+-
+-			temp1_fp =
+-				drm_fixp_from_fraction(tu->tu_size_desired, 1);
+-			temp2_fp =
+-				drm_fixp_div(tu->resulting_valid_fp, temp1_fp);
+-			tu->TU_ratio_err_fp = temp2_fp - tu->original_ratio_fp;
+-		}
+-	}
+-
+-	temp2_fp = drm_fixp_mul(LCLK_FAST_SKEW_fp, tu->lwidth_fp);
+-
+-	if (temp2_fp)
+-		temp = drm_fixp2int_ceil(temp2_fp);
+-	else
+-		temp = 0;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->nlanes, 1);
+-	temp2_fp = drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
+-	temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
+-	temp2_fp = drm_fixp_div(temp1_fp, temp2_fp);
+-	temp1_fp = drm_fixp_from_fraction(temp, 1);
+-	temp2_fp = drm_fixp_mul(temp1_fp, temp2_fp);
+-	temp = drm_fixp2int(temp2_fp);
+-
+-	if (tu->async_en)
+-		tu->delay_start_link += (int)temp;
+-
+-	temp1_fp = drm_fixp_from_fraction(tu->delay_start_link, 1);
+-	tu->delay_start_time_fp = drm_fixp_div(temp1_fp, tu->lclk_fp);
+-
+-	/* OUTPUTS */
+-	tu_table->valid_boundary_link       = tu->valid_boundary_link;
+-	tu_table->delay_start_link          = tu->delay_start_link;
+-	tu_table->boundary_moderation_en    = tu->boundary_moderation_en;
+-	tu_table->valid_lower_boundary_link = tu->valid_lower_boundary_link;
+-	tu_table->upper_boundary_count      = tu->upper_boundary_count;
+-	tu_table->lower_boundary_count      = tu->lower_boundary_count;
+-	tu_table->tu_size_minus1            = tu->tu_size_minus1;
+-
+-	drm_dbg_dp(ctrl->drm_dev, "TU: valid_boundary_link: %d\n",
+-				tu_table->valid_boundary_link);
+-	drm_dbg_dp(ctrl->drm_dev, "TU: delay_start_link: %d\n",
+-				tu_table->delay_start_link);
+-	drm_dbg_dp(ctrl->drm_dev, "TU: boundary_moderation_en: %d\n",
+-			tu_table->boundary_moderation_en);
+-	drm_dbg_dp(ctrl->drm_dev, "TU: valid_lower_boundary_link: %d\n",
+-			tu_table->valid_lower_boundary_link);
+-	drm_dbg_dp(ctrl->drm_dev, "TU: upper_boundary_count: %d\n",
+-			tu_table->upper_boundary_count);
+-	drm_dbg_dp(ctrl->drm_dev, "TU: lower_boundary_count: %d\n",
+-			tu_table->lower_boundary_count);
+-	drm_dbg_dp(ctrl->drm_dev, "TU: tu_size_minus1: %d\n",
+-			tu_table->tu_size_minus1);
+-
+-	kfree(tu);
+-}
+-
+ static void msm_dp_ctrl_calc_tu_parameters(struct msm_dp_ctrl_private *ctrl,
+ 		struct msm_dp_vc_tu_mapping_table *tu_table)
+ {
+@@ -1344,7 +550,7 @@ static void msm_dp_ctrl_calc_tu_parameters(struct msm_dp_ctrl_private *ctrl,
+ 	in.num_of_dsc_slices = ctrl->panel->msm_dp_mode.drm_dsc.slice_count;
+ 	in.compress_ratio = 100 * MSM_DP_DSC_COMP_RATIO;
+ 
+-	_dp_ctrl_calc_tu(ctrl, &in, tu_table);
++	msm_dp_ctrl_calc_tu(ctrl->drm_dev, &in, tu_table);
+ }
+ 
+ static void msm_dp_ctrl_setup_tr_unit(struct msm_dp_ctrl_private *ctrl)
+diff --git a/drivers/gpu/drm/msm/dp/dp_tu_calc.c b/drivers/gpu/drm/msm/dp/dp_tu_calc.c
+new file mode 100644
+index 000000000000..2aa607c03492
+--- /dev/null
++++ b/drivers/gpu/drm/msm/dp/dp_tu_calc.c
+@@ -0,0 +1,894 @@
++#include "dp_tu_calc.h"
++
++#include <drm/drm_fixed.h>
++#include <drm/drm_print.h>
++
++/*
++ * The structure and few functions present below are IP/Hardware
++ * specific implementation. Most of the implementation will not
++ * have coding comments
++ */
++struct tu_algo_data {
++	s64 lclk_fp;
++	s64 orig_lclk_fp;
++	s64 pclk_fp;
++	s64 orig_pclk_fp;
++	s64 lwidth;
++	s64 lwidth_fp;
++	int orig_lwidth;
++	s64 hbp_relative_to_pclk;
++	s64 hbp_relative_to_pclk_fp;
++	int nlanes;
++	int orig_hbp;
++	int bpp;
++	int pixelEnc;
++	int dsc_en;
++	int async_en;
++	int fec_en;
++	int bpc;
++
++	int rb2;
++	uint delay_start_link_extra_pixclk;
++	int extra_buffer_margin;
++	s64 ratio_fp;
++	s64 original_ratio_fp;
++
++	s64 err_fp;
++	s64 n_err_fp;
++	s64 n_n_err_fp;
++	int tu_size;
++	int tu_size_desired;
++	int tu_size_minus1;
++
++	int valid_boundary_link;
++	s64 resulting_valid_fp;
++	s64 total_valid_fp;
++	s64 effective_valid_fp;
++	s64 effective_valid_recorded_fp;
++	int n_tus;
++	int n_tus_per_lane;
++	int paired_tus;
++	int remainder_tus;
++	int remainder_tus_upper;
++	int remainder_tus_lower;
++	int extra_bytes;
++	int filler_size;
++	int delay_start_link;
++
++	int extra_pclk_cycles;
++	int extra_pclk_cycles_in_link_clk;
++	s64 ratio_by_tu_fp;
++	s64 average_valid2_fp;
++	int new_valid_boundary_link;
++	int remainder_symbols_exist;
++	int n_symbols;
++	s64 n_remainder_symbols_per_lane_fp;
++	s64 last_partial_tu_fp;
++	s64 TU_ratio_err_fp;
++
++	int n_tus_incl_last_incomplete_tu;
++	int extra_pclk_cycles_tmp;
++	int extra_pclk_cycles_in_link_clk_tmp;
++	int extra_required_bytes_new_tmp;
++	int filler_size_tmp;
++	int lower_filler_size_tmp;
++	int delay_start_link_tmp;
++
++	bool boundary_moderation_en;
++	int boundary_mod_lower_err;
++	int upper_boundary_count;
++	int lower_boundary_count;
++	int i_upper_boundary_count;
++	int i_lower_boundary_count;
++	int valid_lower_boundary_link;
++	int even_distribution_BF;
++	int even_distribution_legacy;
++	int even_distribution;
++
++	int hbp_delayStartCheck;
++	int pre_tu_hw_pipe_delay;
++	int post_tu_hw_pipe_delay;
++	int link_config_hactive_time;
++	int delay_start_link_lclk;
++	int tu_active_cycles;
++	s64 parity_symbols;
++	int resolution_line_time;
++	int last_partial_lclk;
++
++	int min_hblank_violated;
++	s64 delay_start_time_fp;
++	s64 hbp_time_fp;
++	s64 hactive_time_fp;
++	s64 diff_abs_fp;
++	int second_loop_set;
++	s64 ratio;
++};
++
++static int _tu_param_compare(s64 a, s64 b)
++{
++	u32 a_sign, b_sign;
++	s64 a_temp, b_temp, minus_1;
++
++	if (a == b)
++		return 0;
++
++	minus_1 = drm_fixp_from_fraction(-1, 1);
++
++	a_sign = (a >> 32) & 0x80000000 ? 1 : 0;
++	b_sign = (b >> 32) & 0x80000000 ? 1 : 0;
++
++	if (a_sign > b_sign)
++		return 2;
++	else if (b_sign > a_sign)
++		return 1;
++
++	if (!a_sign && !b_sign) { /* positive */
++		if (a > b)
++			return 1;
++		else
++			return 2;
++	} else { /* negative */
++		a_temp = drm_fixp_mul(a, minus_1);
++		b_temp = drm_fixp_mul(b, minus_1);
++
++		if (a_temp > b_temp)
++			return 2;
++		else
++			return 1;
++	}
++}
++
++static s64 msm_fixp_subtract(s64 a, s64 b)
++{
++	s64 minus_1 = drm_fixp_from_fraction(-1, 1);
++
++	if (a >= b)
++		return a - b;
++
++	return drm_fixp_mul(b - a, minus_1);
++}
++
++static inline int msm_fixp2int_ceil(s64 a)
++{
++	return a ? drm_fixp2int_ceil(a) : 0;
++}
++
++static void msm_dp_panel_update_tu_timings(struct msm_dp_tu_calc_input *in,
++					struct tu_algo_data *tu)
++{
++	int nlanes = in->nlanes;
++	int dsc_num_slices = in->num_of_dsc_slices;
++	int dsc_num_bytes  = 0;
++	int numerator;
++	s64 pclk_dsc_fp;
++	s64 dwidth_dsc_fp;
++	s64 hbp_dsc_fp;
++
++	int tot_num_eoc_symbols = 0;
++	int tot_num_hor_bytes   = 0;
++	int tot_num_dummy_bytes = 0;
++	int dwidth_dsc_bytes    = 0;
++	int  eoc_bytes           = 0;
++
++	s64 temp1_fp, temp2_fp, temp3_fp;
++
++	tu->lclk_fp              = drm_fixp_from_fraction(in->lclk, 1);
++	tu->orig_lclk_fp         = tu->lclk_fp;
++	tu->pclk_fp              = drm_fixp_from_fraction(in->pclk_khz, 1000);
++	tu->orig_pclk_fp         = tu->pclk_fp;
++	tu->lwidth               = in->hactive;
++	tu->hbp_relative_to_pclk = in->hporch;
++	tu->nlanes               = in->nlanes;
++	tu->bpp                  = in->bpp;
++	tu->pixelEnc             = in->pixel_enc;
++	tu->dsc_en               = in->dsc_en;
++	tu->fec_en               = in->fec_en;
++	tu->async_en             = in->async_en;
++	tu->lwidth_fp            = drm_fixp_from_fraction(in->hactive, 1);
++	tu->orig_lwidth          = in->hactive;
++	tu->hbp_relative_to_pclk_fp = drm_fixp_from_fraction(in->hporch, 1);
++	tu->orig_hbp             = in->hporch;
++	tu->rb2                  = (in->hporch < 160) ? 1 : 0;
++
++	if (tu->pixelEnc == 420) {
++		temp1_fp = drm_fixp_from_fraction(2, 1);
++		tu->pclk_fp = drm_fixp_div(tu->pclk_fp, temp1_fp);
++		tu->lwidth_fp = drm_fixp_div(tu->lwidth_fp, temp1_fp);
++		tu->hbp_relative_to_pclk_fp =
++				drm_fixp_div(tu->hbp_relative_to_pclk_fp, 2);
++	}
++
++	if (tu->pixelEnc == 422) {
++		switch (tu->bpp) {
++		case 24:
++			tu->bpp = 16;
++			tu->bpc = 8;
++			break;
++		case 30:
++			tu->bpp = 20;
++			tu->bpc = 10;
++			break;
++		default:
++			tu->bpp = 16;
++			tu->bpc = 8;
++			break;
++		}
++	} else {
++		tu->bpc = tu->bpp/3;
++	}
++
++	if (!in->dsc_en)
++		goto fec_check;
++
++	tu->bpp = 24; /* hardcode to 24 if DSC is enabled */
++
++	temp1_fp = drm_fixp_from_fraction(in->compress_ratio, 100);
++	temp2_fp = drm_fixp_from_fraction(in->bpp, 1);
++	temp3_fp = drm_fixp_div(temp2_fp, temp1_fp);
++	temp2_fp = drm_fixp_mul(tu->lwidth_fp, temp3_fp);
++
++	temp1_fp = drm_fixp_from_fraction(8, 1);
++	temp3_fp = drm_fixp_div(temp2_fp, temp1_fp);
++
++	numerator = drm_fixp2int(temp3_fp);
++
++	dsc_num_bytes  = numerator / dsc_num_slices;
++	eoc_bytes           = dsc_num_bytes % nlanes;
++	tot_num_eoc_symbols = nlanes * dsc_num_slices;
++	tot_num_hor_bytes   = dsc_num_bytes * dsc_num_slices;
++	tot_num_dummy_bytes = (nlanes - eoc_bytes) * dsc_num_slices;
++
++	if (dsc_num_bytes == 0)
++		pr_info("incorrect no of bytes per slice=%d\n", dsc_num_bytes);
++
++	dwidth_dsc_bytes = (tot_num_hor_bytes +
++				tot_num_eoc_symbols +
++				(eoc_bytes == 0 ? 0 : tot_num_dummy_bytes));
++
++	dwidth_dsc_fp = drm_fixp_from_fraction(dwidth_dsc_bytes, 3);
++
++	temp2_fp = drm_fixp_mul(tu->pclk_fp, dwidth_dsc_fp);
++	temp1_fp = drm_fixp_div(temp2_fp, tu->lwidth_fp);
++	pclk_dsc_fp = temp1_fp;
++
++	temp1_fp = drm_fixp_div(pclk_dsc_fp, tu->pclk_fp);
++	temp2_fp = drm_fixp_mul(tu->hbp_relative_to_pclk_fp, temp1_fp);
++	hbp_dsc_fp = temp2_fp;
++
++	/* output */
++	tu->pclk_fp = pclk_dsc_fp;
++	tu->lwidth_fp = dwidth_dsc_fp;
++	tu->hbp_relative_to_pclk_fp = hbp_dsc_fp;
++
++fec_check:
++	if (in->fec_en) {
++		temp1_fp = drm_fixp_from_fraction(976, 1000); /* 0.976 */
++		tu->lclk_fp = drm_fixp_mul(tu->lclk_fp, temp1_fp);
++	}
++}
++
++static void _tu_valid_boundary_calc(struct tu_algo_data *tu)
++{
++	s64 temp1_fp, temp2_fp, temp, temp1, temp2;
++	int compare_result_1, compare_result_2, compare_result_3;
++
++	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
++	temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
++
++	tu->new_valid_boundary_link = msm_fixp2int_ceil(temp2_fp);
++
++	temp = (tu->i_upper_boundary_count *
++				tu->new_valid_boundary_link +
++				tu->i_lower_boundary_count *
++				(tu->new_valid_boundary_link - 1));
++	tu->average_valid2_fp = drm_fixp_from_fraction(temp,
++					(tu->i_upper_boundary_count +
++					tu->i_lower_boundary_count));
++
++	temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
++	temp2_fp = tu->lwidth_fp;
++	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
++	temp2_fp = drm_fixp_div(temp1_fp, tu->average_valid2_fp);
++	tu->n_tus = drm_fixp2int(temp2_fp);
++	if ((temp2_fp & 0xFFFFFFFF) > 0xFFFFF000)
++		tu->n_tus += 1;
++
++	temp1_fp = drm_fixp_from_fraction(tu->n_tus, 1);
++	temp2_fp = drm_fixp_mul(temp1_fp, tu->average_valid2_fp);
++	temp1_fp = drm_fixp_from_fraction(tu->n_symbols, 1);
++	temp2_fp = temp1_fp - temp2_fp;
++	temp1_fp = drm_fixp_from_fraction(tu->nlanes, 1);
++	temp2_fp = drm_fixp_div(temp2_fp, temp1_fp);
++	tu->n_remainder_symbols_per_lane_fp = temp2_fp;
++
++	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
++	tu->last_partial_tu_fp =
++			drm_fixp_div(tu->n_remainder_symbols_per_lane_fp,
++					temp1_fp);
++
++	if (tu->n_remainder_symbols_per_lane_fp != 0)
++		tu->remainder_symbols_exist = 1;
++	else
++		tu->remainder_symbols_exist = 0;
++
++	temp1_fp = drm_fixp_from_fraction(tu->n_tus, tu->nlanes);
++	tu->n_tus_per_lane = drm_fixp2int(temp1_fp);
++
++	tu->paired_tus = (int)((tu->n_tus_per_lane) /
++					(tu->i_upper_boundary_count +
++					 tu->i_lower_boundary_count));
++
++	tu->remainder_tus = tu->n_tus_per_lane - tu->paired_tus *
++						(tu->i_upper_boundary_count +
++						tu->i_lower_boundary_count);
++
++	if ((tu->remainder_tus - tu->i_upper_boundary_count) > 0) {
++		tu->remainder_tus_upper = tu->i_upper_boundary_count;
++		tu->remainder_tus_lower = tu->remainder_tus -
++						tu->i_upper_boundary_count;
++	} else {
++		tu->remainder_tus_upper = tu->remainder_tus;
++		tu->remainder_tus_lower = 0;
++	}
++
++	temp = tu->paired_tus * (tu->i_upper_boundary_count *
++				tu->new_valid_boundary_link +
++				tu->i_lower_boundary_count *
++				(tu->new_valid_boundary_link - 1)) +
++				(tu->remainder_tus_upper *
++				 tu->new_valid_boundary_link) +
++				(tu->remainder_tus_lower *
++				(tu->new_valid_boundary_link - 1));
++	tu->total_valid_fp = drm_fixp_from_fraction(temp, 1);
++
++	if (tu->remainder_symbols_exist) {
++		temp1_fp = tu->total_valid_fp +
++				tu->n_remainder_symbols_per_lane_fp;
++		temp2_fp = drm_fixp_from_fraction(tu->n_tus_per_lane, 1);
++		temp2_fp = temp2_fp + tu->last_partial_tu_fp;
++		temp1_fp = drm_fixp_div(temp1_fp, temp2_fp);
++	} else {
++		temp2_fp = drm_fixp_from_fraction(tu->n_tus_per_lane, 1);
++		temp1_fp = drm_fixp_div(tu->total_valid_fp, temp2_fp);
++	}
++	tu->effective_valid_fp = temp1_fp;
++
++	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
++	temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
++	tu->n_n_err_fp = msm_fixp_subtract(tu->effective_valid_fp, temp2_fp);
++
++	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
++	temp2_fp = drm_fixp_mul(tu->ratio_fp, temp1_fp);
++	tu->n_err_fp = msm_fixp_subtract(tu->average_valid2_fp, temp2_fp);
++
++	tu->even_distribution = tu->n_tus % tu->nlanes == 0 ? 1 : 0;
++
++	temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
++	temp2_fp = tu->lwidth_fp;
++	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
++	temp2_fp = drm_fixp_div(temp1_fp, tu->average_valid2_fp);
++	tu->n_tus_incl_last_incomplete_tu = msm_fixp2int_ceil(temp2_fp);
++
++	temp1 = 0;
++	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
++	temp2_fp = drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
++	temp1_fp = tu->average_valid2_fp - temp2_fp;
++	temp2_fp = drm_fixp_from_fraction(tu->n_tus_incl_last_incomplete_tu, 1);
++	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
++	temp1 = msm_fixp2int_ceil(temp1_fp);
++
++	temp = tu->i_upper_boundary_count * tu->nlanes;
++	temp1_fp = drm_fixp_from_fraction(tu->tu_size, 1);
++	temp2_fp = drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
++	temp1_fp = drm_fixp_from_fraction(tu->new_valid_boundary_link, 1);
++	temp2_fp = temp1_fp - temp2_fp;
++	temp1_fp = drm_fixp_from_fraction(temp, 1);
++	temp2_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++	temp2 = msm_fixp2int_ceil(temp2_fp);
++
++	tu->extra_required_bytes_new_tmp = (int)(temp1 + temp2);
++
++	temp1_fp = drm_fixp_from_fraction(8, tu->bpp);
++	temp2_fp = drm_fixp_from_fraction(
++	tu->extra_required_bytes_new_tmp, 1);
++	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
++	tu->extra_pclk_cycles_tmp = msm_fixp2int_ceil(temp1_fp);
++
++	temp1_fp = drm_fixp_from_fraction(tu->extra_pclk_cycles_tmp, 1);
++	temp2_fp = drm_fixp_div(tu->lclk_fp, tu->pclk_fp);
++	temp1_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++	tu->extra_pclk_cycles_in_link_clk_tmp = msm_fixp2int_ceil(temp1_fp);
++
++	tu->filler_size_tmp = tu->tu_size - tu->new_valid_boundary_link;
++
++	tu->lower_filler_size_tmp = tu->filler_size_tmp + 1;
++
++	tu->delay_start_link_tmp = tu->extra_pclk_cycles_in_link_clk_tmp +
++					tu->lower_filler_size_tmp +
++					tu->extra_buffer_margin;
++
++	temp1_fp = drm_fixp_from_fraction(tu->delay_start_link_tmp, 1);
++	tu->delay_start_time_fp = drm_fixp_div(temp1_fp, tu->lclk_fp);
++
++	if (tu->rb2) {
++		temp1_fp = drm_fixp_mul(tu->delay_start_time_fp, tu->lclk_fp);
++		tu->delay_start_link_lclk = msm_fixp2int_ceil(temp1_fp);
++
++		if (tu->remainder_tus > tu->i_upper_boundary_count) {
++			temp = (tu->remainder_tus - tu->i_upper_boundary_count) *
++							(tu->new_valid_boundary_link - 1);
++			temp += (tu->i_upper_boundary_count * tu->new_valid_boundary_link);
++			temp *= tu->nlanes;
++		} else {
++			temp = tu->nlanes * tu->remainder_tus * tu->new_valid_boundary_link;
++		}
++
++		temp1 = tu->i_lower_boundary_count * (tu->new_valid_boundary_link - 1);
++		temp1 += tu->i_upper_boundary_count * tu->new_valid_boundary_link;
++		temp1 *= tu->paired_tus * tu->nlanes;
++		temp1_fp = drm_fixp_from_fraction(tu->n_symbols - temp1 - temp, tu->nlanes);
++		tu->last_partial_lclk = msm_fixp2int_ceil(temp1_fp);
++
++		tu->tu_active_cycles = (int)((tu->n_tus_per_lane * tu->tu_size) +
++								tu->last_partial_lclk);
++		tu->post_tu_hw_pipe_delay = 4 /*BS_on_the_link*/ + 1 /*BE_next_ren*/;
++		temp = tu->pre_tu_hw_pipe_delay + tu->delay_start_link_lclk +
++					tu->tu_active_cycles + tu->post_tu_hw_pipe_delay;
++
++		if (tu->fec_en == 1) {
++			if (tu->nlanes == 1) {
++				temp1_fp = drm_fixp_from_fraction(temp, 500);
++				tu->parity_symbols = msm_fixp2int_ceil(temp1_fp) * 12 + 1;
++			} else {
++				temp1_fp = drm_fixp_from_fraction(temp, 250);
++				tu->parity_symbols = msm_fixp2int_ceil(temp1_fp) * 6 + 1;
++			}
++		} else { //no fec BW impact
++			tu->parity_symbols = 0;
++		}
++
++		tu->link_config_hactive_time = temp + tu->parity_symbols;
++
++		if (tu->resolution_line_time >= tu->link_config_hactive_time + 1 /*margin*/)
++			tu->hbp_delayStartCheck = 1;
++		else
++			tu->hbp_delayStartCheck = 0;
++	} else {
++		compare_result_3 = _tu_param_compare(tu->hbp_time_fp, tu->delay_start_time_fp);
++		if (compare_result_3 < 2)
++			tu->hbp_delayStartCheck = 1;
++		else
++			tu->hbp_delayStartCheck = 0;
++	}
++
++	compare_result_1 = _tu_param_compare(tu->n_n_err_fp, tu->diff_abs_fp);
++	if (compare_result_1 == 2)
++		compare_result_1 = 1;
++	else
++		compare_result_1 = 0;
++
++	compare_result_2 = _tu_param_compare(tu->n_n_err_fp, tu->err_fp);
++	if (compare_result_2 == 2)
++		compare_result_2 = 1;
++	else
++		compare_result_2 = 0;
++
++	if (((tu->even_distribution == 1) ||
++			((tu->even_distribution_BF == 0) &&
++			(tu->even_distribution_legacy == 0))) &&
++			tu->n_err_fp >= 0 && tu->n_n_err_fp >= 0 &&
++			compare_result_2 &&
++			(compare_result_1 || (tu->min_hblank_violated == 1)) &&
++			(tu->new_valid_boundary_link - 1) > 0 &&
++			(tu->hbp_delayStartCheck == 1) &&
++			(tu->delay_start_link_tmp <= 1023)) {
++		tu->upper_boundary_count = tu->i_upper_boundary_count;
++		tu->lower_boundary_count = tu->i_lower_boundary_count;
++		tu->err_fp = tu->n_n_err_fp;
++		tu->boundary_moderation_en = true;
++		tu->tu_size_desired = tu->tu_size;
++		tu->valid_boundary_link = tu->new_valid_boundary_link;
++		tu->effective_valid_recorded_fp = tu->effective_valid_fp;
++		tu->even_distribution_BF = 1;
++		tu->delay_start_link = tu->delay_start_link_tmp;
++	} else if (tu->boundary_mod_lower_err == 0) {
++		compare_result_1 = _tu_param_compare(tu->n_n_err_fp,
++							tu->diff_abs_fp);
++		if (compare_result_1 == 2)
++			tu->boundary_mod_lower_err = 1;
++	}
++}
++
++static void _dp_calc_boundary(struct tu_algo_data *tu)
++{
++	s64 temp1_fp = 0, temp2_fp = 0;
++
++	do {
++		tu->err_fp = drm_fixp_from_fraction(1000, 1);
++
++		temp1_fp = drm_fixp_div(tu->lclk_fp, tu->pclk_fp);
++		temp2_fp = drm_fixp_from_fraction(
++				tu->delay_start_link_extra_pixclk, 1);
++		temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
++		tu->extra_buffer_margin = msm_fixp2int_ceil(temp1_fp);
++
++		temp1_fp = drm_fixp_from_fraction(tu->bpp, 8);
++		temp1_fp = drm_fixp_mul(tu->lwidth_fp, temp1_fp);
++		tu->n_symbols = msm_fixp2int_ceil(temp1_fp);
++
++		for (tu->tu_size = 32; tu->tu_size <= 64; tu->tu_size++) {
++			for (tu->i_upper_boundary_count = 1;
++				tu->i_upper_boundary_count <= 15;
++				tu->i_upper_boundary_count++) {
++				for (tu->i_lower_boundary_count = 1;
++					tu->i_lower_boundary_count <= 15;
++					tu->i_lower_boundary_count++) {
++					_tu_valid_boundary_calc(tu);
++				}
++			}
++		}
++		tu->delay_start_link_extra_pixclk--;
++	} while (!tu->boundary_moderation_en &&
++		tu->boundary_mod_lower_err == 1 &&
++		tu->delay_start_link_extra_pixclk != 0 &&
++		((tu->second_loop_set == 0 && tu->rb2 == 1) || tu->rb2 == 0));
++}
++
++static void _dp_calc_extra_bytes(struct tu_algo_data *tu)
++{
++	u64 temp = 0;
++	s64 temp1_fp = 0, temp2_fp = 0;
++
++	temp1_fp = drm_fixp_from_fraction(tu->tu_size_desired, 1);
++	temp2_fp = drm_fixp_mul(tu->original_ratio_fp, temp1_fp);
++	temp1_fp = drm_fixp_from_fraction(tu->valid_boundary_link, 1);
++	temp2_fp = temp1_fp - temp2_fp;
++	temp1_fp = drm_fixp_from_fraction(tu->n_tus + 1, 1);
++	temp2_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++
++	temp = drm_fixp2int(temp2_fp);
++	if (temp)
++		tu->extra_bytes = msm_fixp2int_ceil(temp2_fp);
++	else
++		tu->extra_bytes = 0;
++
++	temp1_fp = drm_fixp_from_fraction(tu->extra_bytes, 1);
++	temp2_fp = drm_fixp_from_fraction(8, tu->bpp);
++	temp1_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++	tu->extra_pclk_cycles = msm_fixp2int_ceil(temp1_fp);
++
++	temp1_fp = drm_fixp_div(tu->lclk_fp, tu->pclk_fp);
++	temp2_fp = drm_fixp_from_fraction(tu->extra_pclk_cycles, 1);
++	temp1_fp = drm_fixp_mul(temp2_fp, temp1_fp);
++	tu->extra_pclk_cycles_in_link_clk = msm_fixp2int_ceil(temp1_fp);
++}
++
++
++void msm_dp_ctrl_calc_tu(struct drm_device *drm_dev,
++				struct msm_dp_tu_calc_input *in,
++				struct msm_dp_vc_tu_mapping_table *tu_table)
++{
++	struct tu_algo_data tu;
++	int compare_result_1, compare_result_2;
++	u64 temp = 0, temp1;
++	s64 temp_fp = 0, temp1_fp = 0, temp2_fp = 0;
++
++	s64 LCLK_FAST_SKEW_fp = drm_fixp_from_fraction(6, 10000); /* 0.0006 */
++	s64 RATIO_SCALE_fp = drm_fixp_from_fraction(1001, 1000);
++
++	u8 DP_BRUTE_FORCE = 1;
++	s64 BRUTE_FORCE_THRESHOLD_fp = drm_fixp_from_fraction(1, 10); /* 0.1 */
++	uint EXTRA_PIXCLK_CYCLE_DELAY = 4;
++	s64 HBLANK_MARGIN = drm_fixp_from_fraction(4, 1);
++	s64 HBLANK_MARGIN_EXTRA = 0;
++
++
++	memset(&tu, 0, sizeof(tu));
++
++	msm_dp_panel_update_tu_timings(in, &tu);
++
++	tu.err_fp = drm_fixp_from_fraction(1000, 1); /* 1000 */
++
++	temp1_fp = drm_fixp_from_fraction(4, 1);
++	temp2_fp = drm_fixp_mul(temp1_fp, tu.lclk_fp);
++	temp_fp = drm_fixp_div(temp2_fp, tu.pclk_fp);
++	tu.extra_buffer_margin = msm_fixp2int_ceil(temp_fp);
++
++	if (in->compress_ratio == 375 && tu.bpp == 30)
++		temp1_fp = drm_fixp_from_fraction(24, 8);
++	else
++		temp1_fp = drm_fixp_from_fraction(tu.bpp, 8);
++
++	temp2_fp = drm_fixp_mul(tu.pclk_fp, temp1_fp);
++	temp1_fp = drm_fixp_from_fraction(tu.nlanes, 1);
++	temp2_fp = drm_fixp_div(temp2_fp, temp1_fp);
++	tu.ratio_fp = drm_fixp_div(temp2_fp, tu.lclk_fp);
++
++	tu.original_ratio_fp = tu.ratio_fp;
++	tu.boundary_moderation_en = false;
++	tu.upper_boundary_count = 0;
++	tu.lower_boundary_count = 0;
++	tu.i_upper_boundary_count = 0;
++	tu.i_lower_boundary_count = 0;
++	tu.valid_lower_boundary_link = 0;
++	tu.even_distribution_BF = 0;
++	tu.even_distribution_legacy = 0;
++	tu.even_distribution = 0;
++	tu.hbp_delayStartCheck = 0;
++	tu.pre_tu_hw_pipe_delay = 0;
++	tu.post_tu_hw_pipe_delay = 0;
++	tu.link_config_hactive_time = 0;
++	tu.delay_start_link_lclk = 0;
++	tu.tu_active_cycles = 0;
++	tu.resolution_line_time = 0;
++	tu.last_partial_lclk = 0;
++	tu.delay_start_time_fp = 0;
++	tu.second_loop_set = 0;
++
++	tu.err_fp = drm_fixp_from_fraction(1000, 1);
++	tu.n_err_fp = 0;
++	tu.n_n_err_fp = 0;
++
++	temp = drm_fixp2int(tu.lwidth_fp);
++	if ((((u32)temp % tu.nlanes) != 0) && (_tu_param_compare(tu.ratio_fp, DRM_FIXED_ONE) == 2)
++			&& (tu.dsc_en == 0)) {
++		tu.ratio_fp = drm_fixp_mul(tu.ratio_fp, RATIO_SCALE_fp);
++		if (_tu_param_compare(tu.ratio_fp, DRM_FIXED_ONE) == 1)
++			tu.ratio_fp = DRM_FIXED_ONE;
++	}
++
++	if (_tu_param_compare(tu.ratio_fp, DRM_FIXED_ONE) == 1)
++		tu.ratio_fp = DRM_FIXED_ONE;
++
++	if (HBLANK_MARGIN_EXTRA != 0) {
++		HBLANK_MARGIN += HBLANK_MARGIN_EXTRA;
++		drm_dbg_dp(drm_dev, "Info: increase HBLANK_MARGIN to %lld. (PLUS%lld)\n", HBLANK_MARGIN,
++			HBLANK_MARGIN_EXTRA);
++	}
++
++	for (tu.tu_size = 32; tu.tu_size <= 64; tu.tu_size++) {
++		temp1_fp = drm_fixp_from_fraction(tu.tu_size, 1);
++		temp2_fp = drm_fixp_mul(tu.ratio_fp, temp1_fp);
++		temp = msm_fixp2int_ceil(temp2_fp);
++		temp1_fp = drm_fixp_from_fraction(temp, 1);
++		tu.n_err_fp = temp1_fp - temp2_fp;
++
++		if (tu.n_err_fp < tu.err_fp) {
++			tu.err_fp = tu.n_err_fp;
++			tu.tu_size_desired = tu.tu_size;
++		}
++	}
++
++	tu.tu_size_minus1 = tu.tu_size_desired - 1;
++
++	temp1_fp = drm_fixp_from_fraction(tu.tu_size_desired, 1);
++	temp2_fp = drm_fixp_mul(tu.ratio_fp, temp1_fp);
++	tu.valid_boundary_link = msm_fixp2int_ceil(temp2_fp);
++
++	temp1_fp = drm_fixp_from_fraction(tu.bpp, 8);
++	temp2_fp = tu.lwidth_fp;
++	temp2_fp = drm_fixp_mul(temp2_fp, temp1_fp);
++
++	temp1_fp = drm_fixp_from_fraction(tu.valid_boundary_link, 1);
++	temp2_fp = drm_fixp_div(temp2_fp, temp1_fp);
++	tu.n_tus = drm_fixp2int(temp2_fp);
++	if ((temp2_fp & 0xFFFFFFFF) > 0xFFFFF000)
++		tu.n_tus += 1;
++
++	tu.even_distribution_legacy = tu.n_tus % tu.nlanes == 0 ? 1 : 0;
++	drm_dbg_dp(drm_dev, "Info: n_sym = %d, num_of_tus = %d\n",
++		tu.valid_boundary_link, tu.n_tus);
++
++	_dp_calc_extra_bytes(&tu);
++
++	tu.filler_size = tu.tu_size_desired - tu.valid_boundary_link;
++
++	temp1_fp = drm_fixp_from_fraction(tu.tu_size_desired, 1);
++	tu.ratio_by_tu_fp = drm_fixp_mul(tu.ratio_fp, temp1_fp);
++
++	tu.delay_start_link = tu.extra_pclk_cycles_in_link_clk +
++				tu.filler_size + tu.extra_buffer_margin;
++
++	tu.resulting_valid_fp =
++			drm_fixp_from_fraction(tu.valid_boundary_link, 1);
++
++	temp1_fp = drm_fixp_from_fraction(tu.tu_size_desired, 1);
++	temp2_fp = drm_fixp_div(tu.resulting_valid_fp, temp1_fp);
++	tu.TU_ratio_err_fp = temp2_fp - tu.original_ratio_fp;
++
++	temp1_fp = drm_fixp_from_fraction((tu.hbp_relative_to_pclk - HBLANK_MARGIN), 1);
++	tu.hbp_time_fp = drm_fixp_div(temp1_fp, tu.pclk_fp);
++
++	temp1_fp = drm_fixp_from_fraction(tu.delay_start_link, 1);
++	tu.delay_start_time_fp = drm_fixp_div(temp1_fp, tu.lclk_fp);
++
++	compare_result_1 = _tu_param_compare(tu.hbp_time_fp,
++					tu.delay_start_time_fp);
++	if (compare_result_1 == 2) /* hbp_time_fp < delay_start_time_fp */
++		tu.min_hblank_violated = 1;
++
++	tu.hactive_time_fp = drm_fixp_div(tu.lwidth_fp, tu.pclk_fp);
++
++	compare_result_2 = _tu_param_compare(tu.hactive_time_fp,
++						tu.delay_start_time_fp);
++	if (compare_result_2 == 2)
++		tu.min_hblank_violated = 1;
++
++	/* brute force */
++
++	tu.delay_start_link_extra_pixclk = EXTRA_PIXCLK_CYCLE_DELAY;
++	tu.diff_abs_fp = tu.resulting_valid_fp - tu.ratio_by_tu_fp;
++
++	temp = drm_fixp2int(tu.diff_abs_fp);
++	if (!temp && tu.diff_abs_fp <= 0xffff)
++		tu.diff_abs_fp = 0;
++
++	/* if(diff_abs < 0) diff_abs *= -1 */
++	if (tu.diff_abs_fp < 0)
++		tu.diff_abs_fp = drm_fixp_mul(tu.diff_abs_fp, -1);
++
++	tu.boundary_mod_lower_err = 0;
++
++	temp1_fp = drm_fixp_div(tu.orig_lclk_fp, tu.orig_pclk_fp);
++
++	temp2_fp = drm_fixp_from_fraction(tu.orig_lwidth + tu.orig_hbp, 2);
++	temp_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++	tu.resolution_line_time = drm_fixp2int(temp_fp);
++	tu.pre_tu_hw_pipe_delay = msm_fixp2int_ceil(temp1_fp) + 2 /*cdc fifo write jitter+2*/
++				+ 3 /*pre-delay start cycles*/
++				+ 3 /*post-delay start cycles*/ + 1 /*BE on the link*/;
++	tu.post_tu_hw_pipe_delay = 4 /*BS_on_the_link*/ + 1 /*BE_next_ren*/;
++
++	temp1_fp = drm_fixp_from_fraction(tu.bpp, 8);
++	temp1_fp = drm_fixp_mul(tu.lwidth_fp, temp1_fp);
++	tu.n_symbols = msm_fixp2int_ceil(temp1_fp);
++
++	if (tu.rb2) {
++		temp1_fp = drm_fixp_mul(tu.delay_start_time_fp, tu.lclk_fp);
++		tu.delay_start_link_lclk = msm_fixp2int_ceil(temp1_fp);
++
++		tu.new_valid_boundary_link = tu.valid_boundary_link;
++		tu.i_upper_boundary_count = 1;
++		tu.i_lower_boundary_count = 0;
++
++		temp1 = tu.i_upper_boundary_count * tu.new_valid_boundary_link;
++		temp1 += tu.i_lower_boundary_count * (tu.new_valid_boundary_link - 1);
++		tu.average_valid2_fp = drm_fixp_from_fraction(temp1,
++				(tu.i_upper_boundary_count + tu.i_lower_boundary_count));
++
++		temp1_fp = drm_fixp_from_fraction(tu.bpp, 8);
++		temp1_fp = drm_fixp_mul(tu.lwidth_fp, temp1_fp);
++		temp2_fp = drm_fixp_div(temp1_fp, tu.average_valid2_fp);
++		tu.n_tus = drm_fixp2int(temp2_fp);
++
++		tu.n_tus_per_lane = tu.n_tus / tu.nlanes;
++		tu.paired_tus = (int)((tu.n_tus_per_lane) /
++				(tu.i_upper_boundary_count + tu.i_lower_boundary_count));
++
++		tu.remainder_tus = tu.n_tus_per_lane - tu.paired_tus *
++				(tu.i_upper_boundary_count + tu.i_lower_boundary_count);
++
++		if (tu.remainder_tus > tu.i_upper_boundary_count) {
++			temp = (tu.remainder_tus - tu.i_upper_boundary_count) *
++							(tu.new_valid_boundary_link - 1);
++			temp += (tu.i_upper_boundary_count * tu.new_valid_boundary_link);
++			temp *= tu.nlanes;
++		} else {
++			temp = tu.nlanes * tu.remainder_tus * tu.new_valid_boundary_link;
++		}
++
++		temp1 = tu.i_lower_boundary_count * (tu.new_valid_boundary_link - 1);
++		temp1 += tu.i_upper_boundary_count * tu.new_valid_boundary_link;
++		temp1 *= tu.paired_tus * tu.nlanes;
++		temp1_fp = drm_fixp_from_fraction(tu.n_symbols - temp1 - temp, tu.nlanes);
++		tu.last_partial_lclk = msm_fixp2int_ceil(temp1_fp);
++
++		tu.tu_active_cycles = (int)((tu.n_tus_per_lane * tu.tu_size) +
++								tu.last_partial_lclk);
++
++		temp = tu.pre_tu_hw_pipe_delay + tu.delay_start_link_lclk +
++						tu.tu_active_cycles + tu.post_tu_hw_pipe_delay;
++
++		if (tu.fec_en == 1) {
++			if (tu.nlanes == 1) {
++				temp1_fp = drm_fixp_from_fraction(temp, 500);
++				tu.parity_symbols = msm_fixp2int_ceil(temp1_fp) * 12 + 1;
++			} else {
++				temp1_fp = drm_fixp_from_fraction(temp, 250);
++				tu.parity_symbols = msm_fixp2int_ceil(temp1_fp) * 6 + 1;
++			}
++		} else { //no fec BW impact
++			tu.parity_symbols = 0;
++		}
++
++		tu.link_config_hactive_time = temp + tu.parity_symbols;
++
++		if (tu.link_config_hactive_time + 1 /*margin*/ >= tu.resolution_line_time)
++			tu.min_hblank_violated = 1;
++	}
++
++	tu.delay_start_time_fp = 0;
++
++	if ((tu.diff_abs_fp != 0 &&
++			((tu.diff_abs_fp > BRUTE_FORCE_THRESHOLD_fp) ||
++			 (tu.even_distribution_legacy == 0) ||
++			 (DP_BRUTE_FORCE == 1))) ||
++			(tu.min_hblank_violated == 1)) {
++		_dp_calc_boundary(&tu);
++
++		if (tu.boundary_moderation_en) {
++			temp1_fp = drm_fixp_from_fraction(
++					(tu.upper_boundary_count *
++					tu.valid_boundary_link +
++					tu.lower_boundary_count *
++					(tu.valid_boundary_link - 1)), 1);
++			temp2_fp = drm_fixp_from_fraction(
++					(tu.upper_boundary_count +
++					tu.lower_boundary_count), 1);
++			tu.resulting_valid_fp =
++					drm_fixp_div(temp1_fp, temp2_fp);
++
++			temp1_fp = drm_fixp_from_fraction(
++					tu.tu_size_desired, 1);
++			tu.ratio_by_tu_fp =
++				drm_fixp_mul(tu.original_ratio_fp, temp1_fp);
++
++			tu.valid_lower_boundary_link =
++				tu.valid_boundary_link - 1;
++
++			temp1_fp = drm_fixp_from_fraction(tu.bpp, 8);
++			temp1_fp = drm_fixp_mul(tu.lwidth_fp, temp1_fp);
++			temp2_fp = drm_fixp_div(temp1_fp,
++						tu.resulting_valid_fp);
++			tu.n_tus = drm_fixp2int(temp2_fp);
++
++			tu.tu_size_minus1 = tu.tu_size_desired - 1;
++			tu.even_distribution_BF = 1;
++
++			temp1_fp =
++				drm_fixp_from_fraction(tu.tu_size_desired, 1);
++			temp2_fp =
++				drm_fixp_div(tu.resulting_valid_fp, temp1_fp);
++			tu.TU_ratio_err_fp = temp2_fp - tu.original_ratio_fp;
++		}
++	}
++
++	if (tu.async_en) {
++		temp2_fp = drm_fixp_mul(LCLK_FAST_SKEW_fp, tu.lwidth_fp);
++		temp = msm_fixp2int_ceil(temp2_fp);
++
++		temp1_fp = drm_fixp_from_fraction(tu.nlanes, 1);
++		temp2_fp = drm_fixp_mul(tu.original_ratio_fp, temp1_fp);
++		temp1_fp = drm_fixp_from_fraction(tu.bpp, 8);
++		temp2_fp = drm_fixp_div(temp1_fp, temp2_fp);
++		temp1_fp = drm_fixp_from_fraction(temp, 1);
++		temp2_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++		temp = drm_fixp2int(temp2_fp);
++
++		tu.delay_start_link += (int)temp;
++	}
++
++	temp1_fp = drm_fixp_from_fraction(tu.delay_start_link, 1);
++	tu.delay_start_time_fp = drm_fixp_div(temp1_fp, tu.lclk_fp);
++
++	/* OUTPUTS */
++	tu_table->valid_boundary_link       = tu.valid_boundary_link;
++	tu_table->delay_start_link          = tu.delay_start_link;
++	tu_table->boundary_moderation_en    = tu.boundary_moderation_en;
++	tu_table->valid_lower_boundary_link = tu.valid_lower_boundary_link;
++	tu_table->upper_boundary_count      = tu.upper_boundary_count;
++	tu_table->lower_boundary_count      = tu.lower_boundary_count;
++	tu_table->tu_size_minus1            = tu.tu_size_minus1;
++
++	drm_dbg_dp(drm_dev, "TU: valid_boundary_link: %d\n", tu_table->valid_boundary_link);
++	drm_dbg_dp(drm_dev, "TU: delay_start_link: %d\n", tu_table->delay_start_link);
++	drm_dbg_dp(drm_dev, "TU: boundary_moderation_en: %d\n",
++			tu_table->boundary_moderation_en);
++	drm_dbg_dp(drm_dev, "TU: valid_lower_boundary_link: %d\n",
++			tu_table->valid_lower_boundary_link);
++	drm_dbg_dp(drm_dev, "TU: upper_boundary_count: %d\n",
++			tu_table->upper_boundary_count);
++	drm_dbg_dp(drm_dev, "TU: lower_boundary_count: %d\n",
++			tu_table->lower_boundary_count);
++	drm_dbg_dp(drm_dev, "TU: tu_size_minus1: %d\n", tu_table->tu_size_minus1);
++}
+diff --git a/drivers/gpu/drm/msm/dp/dp_tu_calc.h b/drivers/gpu/drm/msm/dp/dp_tu_calc.h
+new file mode 100644
+index 000000000000..95af5b6b43b9
+--- /dev/null
++++ b/drivers/gpu/drm/msm/dp/dp_tu_calc.h
+@@ -0,0 +1,40 @@
++#ifndef _DP_TU_CALC_H_
++#define _DP_TU_CALC_H_
++
++#include <linux/types.h>
++#include <drm/drm_device.h>
++
++struct msm_dp_tu_calc_input {
++	u64 lclk;        /* 162, 270, 540 and 810 */
++	u64 pclk_khz;    /* in KHz */
++	u64 hactive;     /* active h-width */
++	u64 hporch;      /* bp + fp + pulse */
++	int nlanes;      /* no.of.lanes */
++	int bpp;         /* bits */
++	int pixel_enc;   /* 444, 420, 422 */
++	int dsc_en;     /* dsc on/off */
++	int async_en;   /* async mode */
++	int fec_en;     /* fec */
++	int compress_ratio; /* 2:1 = 200, 3:1 = 300, 3.75:1 = 375 */
++	int num_of_dsc_slices; /* number of slices per line */
++};
++
++struct msm_dp_vc_tu_mapping_table {
++	u32 vic;
++	u8 lanes;
++	u8 lrate; /* DP_LINK_RATE -> 162(6), 270(10), 540(20), 810 (30) */
++	u8 bpp;
++	u8 valid_boundary_link;
++	u16 delay_start_link;
++	bool boundary_moderation_en;
++	u8 valid_lower_boundary_link;
++	u8 upper_boundary_count;
++	u8 lower_boundary_count;
++	u8 tu_size_minus1;
++};
++
++void msm_dp_ctrl_calc_tu(struct drm_device *drm_dev,
++				struct msm_dp_tu_calc_input *in,
++				struct msm_dp_vc_tu_mapping_table *tu_table);
++
++#endif /* _DP_TU_CALC_H_ */
+-- 
+2.54.0
+
+
+From ded3b5ed122ad941b53e7c00b095041d658a7190 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Tue, 12 May 2026 13:15:36 -0300
+Subject: [PATCH 13/16] drm/msm/dpu: update initial lines calc
+
+---
+ drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c | 97 ++++++++++++++-------
+ 1 file changed, 65 insertions(+), 32 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+index df66dcd90111..7a8389764286 100644
+--- a/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
++++ b/drivers/gpu/drm/msm/disp/dpu1/dpu_encoder.c
+@@ -1358,28 +1358,70 @@ static void dpu_encoder_virt_atomic_mode_set(struct drm_encoder *drm_enc,
+ }
+ 
+ static u32
+-dpu_encoder_dsc_initial_line_calc(struct drm_dsc_config *dsc,
+-				  u32 enc_ip_width)
+-{
+-	int ssm_delay, total_pixels, soft_slice_per_enc;
+-
+-	soft_slice_per_enc = enc_ip_width / dsc->slice_width;
+-
+-	/*
+-	 * minimum number of initial line pixels is a sum of:
+-	 * 1. sub-stream multiplexer delay (83 groups for 8bpc,
+-	 *    91 for 10 bpc) * 3
+-	 * 2. for two soft slice cases, add extra sub-stream multiplexer * 3
+-	 * 3. the initial xmit delay
+-	 * 4. total pipeline delay through the "lock step" of encoder (47)
+-	 * 5. 6 additional pixels as the output of the rate buffer is
+-	 *    48 bits wide
+-	 */
+-	ssm_delay = ((dsc->bits_per_component < 10) ? 84 : 92);
+-	total_pixels = ssm_delay * 3 + dsc->initial_xmit_delay + 47;
+-	if (soft_slice_per_enc > 1)
+-		total_pixels += (ssm_delay * 3);
+-	return DIV_ROUND_UP(total_pixels, dsc->slice_width);
++dpu_encoder_dsc_initial_line_calc(struct drm_dsc_config *drm_dsc, u32 dsc_cmn_mode)
++{
++	u32 num_active_ss_per_enc;
++	u32 max_ssm_delay, max_se_size, max_muxword_size;
++	u32 compress_bpp_group, obuf_latency, input_ssm_out_latency;
++	u32 base_hs_latency, chunk_bits, ob_data_width;
++	u32 output_rate_extra_budget_bits, multi_hs_extra_budget_bits;
++	u32 multi_hs_extra_latency,  mux_word_size;
++	u32 ob_data_width_4comps, ob_data_width_3comps;
++	u32 output_rate_ratio_complement, container_slice_width;
++	u32 rtl_num_components;
++	bool multi_hs_c, multi_hs_d;
++
++	u32 bpc = drm_dsc->bits_per_component;
++	u32 bpp = drm_dsc->bits_per_pixel >> 4;
++	bool native_422 = drm_dsc->native_422;
++	bool native_420 = drm_dsc->native_420;
++
++	/* Hardent core config */
++	bool multiplex_mode_enable = 0, split_panel_enable = 0;
++	u32 rtl_max_bpc = 10, rtl_output_data_width = 64;
++	u32 pipeline_latency = 28;
++
++	if (dsc_cmn_mode & DSC_MODE_MULTIPLEX)
++		multiplex_mode_enable = true;
++	if (dsc_cmn_mode & DSC_MODE_SPLIT_PANEL)
++		split_panel_enable = true;
++
++	num_active_ss_per_enc = drm_dsc->slice_count;
++	if (multiplex_mode_enable)
++		num_active_ss_per_enc >>= 1;
++	container_slice_width = (native_422 ?
++			drm_dsc->slice_width / 2 : drm_dsc->slice_width);
++	max_muxword_size = rtl_max_bpc >= 12 ? 64 : 48;
++	max_se_size = 4 * (rtl_max_bpc + 1);
++	max_ssm_delay = max_se_size + max_muxword_size - 1;
++	mux_word_size = bpc >= 12 ? 64 : 48;
++	compress_bpp_group = native_422 ? 2 * bpp : bpp;
++	input_ssm_out_latency = pipeline_latency + 3 * (max_ssm_delay + 2)
++			* num_active_ss_per_enc;
++	rtl_num_components = native_420 || native_422 ? 4 : 3;
++	ob_data_width_4comps = rtl_output_data_width >= 2 * max_muxword_size ?
++			rtl_output_data_width : 2 * rtl_output_data_width;
++	ob_data_width_3comps = rtl_output_data_width >= max_muxword_size ?
++			rtl_output_data_width : 2 * rtl_output_data_width;
++	ob_data_width = rtl_num_components == 4 ?
++			ob_data_width_4comps : ob_data_width_3comps;
++	obuf_latency = DIV_ROUND_UP(9 * ob_data_width + mux_word_size,
++			compress_bpp_group) + 1;
++	base_hs_latency = drm_dsc->initial_xmit_delay +
++		input_ssm_out_latency + obuf_latency;
++	chunk_bits = 8 * drm_dsc->slice_chunk_size;
++	output_rate_ratio_complement = ob_data_width - compress_bpp_group;
++	output_rate_extra_budget_bits =
++			(output_rate_ratio_complement * chunk_bits) >>
++			(ob_data_width == 128 ? 7 : 6);
++	multi_hs_c = split_panel_enable && multiplex_mode_enable;
++	multi_hs_d = num_active_ss_per_enc > 1 && ob_data_width > compress_bpp_group;
++	multi_hs_extra_budget_bits = multi_hs_c || multi_hs_d ? chunk_bits :
++			output_rate_extra_budget_bits;
++	multi_hs_extra_latency = DIV_ROUND_UP(multi_hs_extra_budget_bits,
++			compress_bpp_group);
++	return DIV_ROUND_UP(base_hs_latency +
++			multi_hs_extra_latency, container_slice_width);
+ }
+ 
+ static void dpu_encoder_dsc_pipe_cfg(struct dpu_hw_ctl *ctl,
+@@ -1415,10 +1457,7 @@ static void dpu_encoder_prep_dsc(struct dpu_encoder_virt *dpu_enc,
+ 	struct dpu_hw_ctl *ctl = enc_master->hw_ctl;
+ 	struct dpu_hw_dsc *hw_dsc[MAX_CHANNELS_PER_ENC];
+ 	struct dpu_hw_pingpong *hw_pp[MAX_CHANNELS_PER_ENC];
+-	int this_frame_slices;
+-	int intf_ip_w, enc_ip_w;
+ 	int dsc_common_mode;
+-	int pic_width;
+ 	u32 initial_lines;
+ 	int num_dsc = 0;
+ 	int i;
+@@ -1433,8 +1472,6 @@ static void dpu_encoder_prep_dsc(struct dpu_encoder_virt *dpu_enc,
+ 		num_dsc++;
+ 	}
+ 
+-	pic_width = dsc->pic_width;
+-
+ 	dsc_common_mode = 0;
+ 	if (num_dsc > 1)
+ 		dsc_common_mode |= DSC_MODE_SPLIT_PANEL;
+@@ -1443,11 +1480,7 @@ static void dpu_encoder_prep_dsc(struct dpu_encoder_virt *dpu_enc,
+ 	if (enc_master->intf_mode == INTF_MODE_VIDEO)
+ 		dsc_common_mode |= DSC_MODE_VIDEO;
+ 
+-	this_frame_slices = pic_width / dsc->slice_width;
+-	intf_ip_w = this_frame_slices * dsc->slice_width;
+-
+-	enc_ip_w = intf_ip_w / num_dsc;
+-	initial_lines = dpu_encoder_dsc_initial_line_calc(dsc, enc_ip_w);
++	initial_lines = dpu_encoder_dsc_initial_line_calc(dsc, dsc_common_mode);
+ 
+ 	for (i = 0; i < num_dsc; i++)
+ 		dpu_encoder_dsc_pipe_cfg(ctl, hw_dsc[i], hw_pp[i],
+-- 
+2.54.0
+
+
+From 0eeacfdbbcf1d2fbbeff7ca84bee0f6bcdaf0161 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Wed, 13 May 2026 18:10:41 -0300
+Subject: [PATCH 14/16] drm/msm/dp: move wide_bus_en to panel from ctrl; match
+ eol_byte_num calc from patch
+
+---
+ drivers/gpu/drm/msm/dp/dp_ctrl.c    |  4 ++--
+ drivers/gpu/drm/msm/dp/dp_ctrl.h    |  2 +-
+ drivers/gpu/drm/msm/dp/dp_display.c |  2 +-
+ drivers/gpu/drm/msm/dp/dp_panel.c   | 15 ++++++++-------
+ drivers/gpu/drm/msm/dp/dp_panel.h   |  3 ++-
+ 5 files changed, 14 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_ctrl.c b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+index 7169a4bc4a93..e8ef77f8e44c 100644
+--- a/drivers/gpu/drm/msm/dp/dp_ctrl.c
++++ b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+@@ -526,7 +526,7 @@ static void msm_dp_ctrl_configure_source_params(struct msm_dp_ctrl_private *ctrl
+ 	drm_dbg_dp(ctrl->drm_dev, "misc settings = 0x%x\n", misc_val);
+ 	msm_dp_write_link(ctrl, REG_DP_MISC1_MISC0, misc_val);
+ 
+-	msm_dp_panel_timing_cfg(ctrl->panel, ctrl->msm_dp_ctrl.wide_bus_en);
++	msm_dp_panel_timing_cfg(ctrl->panel);
+ }
+ 
+ static void msm_dp_ctrl_calc_tu_parameters(struct msm_dp_ctrl_private *ctrl,
+@@ -1968,7 +1968,7 @@ int msm_dp_ctrl_on_stream(struct msm_dp_ctrl *msm_dp_ctrl, bool force_link_train
+ 
+ 	pixel_rate = pixel_rate_orig = ctrl->panel->msm_dp_mode.drm_mode.clock;
+ 
+-	if (msm_dp_ctrl->wide_bus_en || ctrl->panel->msm_dp_mode.out_fmt_is_yuv_420)
++	if (ctrl->panel->msm_dp_mode.wide_bus_en || ctrl->panel->msm_dp_mode.out_fmt_is_yuv_420)
+ 		pixel_rate >>= 1;
+ 
+ 	drm_dbg_dp(ctrl->drm_dev, "rate=%d, num_lanes=%d, pixel_rate=%lu\n",
+diff --git a/drivers/gpu/drm/msm/dp/dp_ctrl.h b/drivers/gpu/drm/msm/dp/dp_ctrl.h
+index 124b9b21bb7f..2be93b3c4540 100644
+--- a/drivers/gpu/drm/msm/dp/dp_ctrl.h
++++ b/drivers/gpu/drm/msm/dp/dp_ctrl.h
+@@ -11,7 +11,7 @@
+ #include "dp_link.h"
+ 
+ struct msm_dp_ctrl {
+-	bool wide_bus_en;
++	u8 _dummy;
+ };
+ 
+ struct phy;
+diff --git a/drivers/gpu/drm/msm/dp/dp_display.c b/drivers/gpu/drm/msm/dp/dp_display.c
+index 87d31f4c6868..e990b2d8537e 100644
+--- a/drivers/gpu/drm/msm/dp/dp_display.c
++++ b/drivers/gpu/drm/msm/dp/dp_display.c
+@@ -1827,7 +1827,7 @@ void msm_dp_bridge_mode_set(struct drm_bridge *drm_bridge,
+ 		msm_dp_panel->vsc_sdp_supported;
+ 
+ 	/* populate wide_bus_support to different layers */
+-	msm_dp_display->ctrl->wide_bus_en =
++	msm_dp_mode->wide_bus_en =
+ 		msm_dp_mode->out_fmt_is_yuv_420 ? false : msm_dp_display->wide_bus_supported;
+ 
+ 	rc = msm_dp_panel_init_panel_info(msm_dp_display->panel);
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index 38c456848653..ecca1dffeb1b 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -784,7 +784,7 @@ static int msm_dp_panel_setup_vsc_sdp_yuv_420(struct msm_dp_panel *msm_dp_panel)
+ 	return 0;
+ }
+ 
+-int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en)
++int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel)
+ {
+ 	u32 data, total_ver, total_hor;
+ 	struct msm_dp_panel_private *panel;
+@@ -796,7 +796,7 @@ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en)
+ 	u32 reg;
+ 
+ 	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
+-	drm_mode = &panel->msm_dp_panel.msm_dp_mode.drm_mode;
++	drm_mode = &msm_dp_panel->msm_dp_mode.drm_mode;
+ 
+ 	drm_dbg_dp(panel->drm_dev, "width=%d hporch= %d %d %d\n",
+ 		drm_mode->hdisplay, drm_mode->htotal - drm_mode->hsync_end,
+@@ -826,9 +826,9 @@ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en)
+ 
+ 	data = drm_mode->vsync_end - drm_mode->vsync_start;
+ 	data <<= 16;
+-	data |= (panel->msm_dp_panel.msm_dp_mode.v_active_low << 31);
++	data |= (msm_dp_panel->msm_dp_mode.v_active_low << 31);
+ 	data |= drm_mode->hsync_end - drm_mode->hsync_start;
+-	data |= (panel->msm_dp_panel.msm_dp_mode.h_active_low << 15);
++	data |= (msm_dp_panel->msm_dp_mode.h_active_low << 15);
+ 
+ 	width_blanking = data;
+ 
+@@ -844,12 +844,13 @@ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en)
+ 	msm_dp_write_link(panel, REG_DP_ACTIVE_HOR_VER, msm_dp_active);
+ 
+ 	reg = msm_dp_read_p0(panel, MMSS_DP_INTF_CONFIG);
+-	if (wide_bus_en)
++	if (msm_dp_panel->msm_dp_mode.wide_bus_en)
+ 		reg |= DP_INTF_CONFIG_DATABUS_WIDEN;
+ 	else
+ 		reg &= ~DP_INTF_CONFIG_DATABUS_WIDEN;
+ 
+-	drm_dbg_dp(panel->drm_dev, "wide_bus_en=%d reg=%#x\n", wide_bus_en, reg);
++	drm_dbg_dp(panel->drm_dev, "wide_bus_en=%d reg=%#x\n",
++				msm_dp_panel->msm_dp_mode.wide_bus_en, reg);
+ 
+ 	msm_dp_write_p0(panel, MMSS_DP_INTF_CONFIG, reg);
+ 
+@@ -1109,7 +1110,7 @@ static int msm_dp_populate_dsc_private_params(struct msm_dp_display_mode *msm_dp
+ 	total_bytes_per_intf = bytes_in_slice * slice_per_intf;
+ 
+ 	msm_dp_dsc->bytes_per_pkt = bytes_in_slice * slice_per_pkt;
+-	msm_dp_dsc->eol_byte_num = total_bytes_per_intf % 3;
++	msm_dp_dsc->eol_byte_num = (3 - total_bytes_per_intf % 3) % 3;
+ 	msm_dp_dsc->pclk_per_line = DIV_ROUND_UP(total_bytes_per_intf, 6) - 1;
+ 
+ 	return 0;
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.h b/drivers/gpu/drm/msm/dp/dp_panel.h
+index ce6f1d7e9ebe..933954204e55 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.h
++++ b/drivers/gpu/drm/msm/dp/dp_panel.h
+@@ -47,6 +47,7 @@ struct msm_dp_display_mode {
+ 	u32 h_active_low;
+ 	u32 v_active_low;
+ 	bool out_fmt_is_yuv_420;
++	bool wide_bus_en;
+ };
+ 
+ struct msm_dp_panel_psr {
+@@ -91,7 +92,7 @@ struct msm_dp_panel {
+ 
+ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel);
+ int msm_dp_panel_deinit(struct msm_dp_panel *msm_dp_panel);
+-int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel, bool wide_bus_en);
++int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel);
+ int msm_dp_panel_read_sink_caps(struct msm_dp_panel *msm_dp_panel,
+ 		struct drm_connector *connector);
+ struct msm_dp_display_mode_cfg msm_dp_panel_get_mode_cfg(struct msm_dp_panel *msm_dp_panel,
+-- 
+2.54.0
+
+
+From af1d486bd7280886951eeab52238ea533c2ad7d3 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Wed, 13 May 2026 21:34:02 -0300
+Subject: [PATCH 15/16] drm/msm/dp: allow 1/2 dsc compression in addition to
+ 1/3 ratio; use table for dto, prioritize tgt_bpp followed by src_bpp
+
+---
+ drivers/gpu/drm/msm/dp/dp_ctrl.c    |   4 +-
+ drivers/gpu/drm/msm/dp/dp_display.c |   6 +-
+ drivers/gpu/drm/msm/dp/dp_panel.c   | 183 ++++++++++++++++++++--------
+ drivers/gpu/drm/msm/dp/dp_panel.h   |  41 ++-----
+ 4 files changed, 145 insertions(+), 89 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_ctrl.c b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+index e8ef77f8e44c..0fbe6c6a334f 100644
+--- a/drivers/gpu/drm/msm/dp/dp_ctrl.c
++++ b/drivers/gpu/drm/msm/dp/dp_ctrl.c
+@@ -548,7 +548,9 @@ static void msm_dp_ctrl_calc_tu_parameters(struct msm_dp_ctrl_private *ctrl,
+ 	in.async_en = 0;
+ 	in.fec_en = ctrl->panel->fec_cap.enabled;
+ 	in.num_of_dsc_slices = ctrl->panel->msm_dp_mode.drm_dsc.slice_count;
+-	in.compress_ratio = 100 * MSM_DP_DSC_COMP_RATIO;
++	in.compress_ratio = mult_frac(100,
++			ctrl->panel->dsc_cap.dto.src_bpp,
++			ctrl->panel->dsc_cap.dto.tgt_bpp);
+ 
+ 	msm_dp_ctrl_calc_tu(ctrl->drm_dev, &in, tu_table);
+ }
+diff --git a/drivers/gpu/drm/msm/dp/dp_display.c b/drivers/gpu/drm/msm/dp/dp_display.c
+index e990b2d8537e..0c825d09e2ff 100644
+--- a/drivers/gpu/drm/msm/dp/dp_display.c
++++ b/drivers/gpu/drm/msm/dp/dp_display.c
+@@ -1587,14 +1587,14 @@ u32 msm_dp_dsc_get_extra_width(const struct msm_dp *msm_dp_display)
+ 	struct msm_dp_display_mode *msm_dp_mode = &dp->panel->msm_dp_mode;
+ 	struct drm_dsc_config *drm_dsc = &msm_dp_mode->drm_dsc;
+ 	struct msm_dp_dsc_cfg *msm_dp_dsc = &msm_dp_mode->msm_dp_dsc;
+-	struct msm_dp_display_mode_cfg *mode_cfg = &msm_dp_mode->mode_cfg;
+-	unsigned int dto_n = 0, dto_d = 0, remainder;
++	unsigned int dto_n, dto_d, remainder;
+ 	int ack_required, last_few_ack_required, accum_ack;
+ 	int last_few_pclk, last_few_pclk_required;
+ 	int start, temp, line_width = drm_dsc->pic_width / 2;
+ 	s64 temp1_fp, temp2_fp;
+ 
+-	msm_dp_panel_get_dto_params(mode_cfg->bpp, mode_cfg->bpp / MSM_DP_DSC_COMP_RATIO, &dto_n, &dto_d);
++	dto_n = dp->panel->dsc_cap.dto.dto_n;
++	dto_d = dp->panel->dsc_cap.dto.dto_d;
+ 
+ 	ack_required = msm_dp_dsc->pclk_per_line + 1;
+ 
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index ecca1dffeb1b..4c5e3aec470c 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -31,6 +31,18 @@ struct msm_dp_panel_private {
+ 	bool panel_on;
+ };
+ 
++/* corresponds to the min src_bpp in the table that follows */
++#define MSM_DP_MIN_SUPPORTED_DSC_SRC_BPP 24
++
++/* assumed to be sorted by tgt_bpp */
++static struct msm_dp_dto msm_dp_dto_params[] = {
++	{30, 15, 5, 8},
++	{24, 12, 1, 2},
++	{30, 10, 5, 12},
++	{30, 8, 1, 3},
++	{24, 8, 1, 3},
++};
++
+ static inline u32 msm_dp_read_link(struct msm_dp_panel_private *panel, u32 offset)
+ {
+ 	return readl_relaxed(panel->link_base + offset);
+@@ -235,13 +247,13 @@ static u32 msm_dp_panel_calc_link_rate(struct msm_dp_panel *msm_dp_panel,
+ 	return data_rate_khz;
+ }
+ 
+-static u32 msm_dp_panel_get_supported_bpp_no_dsc(
+-		u32 mode_edid_bpp,
++static u8 msm_dp_panel_get_supported_bpp_no_dsc(
++		u8 mode_edid_bpp,
+ 		u32 mode_pclk_khz,
+ 		u32 data_rate_khz)
+ {
+-	const u32 max_supported_bpp = 30, min_supported_bpp = 18;
+-	u32 bpp = min(mode_edid_bpp, max_supported_bpp);
++	const u8 max_supported_bpp = 30, min_supported_bpp = 18;
++	u8 bpp = min(mode_edid_bpp, max_supported_bpp);
+ 
+ 	for (; bpp >= min_supported_bpp; bpp -= 6)
+ 		if (mode_pclk_khz * bpp <= data_rate_khz)
+@@ -250,42 +262,50 @@ static u32 msm_dp_panel_get_supported_bpp_no_dsc(
+ 	return MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+ }
+ 
+-#define MSM_DP_MIN_SUPPORTED_DSC_BPP 24
+-static u32 msm_dp_panel_get_supported_bpp_dsc(
+-		u32 mode_edid_bpp,
++static u8 msm_dp_panel_get_supported_bpp_dsc(
++		u8 mode_edid_bpp,
+ 		u32 mode_pclk_khz,
+ 		u32 data_rate_khz,
+-		u8 bpc[3])
++		u8 bpc[3],
++		u8 *tgt_bpp)
+ {
+-	const u32 max_supported_bpp = min(mode_edid_bpp, 30);
+-	const u32 min_supported_bpp = MSM_DP_MIN_SUPPORTED_DSC_BPP;
+-	const u32 num_components = 3;
+-	u32 max_bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+-	int i;
+-
+-	for (i = 0; i < 3; i++) {
+-		if (bpc[i]) {
+-			u32 bpp = bpc[i] * num_components;
+-
+-			if (bpp > max_bpp &&
+-						bpp >= min_supported_bpp &&
+-						bpp <= max_supported_bpp &&
+-						mode_pclk_khz * bpp / MSM_DP_DSC_COMP_RATIO <=
+-									data_rate_khz)
+-				max_bpp = bpp;
++	const u8 max_supported_bpp = min(mode_edid_bpp, 30);
++	const u8 num_components = 3;
++	int i, j;
++
++	for (j = 0; j < ARRAY_SIZE(msm_dp_dto_params); j++) {
++		for (i = 0; i < 3; i++) {
++			if (bpc[i]) {
++				u8 bpp = bpc[i] * num_components;
++
++				if (bpp != msm_dp_dto_params[j].src_bpp)
++					continue;
++
++				if (bpp > max_supported_bpp)
++					continue;
++
++				if (mode_pclk_khz * msm_dp_dto_params[j].tgt_bpp <= data_rate_khz) {
++					if (tgt_bpp)
++						*tgt_bpp = msm_dp_dto_params[j].tgt_bpp;
++					return bpp;
++				}
++			}
+ 		}
+ 	}
+ 
+-	return max_bpp;
++	if (tgt_bpp)
++		*tgt_bpp = 0;
++	return MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+ }
+ 
+ static struct msm_dp_display_mode_cfg msm_dp_panel_get_cfg_from_bpp(
+-	u32 bpp, u32 dsc_bpp, enum msm_mode_dsc_cfg dsc_cfg, bool fec_en)
++	u8 bpp, u8 dsc_bpp, enum msm_mode_dsc_cfg dsc_cfg, bool fec_en, u8 tgt_bpp)
+ {
+-	const u32 min_supported_bpp = MSM_DP_MIN_SUPPORTED_DSC_BPP;
++	const u8 min_supported_bpp = MSM_DP_MIN_SUPPORTED_DSC_SRC_BPP;
+ 	struct msm_dp_display_mode_cfg cfg = {0};
+ 
+ 	cfg.fec_available = fec_en;
++	cfg.tgt_bpp = tgt_bpp;
+ 
+ 	if (!dsc_bpp)
+ 		dsc_cfg = MSM_MODE_DSC_UNAVAILABLE;
+@@ -321,14 +341,15 @@ static struct msm_dp_display_mode_cfg msm_dp_panel_get_cfg_from_bpp(
+ 
+ static struct msm_dp_display_mode_cfg msm_dp_panel_get_supported_cfg(
+ 		struct msm_dp_panel *msm_dp_panel,
+-		u32 mode_edid_bpp,
++		u8 mode_edid_bpp,
+ 		enum msm_mode_dsc_cfg dsc_cfg,
+ 		u32 mode_pclk_khz)
+ {
+-	u32 bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+-	u32 dsc_bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
++	u8 bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
++	u8 dsc_bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+ 	u32 data_rate_khz;
+ 	bool fec_en;
++	u8 tgt_bpp = 0;
+ 
+ 	fec_en = msm_dp_panel->fec_cap.supported;
+ 	data_rate_khz = msm_dp_panel_calc_link_rate(msm_dp_panel, fec_en);
+@@ -340,9 +361,9 @@ static struct msm_dp_display_mode_cfg msm_dp_panel_get_supported_cfg(
+ 	if (dsc_cfg > MSM_MODE_DSC_UNAVAILABLE)
+ 		dsc_bpp = msm_dp_panel_get_supported_bpp_dsc(
+ 					mode_edid_bpp, mode_pclk_khz, data_rate_khz,
+-					msm_dp_panel->dsc_cap.bpc);
++					msm_dp_panel->dsc_cap.bpc, &tgt_bpp);
+ 
+-	return msm_dp_panel_get_cfg_from_bpp(bpp, dsc_bpp, dsc_cfg, fec_en);
++	return msm_dp_panel_get_cfg_from_bpp(bpp, dsc_bpp, dsc_cfg, fec_en, tgt_bpp);
+ }
+ 
+ static void msm_dp_panel_read_sink_fec_caps(struct msm_dp_panel_private *panel)
+@@ -862,6 +883,28 @@ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel)
+ 	return 0;
+ }
+ 
++/**
++ * msm_dp_panel_get_dto_params() - get numerator and denominator for dsc bpp config
++ * @src_bpp: uncompressed bits per pixel
++ * @tgt_bpp: compressed bits per pixel
++ * @num: returning numerator
++ * @denom: returning denominator
++ */
++static inline void msm_dp_panel_get_dto_params(u8 src_bpp, u8 tgt_bpp, u8 *num, u8 *denom)
++{
++	int i;
++	for (i = 0; i < ARRAY_SIZE(msm_dp_dto_params); i++) {
++		if (msm_dp_dto_params[i].src_bpp == src_bpp && msm_dp_dto_params[i].tgt_bpp == tgt_bpp) {
++			*num = msm_dp_dto_params[i].dto_n;
++			*denom = msm_dp_dto_params[i].dto_d;
++			return;
++		}
++	}
++	DRM_ERROR("dto params not found for sbpp=%d tbpp=%d\n", src_bpp, tgt_bpp);
++	*num = 0;
++	*denom = 1;
++}
++
+ struct msm_dp_dsc_slices_per_line {
+ 	u32 min_ppr;
+ 	u32 max_ppr;
+@@ -1039,10 +1082,17 @@ static int msm_dp_panel_dsc_prepare(struct msm_dp_panel_private *panel)
+ 	else
+ 		drm_dsc->slice_height = 15;
+ 
+-	drm_dsc->bits_per_component = (msm_dp_mode->mode_cfg.bpp / 3);
+-	drm_dsc->bits_per_pixel = (msm_dp_mode->mode_cfg.bpp / MSM_DP_DSC_COMP_RATIO) << 4;
++	drm_dsc->bits_per_component = msm_dp_mode->mode_cfg.bpp / 3;
++	drm_dsc->bits_per_pixel = msm_dp_mode->mode_cfg.tgt_bpp << 4;
+ 	drm_dsc->slice_count = DIV_ROUND_UP(drm_mode->hdisplay, slice_width);
+ 
++	msm_dp_panel->dsc_cap.dto.src_bpp = msm_dp_mode->mode_cfg.bpp;
++	msm_dp_panel->dsc_cap.dto.tgt_bpp = msm_dp_mode->mode_cfg.tgt_bpp;
++	msm_dp_panel_get_dto_params(msm_dp_panel->dsc_cap.dto.src_bpp,
++				msm_dp_panel->dsc_cap.dto.tgt_bpp,
++				&msm_dp_panel->dsc_cap.dto.dto_n,
++				&msm_dp_panel->dsc_cap.dto.dto_d);
++
+ 	return 0;
+ }
+ 
+@@ -1074,8 +1124,9 @@ static int msm_populate_dsc_params(struct device *dev, struct drm_dsc_config *ds
+ 	return drm_dsc_compute_rc_parameters(dsc);
+ }
+ 
+-static int msm_dp_populate_dsc_private_params(struct msm_dp_display_mode *msm_dp_mode)
++static int msm_dp_populate_dsc_private_params(struct msm_dp_panel *msm_dp_panel)
+ {
++	struct msm_dp_display_mode *msm_dp_mode = &msm_dp_panel->msm_dp_mode;
+ 	struct drm_display_mode *drm_mode = &msm_dp_mode->drm_mode;
+ 	struct drm_dsc_config *drm_dsc = &msm_dp_mode->drm_dsc;
+ 	struct msm_dp_dsc_cfg *msm_dp_dsc = &msm_dp_mode->msm_dp_dsc;
+@@ -1084,7 +1135,11 @@ static int msm_dp_populate_dsc_private_params(struct msm_dp_display_mode *msm_dp
+ 	u32 slice_per_intf;
+ 	u32 bpp;
+ 	u32 bytes_in_slice;
+-	u32 total_bytes_per_intf;
++	u32 comp_ratio;
++	s64 temp1_fp, temp2_fp;
++	s64 numerator_fp, denominator_fp;
++	s64 dsc_byte_count_fp;
++	u32 dsc_byte_count, temp1, temp2;
+ 
+ 	if (!drm_dsc->slice_width ||
+ 			!drm_dsc->slice_height ||
+@@ -1098,20 +1153,32 @@ static int msm_dp_populate_dsc_private_params(struct msm_dp_display_mode *msm_dp
+ 	slice_per_intf = DIV_ROUND_UP(intf_width,
+ 				drm_dsc->slice_width);
+ 
+-	/*
+-	 * If slice_per_pkt is greater than slice_per_intf then default to 1.
+-	 * This can happen during partial update.
+-	 */
+-	if (slice_per_pkt > slice_per_intf)
+-		slice_per_pkt = 1;
+-
+ 	bpp = drm_dsc->bits_per_pixel >> 4;
+ 	bytes_in_slice = DIV_ROUND_UP(drm_dsc->slice_width * bpp, 8);
+-	total_bytes_per_intf = bytes_in_slice * slice_per_intf;
+ 
+ 	msm_dp_dsc->bytes_per_pkt = bytes_in_slice * slice_per_pkt;
+-	msm_dp_dsc->eol_byte_num = (3 - total_bytes_per_intf % 3) % 3;
+-	msm_dp_dsc->pclk_per_line = DIV_ROUND_UP(total_bytes_per_intf, 6) - 1;
++	comp_ratio = mult_frac(100,
++				msm_dp_panel->dsc_cap.dto.src_bpp,
++				msm_dp_panel->dsc_cap.dto.tgt_bpp);
++
++	temp1_fp = drm_fixp_from_fraction(comp_ratio, 100);
++	temp2_fp = drm_fixp_from_fraction(slice_per_pkt * 8, 1);
++	denominator_fp = drm_fixp_mul(temp1_fp, temp2_fp);
++	numerator_fp = drm_fixp_from_fraction(
++			intf_width * drm_dsc->bits_per_component * 3, 1);
++	dsc_byte_count_fp = drm_fixp_div(numerator_fp, denominator_fp);
++	dsc_byte_count = drm_fixp2int_ceil(dsc_byte_count_fp);
++
++	temp1 = dsc_byte_count * slice_per_intf;
++	temp2 = temp1;
++	if (temp1 % 3 != 0)
++		temp1 += 3 - (temp1 % 3);
++
++	msm_dp_dsc->eol_byte_num = temp1 - temp2;
++
++	temp1_fp = drm_fixp_from_fraction(slice_per_intf, 6);
++	temp2_fp = drm_fixp_mul(dsc_byte_count_fp, temp1_fp);
++	msm_dp_dsc->pclk_per_line = drm_fixp2int_ceil(temp2_fp) - 1;
+ 
+ 	return 0;
+ }
+@@ -1120,6 +1187,7 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ {
+ 	struct drm_display_mode *drm_mode;
+ 	struct msm_dp_display_mode_cfg *mode_cfg;
++	enum msm_mode_dsc_cfg dsc_cfg;
+ 	struct msm_dp_panel_private *panel;
+ 	struct msm_dp_display_mode *msm_dp_mode = &msm_dp_panel->msm_dp_mode;
+ 	int rc;
+@@ -1150,22 +1218,29 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 				drm_mode->clock);
+ 	drm_dbg_dp(panel->drm_dev, "bpp = %d\n", mode_cfg->bpp);
+ 
+-	mode_cfg->dsc = msm_dp_panel->dsc_cap.enabled ?
++	dsc_cfg = msm_dp_panel->dsc_cap.enabled ?
+ 				MSM_MODE_DSC_REQUIRED : MSM_MODE_DSC_UNAVAILABLE;
+ 
+ 	*mode_cfg = msm_dp_panel_get_mode_cfg(
+ 						      msm_dp_panel,
+ 						      mode_cfg->bpp,
+-						      mode_cfg->dsc,
++						      dsc_cfg,
+ 						      drm_mode->clock);
+ 
++	if (mode_cfg->dsc != dsc_cfg) {
++		drm_dbg_dp(panel->drm_dev,
++				"dsc config failed\n");
++		return -EINVAL;
++	}
++
+ 	msm_dp_panel->fec_cap.enabled = mode_cfg->fec_available;
+ 	msm_dp_panel->dsc_cap.enabled = mode_cfg->dsc == MSM_MODE_DSC_REQUIRED;
+ 
+-	drm_dbg_dp(panel->drm_dev, "updated_bpp=%d fec=%d dsc=%d\n",
++	drm_dbg_dp(panel->drm_dev, "updated_bpp=%d fec=%d dsc=%d dsc_bpp=%d\n",
+ 				mode_cfg->bpp,
+ 				msm_dp_panel->fec_cap.enabled,
+-				msm_dp_panel->dsc_cap.enabled);
++				msm_dp_panel->dsc_cap.enabled,
++				mode_cfg->tgt_bpp);
+ 
+ 	if (msm_dp_panel->dsc_cap.enabled) {
+ 		if ((rc = msm_dp_panel_dsc_prepare(panel))) {
+@@ -1180,7 +1255,7 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 			return rc;
+ 		}
+ 
+-		if ((rc = msm_dp_populate_dsc_private_params(msm_dp_mode))) {
++		if ((rc = msm_dp_populate_dsc_private_params(msm_dp_panel))) {
+ 			drm_dbg_dp(panel->drm_dev,
+ 					"failed populating other dsc params\n");
+ 			return rc;
+@@ -1228,11 +1303,11 @@ u8 msm_dp_panel_get_colorimetry_config(struct msm_dp_panel *msm_dp_panel)
+ 
+ 	return colorimetry;
+ }
++
+ void msm_dp_panel_config_dsc_dto(struct msm_dp_panel *msm_dp_panel)
+ {
+ 	struct msm_dp_panel_private *panel;
+ 	struct msm_dp_dsc_cfg *msm_dp_dsc;
+-	struct msm_dp_display_mode_cfg *mode_cfg;
+ 	u32 reg;
+ 
+ 	bool dto_en = true;
+@@ -1247,10 +1322,10 @@ void msm_dp_panel_config_dsc_dto(struct msm_dp_panel *msm_dp_panel)
+ 
+ 	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
+ 	msm_dp_dsc = &msm_dp_panel->msm_dp_mode.msm_dp_dsc;
+-	mode_cfg = &msm_dp_panel->msm_dp_mode.mode_cfg;
+ 
+ 	dto_count = msm_dp_dsc->pclk_per_line;
+-	msm_dp_panel_get_dto_params(mode_cfg->bpp, mode_cfg->bpp / MSM_DP_DSC_COMP_RATIO, &dto_n, &dto_d);
++	dto_n = msm_dp_panel->dsc_cap.dto.dto_n;
++	dto_d = msm_dp_panel->dsc_cap.dto.dto_d;
+ 
+ 	msm_dp_write_p0(panel, MMSS_DP_DSC_DTO_COUNT, dto_count);
+ 	reg = msm_dp_read_p0(panel, MMSS_DP_DSC_DTO);
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.h b/drivers/gpu/drm/msm/dp/dp_panel.h
+index 933954204e55..d41bea77534b 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.h
++++ b/drivers/gpu/drm/msm/dp/dp_panel.h
+@@ -15,12 +15,11 @@
+ 
+ struct edid;
+ 
+-#define MSM_DP_DSC_COMP_RATIO 3
+-
+ #define MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE 0
+ 
+ struct msm_dp_display_mode_cfg {
+-	u32 bpp;
++	u8 bpp;
++	u8 tgt_bpp;
+ 	bool fec_available;
+ 	enum msm_mode_dsc_cfg dsc;
+ };
+@@ -60,6 +59,13 @@ struct msm_dp_panel_fec {
+ 	bool enabled;
+ };
+ 
++struct msm_dp_dto {
++	u8 src_bpp;
++	u8 tgt_bpp;
++	u8 dto_n;
++	u8 dto_d;
++};
++
+ struct msm_dp_panel_dsc {
+ 	bool supported;
+ 	u8 version_major;
+@@ -68,6 +74,7 @@ struct msm_dp_panel_dsc {
+ 	u8 bpc[3];
+ 	bool enabled;
+ 	u32 num_dsc;
++	struct msm_dp_dto dto;
+ };
+ 
+ struct msm_dp_panel {
+@@ -109,34 +116,6 @@ void msm_dp_panel_override_ack_dto(struct msm_dp_panel *msm_dp_panel, bool not_a
+ void msm_dp_panel_enable_vsc_sdp(struct msm_dp_panel *msm_dp_panel, struct dp_sdp *vsc_sdp);
+ void msm_dp_panel_disable_vsc_sdp(struct msm_dp_panel *msm_dp_panel);
+ 
+-/**
+- * msm_dp_panel_get_dto_params() - get numerator and denominator for dsc bpp config
+- * @src_bpp: uncompressed bits per pixel
+- * @tgt_bpp: compressed bits per pixel
+- * @num: returning numerator
+- * @denom: returning denominator
+- */
+-static inline void msm_dp_panel_get_dto_params(u32 src_bpp, u32 tgt_bpp, u32 *num, u32 *denom)
+-{
+-	if ((tgt_bpp == 12) && (src_bpp == 24)) {
+-		*num = 1;
+-		*denom = 2;
+-	} else if ((tgt_bpp == 15) && (src_bpp == 30)) {
+-		*num = 5;
+-		*denom = 8;
+-	} else if ((tgt_bpp == 8) && ((src_bpp == 24) || (src_bpp == 30))) {
+-		*num = 1;
+-		*denom = 3;
+-	} else if ((tgt_bpp == 10) && (src_bpp == 30)) {
+-		*num = 5;
+-		*denom = 12;
+-	} else {
+-		DRM_ERROR("dto params not found for sbpp=%d tbpp=%d\n", src_bpp, tgt_bpp);
+-		*num = 0;
+-		*denom = 1;
+-	}
+-}
+-
+ /**
+  * is_link_rate_valid() - validates the link rate
+  * @bw_code: link rate requested by the sink
+-- 
+2.54.0
+
+
+From 970a7a77e8357fb49aa1acffd98c3548a91de034 Mon Sep 17 00:00:00 2001
+From: JS Deck <jsdeckerido@gmail.com>
+Date: Thu, 14 May 2026 13:09:44 -0300
+Subject: [PATCH 16/16] drm/msm/dp: add dsc overhead to bandwidth calc
+
+---
+ drivers/gpu/drm/msm/dp/dp_debug.c   |   2 +
+ drivers/gpu/drm/msm/dp/dp_display.c |  20 +--
+ drivers/gpu/drm/msm/dp/dp_panel.c   | 210 ++++++++++++++++++++--------
+ drivers/gpu/drm/msm/dp/dp_panel.h   |   4 +-
+ 4 files changed, 166 insertions(+), 70 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_debug.c b/drivers/gpu/drm/msm/dp/dp_debug.c
+index 18fc3b6f7902..82ab66d6826b 100644
+--- a/drivers/gpu/drm/msm/dp/dp_debug.c
++++ b/drivers/gpu/drm/msm/dp/dp_debug.c
+@@ -66,6 +66,8 @@ static int msm_dp_debug_show(struct seq_file *seq, void *p)
+ 			drm_mode->clock);
+ 	seq_printf(seq, "\t\tbpp = %d\n",
+ 			debug->panel->msm_dp_mode.mode_cfg.bpp);
++	seq_printf(seq, "\t\ttgt_bpp = %d\n",
++			debug->panel->msm_dp_mode.mode_cfg.tgt_bpp);
+ 	seq_printf(seq, "\t\tfec = %d\n",
+ 			debug->panel->msm_dp_mode.mode_cfg.fec_available);
+ 	seq_printf(seq, "\t\tdsc = %d\n",
+diff --git a/drivers/gpu/drm/msm/dp/dp_display.c b/drivers/gpu/drm/msm/dp/dp_display.c
+index 0c825d09e2ff..b86cbfc77930 100644
+--- a/drivers/gpu/drm/msm/dp/dp_display.c
++++ b/drivers/gpu/drm/msm/dp/dp_display.c
+@@ -923,7 +923,7 @@ enum drm_mode_status msm_dp_bridge_mode_valid(struct drm_bridge *bridge,
+ 	u32 mode_bpp;
+ 	struct msm_dp *dp;
+ 	int mode_pclk_khz = mode->clock;
+-	struct msm_dp_display_mode_cfg mode_cfg;
++	struct msm_dp_display_mode msm_dp_mode = {0};
+ 
+ 	dp = to_dp_bridge(bridge)->msm_dp_display;
+ 
+@@ -946,14 +946,16 @@ enum drm_mode_status msm_dp_bridge_mode_valid(struct drm_bridge *bridge,
+ 	if (!mode_bpp)
+ 		mode_bpp = default_bpp;
+ 
++	drm_mode_copy(&msm_dp_mode.drm_mode, mode);
++
+ 	/* Need to use clock not-scaled by yuv/wide-bus for link rate check */
+-	mode_cfg = msm_dp_panel_get_mode_cfg(msm_dp_display->panel,
++	msm_dp_mode.mode_cfg = msm_dp_panel_get_mode_cfg(msm_dp_display->panel,
+ 			mode_bpp,
+ 			msm_dp_display->panel->dsc_cap.supported ?
+ 					MSM_MODE_DSC_OPTIONAL : MSM_MODE_DSC_UNAVAILABLE,
+-			mode->clock);
++			&msm_dp_mode);
+ 
+-	if (mode_cfg.bpp == MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE)
++	if (msm_dp_mode.mode_cfg.bpp == MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE)
+ 		return MODE_BAD;
+ 
+ 	return MODE_OK;
+@@ -1552,7 +1554,7 @@ enum msm_mode_dsc_cfg msm_dp_get_mode_dsc_cfg(struct msm_dp *msm_dp_display,
+ 	const u32 num_components = 3, default_bpp = 24;
+ 	struct msm_dp_display_private *dp;
+ 	u32 mode_bpp;
+-	struct msm_dp_display_mode_cfg mode_cfg;
++	struct msm_dp_display_mode msm_dp_mode = {0};
+ 
+ 	dp = container_of(msm_dp_display, struct msm_dp_display_private, msm_dp_display);
+ 
+@@ -1563,9 +1565,11 @@ enum msm_mode_dsc_cfg msm_dp_get_mode_dsc_cfg(struct msm_dp *msm_dp_display,
+ 	if (!mode_bpp)
+ 		mode_bpp = default_bpp;
+ 
+-	mode_cfg = msm_dp_panel_get_mode_cfg(dp->panel,
+-			mode_bpp, MSM_MODE_DSC_OPTIONAL, mode->clock);
+-	return mode_cfg.dsc;
++	drm_mode_copy(&msm_dp_mode.drm_mode, mode);
++
++	msm_dp_mode.mode_cfg = msm_dp_panel_get_mode_cfg(dp->panel,
++			mode_bpp, MSM_MODE_DSC_OPTIONAL, &msm_dp_mode);
++	return msm_dp_mode.mode_cfg.dsc;
+ }
+ 
+ void msm_dp_set_dsc_enable(struct msm_dp *msm_dp_display, int num_dsc)
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.c b/drivers/gpu/drm/msm/dp/dp_panel.c
+index 4c5e3aec470c..038a77ccfa43 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.c
++++ b/drivers/gpu/drm/msm/dp/dp_panel.c
+@@ -262,21 +262,31 @@ static u8 msm_dp_panel_get_supported_bpp_no_dsc(
+ 	return MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+ }
+ 
++static int msm_dp_panel_dsc_populate_params(struct msm_dp_panel *msm_dp_panel,
++			struct msm_dp_display_mode *msm_dp_mode,
++			u32 num_dsc,
++			struct msm_dp_dto *dto_params);
+ static u8 msm_dp_panel_get_supported_bpp_dsc(
++		struct msm_dp_panel *msm_dp_panel,
+ 		u8 mode_edid_bpp,
+ 		u32 mode_pclk_khz,
+ 		u32 data_rate_khz,
+-		u8 bpc[3],
+-		u8 *tgt_bpp)
++		u8 *tgt_bpp,
++		struct msm_dp_display_mode *msm_dp_mode,
++		u32 num_dsc,
++		struct msm_dp_dto *dto_params)
+ {
+ 	const u8 max_supported_bpp = min(mode_edid_bpp, 30);
+ 	const u8 num_components = 3;
+-	int i, j;
++	int i, j, rc;
++	s64 data_rate_fp = drm_int2fixp(data_rate_khz);
+ 
+ 	for (j = 0; j < ARRAY_SIZE(msm_dp_dto_params); j++) {
+ 		for (i = 0; i < 3; i++) {
+-			if (bpc[i]) {
+-				u8 bpp = bpc[i] * num_components;
++			if (msm_dp_panel->dsc_cap.bpc[i]) {
++				u8 bpp = msm_dp_panel->dsc_cap.bpc[i] * num_components;
++				s64 data_rate_dsc_fp;
++				u32 data_rate_dsc;
+ 
+ 				if (bpp != msm_dp_dto_params[j].src_bpp)
+ 					continue;
+@@ -284,7 +294,18 @@ static u8 msm_dp_panel_get_supported_bpp_dsc(
+ 				if (bpp > max_supported_bpp)
+ 					continue;
+ 
+-				if (mode_pclk_khz * msm_dp_dto_params[j].tgt_bpp <= data_rate_khz) {
++				msm_dp_mode->mode_cfg.bpp = msm_dp_dto_params[j].src_bpp;
++				msm_dp_mode->mode_cfg.tgt_bpp = msm_dp_dto_params[j].tgt_bpp;
++
++				if ((rc = msm_dp_panel_dsc_populate_params(msm_dp_panel,
++							msm_dp_mode, num_dsc, dto_params)))
++					continue;
++
++				data_rate_dsc_fp = drm_fixp_div(data_rate_fp,
++							msm_dp_mode->msm_dp_dsc.dsc_overhead_fp);
++				data_rate_dsc = drm_fixp2int(data_rate_dsc_fp);
++
++				if (mode_pclk_khz * msm_dp_dto_params[j].tgt_bpp <= data_rate_dsc) {
+ 					if (tgt_bpp)
+ 						*tgt_bpp = msm_dp_dto_params[j].tgt_bpp;
+ 					return bpp;
+@@ -343,13 +364,16 @@ static struct msm_dp_display_mode_cfg msm_dp_panel_get_supported_cfg(
+ 		struct msm_dp_panel *msm_dp_panel,
+ 		u8 mode_edid_bpp,
+ 		enum msm_mode_dsc_cfg dsc_cfg,
+-		u32 mode_pclk_khz)
++		struct msm_dp_display_mode *msm_dp_mode,
++		u32 num_dsc,
++		struct msm_dp_dto *dto_params)
+ {
+ 	u8 bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+ 	u8 dsc_bpp = MSM_DP_DISPLAY_MODE_BPP_UNAVAILABLE;
+ 	u32 data_rate_khz;
+ 	bool fec_en;
+ 	u8 tgt_bpp = 0;
++	u32 mode_pclk_khz = msm_dp_mode->drm_mode.clock;
+ 
+ 	fec_en = msm_dp_panel->fec_cap.supported;
+ 	data_rate_khz = msm_dp_panel_calc_link_rate(msm_dp_panel, fec_en);
+@@ -360,8 +384,9 @@ static struct msm_dp_display_mode_cfg msm_dp_panel_get_supported_cfg(
+ 
+ 	if (dsc_cfg > MSM_MODE_DSC_UNAVAILABLE)
+ 		dsc_bpp = msm_dp_panel_get_supported_bpp_dsc(
+-					mode_edid_bpp, mode_pclk_khz, data_rate_khz,
+-					msm_dp_panel->dsc_cap.bpc, &tgt_bpp);
++					msm_dp_panel,
++					mode_edid_bpp, mode_pclk_khz, data_rate_khz, &tgt_bpp,
++					msm_dp_mode, num_dsc, dto_params);
+ 
+ 	return msm_dp_panel_get_cfg_from_bpp(bpp, dsc_bpp, dsc_cfg, fec_en, tgt_bpp);
+ }
+@@ -501,16 +526,18 @@ int msm_dp_panel_read_sink_caps(struct msm_dp_panel *msm_dp_panel,
+ 	return rc;
+ }
+ 
++#define MSM_DP_NUM_DSC_MAX 2
++/* msm_dp_mode may be NULL, in which case we use the one from msm_dp_panel */
+ struct msm_dp_display_mode_cfg msm_dp_panel_get_mode_cfg(
+ 		struct msm_dp_panel *msm_dp_panel,
+ 		u32 mode_edid_bpp,
+ 		enum msm_mode_dsc_cfg dsc_cfg,
+-		u32 mode_pclk_khz)
++		struct msm_dp_display_mode *msm_dp_mode)
+ {
+ 	struct msm_dp_panel_private *panel;
+ 	struct msm_dp_display_mode_cfg cfg = {0};
+ 
+-	if (!msm_dp_panel || !mode_edid_bpp || !mode_pclk_khz) {
++	if (!msm_dp_panel || !mode_edid_bpp) {
+ 		DRM_ERROR("invalid input\n");
+ 		return cfg;
+ 	}
+@@ -522,8 +549,17 @@ struct msm_dp_display_mode_cfg msm_dp_panel_get_mode_cfg(
+ 				panel->link->test_video.test_bit_depth);
+ 		return cfg;
+ 	} else {
+-		return msm_dp_panel_get_supported_cfg(msm_dp_panel, mode_edid_bpp,
+-				dsc_cfg, mode_pclk_khz);
++		if (msm_dp_mode) {
++			struct msm_dp_dto dto_params;
++			return msm_dp_panel_get_supported_cfg(msm_dp_panel, mode_edid_bpp,
++					dsc_cfg, msm_dp_mode, MSM_DP_NUM_DSC_MAX, &dto_params);
++		} else {
++			return msm_dp_panel_get_supported_cfg(msm_dp_panel, mode_edid_bpp,
++					dsc_cfg,
++					&msm_dp_panel->msm_dp_mode,
++					msm_dp_panel->dsc_cap.num_dsc,
++					&msm_dp_panel->dsc_cap.dto);
++		}
+ 	}
+ }
+ 
+@@ -980,13 +1016,17 @@ static bool msm_dp_panel_check_slice_support(u32 num_slices, u32 slice_caps_1,
+ 	return false;
+ }
+ 
+-static int msm_dp_panel_dsc_prepare(struct msm_dp_panel_private *panel)
++static int msm_dp_panel_dsc_prepare(struct msm_dp_panel *msm_dp_panel,
++			struct msm_dp_display_mode *msm_dp_mode,
++			u32 num_dsc,
++			struct msm_dp_dto *dto_params)
+ {
+-	struct msm_dp_panel *msm_dp_panel = &panel->msm_dp_panel;
+-	struct msm_dp_display_mode *msm_dp_mode = &msm_dp_panel->msm_dp_mode;
++	struct msm_dp_panel_private *panel =
++				container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
+ 	struct drm_display_mode *drm_mode = &msm_dp_mode->drm_mode;
+ 	struct drm_dsc_config *drm_dsc = &msm_dp_mode->drm_dsc;
+ 	struct msm_dp_dsc_cfg *msm_dp_dsc = &msm_dp_mode->msm_dp_dsc;
++	struct msm_dp_display_mode_cfg *mode_cfg = &msm_dp_mode->mode_cfg;
+ 
+ 	int slice_per_line_tbl_i;
+ 	const struct msm_dp_dsc_slices_per_line *rec;
+@@ -1030,12 +1070,12 @@ static int msm_dp_panel_dsc_prepare(struct msm_dp_panel_private *panel)
+ 
+ 	peak_throughput = peak_throughput_mode_0_tbl[ppr_max_index];
+ 
+-	if (!msm_dp_panel->dsc_cap.num_dsc)
++	if (!num_dsc)
+ 		return -EINVAL;
+ 
+ 	max_slice_width = msm_dp_panel->dsc_dpcd[DP_DSC_MAX_SLICE_WIDTH - DP_DSC_SUPPORT] *
+ 				DP_DSC_SLICE_WIDTH_MULTIPLIER;
+-	max_slice_width = min(max_slice_width, drm_mode->hdisplay / msm_dp_panel->dsc_cap.num_dsc);
++	max_slice_width = min(max_slice_width, drm_mode->hdisplay / num_dsc);
+ 
+ 	slice_width = (drm_mode->hdisplay /
+ 				msm_dp_dsc->slice_per_pkt);
+@@ -1082,25 +1122,28 @@ static int msm_dp_panel_dsc_prepare(struct msm_dp_panel_private *panel)
+ 	else
+ 		drm_dsc->slice_height = 15;
+ 
+-	drm_dsc->bits_per_component = msm_dp_mode->mode_cfg.bpp / 3;
+-	drm_dsc->bits_per_pixel = msm_dp_mode->mode_cfg.tgt_bpp << 4;
++	drm_dsc->bits_per_component = mode_cfg->bpp / 3;
++	drm_dsc->bits_per_pixel = mode_cfg->tgt_bpp << 4;
+ 	drm_dsc->slice_count = DIV_ROUND_UP(drm_mode->hdisplay, slice_width);
+ 
+-	msm_dp_panel->dsc_cap.dto.src_bpp = msm_dp_mode->mode_cfg.bpp;
+-	msm_dp_panel->dsc_cap.dto.tgt_bpp = msm_dp_mode->mode_cfg.tgt_bpp;
+-	msm_dp_panel_get_dto_params(msm_dp_panel->dsc_cap.dto.src_bpp,
+-				msm_dp_panel->dsc_cap.dto.tgt_bpp,
+-				&msm_dp_panel->dsc_cap.dto.dto_n,
+-				&msm_dp_panel->dsc_cap.dto.dto_d);
++	dto_params->src_bpp = mode_cfg->bpp;
++	dto_params->tgt_bpp = mode_cfg->tgt_bpp;
++	msm_dp_panel_get_dto_params(dto_params->src_bpp,
++				dto_params->tgt_bpp,
++				&dto_params->dto_n,
++				&dto_params->dto_d);
+ 
+ 	return 0;
+ }
+ 
+-static int msm_populate_dsc_params(struct device *dev, struct drm_dsc_config *dsc)
++static int msm_populate_dsc_params(struct msm_dp_panel *msm_dp_panel, struct drm_dsc_config *dsc)
+ {
+ 	int ret;
+ 	u32 bpp;
+ 
++	struct msm_dp_panel_private *panel =
++				container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
++
+ 	dsc->convert_rgb = 1;
+ 
+ 	drm_dsc_set_const_params(dsc);
+@@ -1114,7 +1157,7 @@ static int msm_populate_dsc_params(struct device *dev, struct drm_dsc_config *ds
+ 				dsc->dsc_version_minor == 1 || bpp == 8 || bpp == 12
+ 						? DRM_DSC_1_1_PRE_SCR : DRM_DSC_1_2_444);
+ 	if (ret) {
+-		DRM_DEV_ERROR(dev, "could not find DSC RC parameters\n");
++		drm_dbg_dp(panel->drm_dev, "could not find DSC RC parameters\n");
+ 		return ret;
+ 	}
+ 
+@@ -1124,9 +1167,44 @@ static int msm_populate_dsc_params(struct device *dev, struct drm_dsc_config *ds
+ 	return drm_dsc_compute_rc_parameters(dsc);
+ }
+ 
+-static int msm_dp_populate_dsc_private_params(struct msm_dp_panel *msm_dp_panel)
++static s64 msm_dp_panel_dsc_bw_overhead_fixp(struct msm_dp_panel *msm_dp_panel,
++		struct msm_dp_dsc_cfg *msm_dp_dsc, u32 dsc_byte_cnt)
+ {
+-	struct msm_dp_display_mode *msm_dp_mode = &msm_dp_panel->msm_dp_mode;
++	int num_slices, tot_num_eoc_symbols;
++	int tot_num_hor_bytes, tot_num_dummy_bytes;
++	int dwidth_dsc_bytes, eoc_bytes;
++	u32 num_lanes;
++	struct msm_dp_panel_private *panel;
++
++	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
++
++	num_lanes = panel->link->link_params.num_lanes;
++	num_slices = msm_dp_dsc->slice_per_pkt;
++
++	eoc_bytes = dsc_byte_cnt % num_lanes;
++	tot_num_eoc_symbols = num_lanes * num_slices;
++	tot_num_hor_bytes = dsc_byte_cnt * num_slices;
++	tot_num_dummy_bytes = (num_lanes - eoc_bytes) * num_slices;
++
++	if (!eoc_bytes)
++		tot_num_dummy_bytes = 0;
++
++	dwidth_dsc_bytes = tot_num_hor_bytes + tot_num_eoc_symbols +
++				tot_num_dummy_bytes;
++
++	drm_dbg_dp(panel->drm_dev, "dwidth_dsc_bytes:%d, tot_num_hor_bytes:%d\n",
++			dwidth_dsc_bytes, tot_num_hor_bytes);
++
++	return drm_fixp_from_fraction(dwidth_dsc_bytes,
++			tot_num_hor_bytes);
++}
++
++static int msm_dp_populate_dsc_private_params(struct msm_dp_panel *msm_dp_panel,
++			struct msm_dp_display_mode *msm_dp_mode,
++			const struct msm_dp_dto *dto_params)
++{
++	struct msm_dp_panel_private *panel;
++
+ 	struct drm_display_mode *drm_mode = &msm_dp_mode->drm_mode;
+ 	struct drm_dsc_config *drm_dsc = &msm_dp_mode->drm_dsc;
+ 	struct msm_dp_dsc_cfg *msm_dp_dsc = &msm_dp_mode->msm_dp_dsc;
+@@ -1141,10 +1219,12 @@ static int msm_dp_populate_dsc_private_params(struct msm_dp_panel *msm_dp_panel)
+ 	s64 dsc_byte_count_fp;
+ 	u32 dsc_byte_count, temp1, temp2;
+ 
++	panel = container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
++
+ 	if (!drm_dsc->slice_width ||
+ 			!drm_dsc->slice_height ||
+ 			intf_width < drm_dsc->slice_width) {
+-		DRM_ERROR("invalid input, intf_width=%d slice_width=%d\n",
++		drm_dbg_dp(panel->drm_dev, "invalid input, intf_width=%d slice_width=%d\n",
+ 			intf_width, drm_dsc->slice_width);
+ 		return -EINVAL;
+ 	}
+@@ -1158,14 +1238,13 @@ static int msm_dp_populate_dsc_private_params(struct msm_dp_panel *msm_dp_panel)
+ 
+ 	msm_dp_dsc->bytes_per_pkt = bytes_in_slice * slice_per_pkt;
+ 	comp_ratio = mult_frac(100,
+-				msm_dp_panel->dsc_cap.dto.src_bpp,
+-				msm_dp_panel->dsc_cap.dto.tgt_bpp);
++				dto_params->src_bpp,
++				dto_params->tgt_bpp);
+ 
+ 	temp1_fp = drm_fixp_from_fraction(comp_ratio, 100);
+-	temp2_fp = drm_fixp_from_fraction(slice_per_pkt * 8, 1);
++	temp2_fp = drm_int2fixp(slice_per_pkt * 8);
+ 	denominator_fp = drm_fixp_mul(temp1_fp, temp2_fp);
+-	numerator_fp = drm_fixp_from_fraction(
+-			intf_width * drm_dsc->bits_per_component * 3, 1);
++	numerator_fp = drm_int2fixp(intf_width * drm_dsc->bits_per_component * 3);
+ 	dsc_byte_count_fp = drm_fixp_div(numerator_fp, denominator_fp);
+ 	dsc_byte_count = drm_fixp2int_ceil(dsc_byte_count_fp);
+ 
+@@ -1180,6 +1259,39 @@ static int msm_dp_populate_dsc_private_params(struct msm_dp_panel *msm_dp_panel)
+ 	temp2_fp = drm_fixp_mul(dsc_byte_count_fp, temp1_fp);
+ 	msm_dp_dsc->pclk_per_line = drm_fixp2int_ceil(temp2_fp) - 1;
+ 
++	msm_dp_dsc->dsc_overhead_fp =
++				msm_dp_panel_dsc_bw_overhead_fixp(msm_dp_panel, msm_dp_dsc, dsc_byte_count);
++
++	return 0;
++}
++
++static int msm_dp_panel_dsc_populate_params(struct msm_dp_panel *msm_dp_panel,
++			struct msm_dp_display_mode *msm_dp_mode,
++			u32 num_dsc,
++			struct msm_dp_dto *dto_params)
++{
++	struct msm_dp_panel_private *panel =
++				container_of(msm_dp_panel, struct msm_dp_panel_private, msm_dp_panel);
++	int rc;
++
++	if ((rc = msm_dp_panel_dsc_prepare(msm_dp_panel, msm_dp_mode, num_dsc, dto_params))) {
++		drm_dbg_dp(panel->drm_dev,
++				"prepare dsc basic params failed\n");
++		return rc;
++	}
++
++	if ((rc = msm_populate_dsc_params(msm_dp_panel, &msm_dp_mode->drm_dsc))) {
++		drm_dbg_dp(panel->drm_dev,
++				"failed populating dsc params\n");
++		return rc;
++	}
++
++	if ((rc = msm_dp_populate_dsc_private_params(msm_dp_panel, msm_dp_mode, dto_params))) {
++		drm_dbg_dp(panel->drm_dev,
++				"failed populating other dsc params\n");
++		return rc;
++	}
++
+ 	return 0;
+ }
+ 
+@@ -1190,7 +1302,6 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 	enum msm_mode_dsc_cfg dsc_cfg;
+ 	struct msm_dp_panel_private *panel;
+ 	struct msm_dp_display_mode *msm_dp_mode = &msm_dp_panel->msm_dp_mode;
+-	int rc;
+ 
+ 	drm_mode = &msm_dp_mode->drm_mode;
+ 	mode_cfg = &msm_dp_mode->mode_cfg;
+@@ -1225,43 +1336,20 @@ int msm_dp_panel_init_panel_info(struct msm_dp_panel *msm_dp_panel)
+ 						      msm_dp_panel,
+ 						      mode_cfg->bpp,
+ 						      dsc_cfg,
+-						      drm_mode->clock);
++						      NULL);
+ 
+ 	if (mode_cfg->dsc != dsc_cfg) {
+ 		drm_dbg_dp(panel->drm_dev,
+ 				"dsc config failed\n");
+ 		return -EINVAL;
+ 	}
+-
+ 	msm_dp_panel->fec_cap.enabled = mode_cfg->fec_available;
+-	msm_dp_panel->dsc_cap.enabled = mode_cfg->dsc == MSM_MODE_DSC_REQUIRED;
+-
+ 	drm_dbg_dp(panel->drm_dev, "updated_bpp=%d fec=%d dsc=%d dsc_bpp=%d\n",
+ 				mode_cfg->bpp,
+ 				msm_dp_panel->fec_cap.enabled,
+ 				msm_dp_panel->dsc_cap.enabled,
+ 				mode_cfg->tgt_bpp);
+ 
+-	if (msm_dp_panel->dsc_cap.enabled) {
+-		if ((rc = msm_dp_panel_dsc_prepare(panel))) {
+-			drm_dbg_dp(panel->drm_dev,
+-					"prepare dsc basic params failed\n");
+-			return rc;
+-		}
+-
+-		if ((rc = msm_populate_dsc_params(panel->dev, &msm_dp_mode->drm_dsc))) {
+-			drm_dbg_dp(panel->drm_dev,
+-					"failed populating dsc params\n");
+-			return rc;
+-		}
+-
+-		if ((rc = msm_dp_populate_dsc_private_params(msm_dp_panel))) {
+-			drm_dbg_dp(panel->drm_dev,
+-					"failed populating other dsc params\n");
+-			return rc;
+-		}
+-	}
+-
+ 	return 0;
+ }
+ 
+diff --git a/drivers/gpu/drm/msm/dp/dp_panel.h b/drivers/gpu/drm/msm/dp/dp_panel.h
+index d41bea77534b..f77b28fdce1a 100644
+--- a/drivers/gpu/drm/msm/dp/dp_panel.h
++++ b/drivers/gpu/drm/msm/dp/dp_panel.h
+@@ -36,6 +36,7 @@ struct msm_dp_dsc_cfg {
+ 	u32 bytes_per_pkt;
+ 	u32 eol_byte_num;
+ 	u32 pclk_per_line;
++	s64 dsc_overhead_fp;
+ };
+ 
+ struct msm_dp_display_mode {
+@@ -103,7 +104,8 @@ int msm_dp_panel_timing_cfg(struct msm_dp_panel *msm_dp_panel);
+ int msm_dp_panel_read_sink_caps(struct msm_dp_panel *msm_dp_panel,
+ 		struct drm_connector *connector);
+ struct msm_dp_display_mode_cfg msm_dp_panel_get_mode_cfg(struct msm_dp_panel *msm_dp_panel,
+-			u32 mode_max_bpp, enum msm_mode_dsc_cfg dsc_cfg, u32 mode_pclk_khz);
++			u32 mode_max_bpp, enum msm_mode_dsc_cfg dsc_cfg,
++			struct msm_dp_display_mode *msm_dp_mode);
+ int msm_dp_panel_get_modes(struct msm_dp_panel *msm_dp_panel,
+ 		struct drm_connector *connector);
+ void msm_dp_panel_handle_sink_request(struct msm_dp_panel *msm_dp_panel);
+-- 
+2.54.0
+


### PR DESCRIPTION
## Summary

Add dsc support to displayport output on qualcomm devices.

## Testing

Tested on Pocket DS only.

## Additional Context

Like the patch that targets dpu resource fix, this patch should apply to all qualcomm devices running on kernel 7.0, for convenience I added the patch to 7.0 folder instead of per device. Let me know if you'd like that changed!

The patch is ported from https://lore.kernel.org/lkml/1674498274-6010-1-git-send-email-quic_khsieh@quicinc.com/

It was first ported as a singular patch (posted at https://gist.github.com/xzn/028a18f78f6fa6f08a8a0d6a3d29c232 )

Now it's split into commits formatted in a single file. Changes unrelated to dsc are separated to #2716

I've only tested this patch set with #2716 together but they should apply separately.

Patch 12 and 13 in this patch set is optional and doesn't seem needed for functions (they upgrade certain function to newer algorithms). They were in the original patch set posted on kernel mailing list so I decided to include them.

Similar to the other patch set, I'll try to upstream this once I figure out the process, and if I can get someone from qualcomm to look at it (more likely to happen if I can get someone from kernel mailing list to have attention).

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
