### PR TITLE
mangohud - bump to v0.8.3 final

### DIFF
--- a/projects/ROCKNIX/packages/apps/mangohud/config/MangoHud.conf
+++ b/projects/ROCKNIX/packages/apps/mangohud/config/MangoHud.conf
@@ -135,7 +135,7 @@ battery
 # device_battery=gamepad,mouse
 # device_battery_icon
 battery_watt
-# battery_time
+battery_time
 
 ### Display FPS and frametime
 fps

--- a/projects/ROCKNIX/packages/apps/mangohud/package.mk
+++ b/projects/ROCKNIX/packages/apps/mangohud/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2025-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="mangohud"
-PKG_VERSION="d7654ebcefb3bdb106d581c937417aa2007eaeeb" # v0.8.3-rc1 + a few fixes
+PKG_VERSION="330c42a5956e005a4d102473f5782bb0e3d94b6f" # v0.8.3
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/flightlessmango/MangoHud"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
@@ -81,12 +81,18 @@ post_makeinstall_target() {
   case ${DEVICE} in
     RK3326)
       sed -e "s/@FONT_SIZE@/30/g" -i ${INSTALL}/usr/config/MangoHud/MangoHud.conf
+
+      # No battery life estimate available
+      sed -i 's/^battery_time/\# battery_time/g' ${INSTALL}/usr/config/MangoHud/MangoHud.conf
     ;;
     S922X)
       sed -e "s/@FONT_SIZE@/30/g" -i ${INSTALL}/usr/config/MangoHud/MangoHud.conf
 
       # No GPU temperature sensor available
       sed -i 's/^gpu_temp/\# gpu_temp/g' ${INSTALL}/usr/config/MangoHud/MangoHud.conf
+
+      # No battery life estimate available
+      sed -i 's/^battery_time/\# battery_time/g' ${INSTALL}/usr/config/MangoHud/MangoHud.conf
     ;;
     *)
       sed -e "s/@FONT_SIZE@/40/g" -i ${INSTALL}/usr/config/MangoHud/MangoHud.conf

--- a/projects/ROCKNIX/packages/apps/mangohud/patches/SM8550/0002-SM8750-Battery.patch
+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/SM8550/0002-SM8750-Battery.patch
@@ -1,0 +1,1 @@
+../SM8750/0002-SM8750-Battery.patch

--- a/projects/ROCKNIX/packages/apps/mangohud/patches/SM8650/0002-SM8750-Battery.patch
+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/SM8650/0002-SM8750-Battery.patch
@@ -1,0 +1,1 @@
+../SM8750/0002-SM8750-Battery.patch

--- a/projects/ROCKNIX/packages/apps/mangohud/patches/qualcomm/0001-Qualcomm-GPU-support.patch
+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/qualcomm/0001-Qualcomm-GPU-support.patch
@@ -1,7 +1,7 @@
-From eb8317d04b29e7a3a0faac4ec386a2ec10071af8 Mon Sep 17 00:00:00 2001
+From 0f3532750022ea78094de7d74cb70553ea4134f1 Mon Sep 17 00:00:00 2001
 From: John Williams <porschemad911@gmail.com>
 Date: Tue, 12 May 2026 09:58:10 +1000
-Subject: [PATCH] Qualcomm GPU support
+Subject: [PATCH 1/2] Qualcomm GPU support
 
 ---
  src/gpu_fdinfo.cpp | 63 +++++++++++++++++++++++++++++++++++-----------

--- a/projects/ROCKNIX/packages/apps/mangohud/patches/qualcomm/0002-Qualcomm-battery-power_now.patch
+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/qualcomm/0002-Qualcomm-battery-power_now.patch
@@ -1,0 +1,50 @@
+From 191cd427d386323c11a02c186f4dab0dc3a9e957 Mon Sep 17 00:00:00 2001
+From: John Williams <porschemad911@gmail.com>
+Date: Thu, 14 May 2026 14:01:00 +1000
+Subject: [PATCH 2/2] Qualcomm - battery - power_now
+
+---
+ src/battery.cpp | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/src/battery.cpp b/src/battery.cpp
+index 947f446..3d5239b 100644
+--- a/src/battery.cpp
++++ b/src/battery.cpp
+@@ -111,16 +111,7 @@ float BatteryStats::getPower() {
+             return 0.0f;
+         }
+ 
+-        // Prefer power_now (µW) when available.
+-        if (fs::exists(power_now)) {
+-            std::ifstream input(power_now);
+-            std::string line;
+-            if (std::getline(input, line)) {
+-                power_w += std::fabs(stof(line)) / 1000000.0f;
+-            }
+-            continue;
+-        }
+-
++        // Prefer current_now and voltage_now, but fall back to power_now (µW).
+         if (fs::exists(current_now) && fs::exists(voltage_now)) {
+             float i_ua = 0.0f;
+             float v_uv = 0.0f;
+@@ -142,6 +133,15 @@ float BatteryStats::getPower() {
+ 
+             power_w += (std::fabs(i_ua) * std::fabs(v_uv)) * 1e-12f;
+         }
++        
++        else if (fs::exists(power_now)) {
++            std::ifstream input(power_now);
++            std::string line;
++            if (std::getline(input, line)) {
++                power_w += std::fabs(stof(line)) / 10000000.0f;
++            }
++            continue;
++        }
+     }
+ 
+     return power_w;
+-- 
+2.47.3
+

--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -319,3 +319,12 @@ rm -rf /storage/.config/ares/settings.*
 
 # Delete gopher64 config file
 rm -rf /storage/.config/gopher64/config.json
+
+# v0.8.3 mangohud config
+if [[ ! -e "/storage/.mangohud_v0.8.3_migration_complete" ]]; then
+  # If mangohud config dir exists, refresh config
+  [[ -d "/storage/.config/MangoHud" ]] && cp -f /usr/config/MangoHud/MangoHud.conf /storage/.config/MangoHud/MangoHud.conf
+
+  # Mark migration as complete
+  touch "/storage/.mangohud_v0.8.3_migration_complete"
+fi


### PR DESCRIPTION
## Summary

mangohud - bump to v0.8.3 final, enable battery time remaining estimates where possible

## Testing

Tested on S922X, SM6115 and SM8550

## Additional Context

Between v0.8.3-rc1 and and v0.8.3 final an upstream code change was made to prioritize `power_now` for power draw estimates. On some SOCs this gives clearly wrong numbers, so `voltage_now * current_now` has been prioritized via patch.

---

### AI Usage

**Did you use AI tools to help write this code?** NO
