### PR TITLE
sm8550/sm8650: fix thermal zone names

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8550/005-thermal_path
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8550/005-thermal_path
@@ -7,7 +7,7 @@ DEVICE_TEMP_SENSOR=""
 for zone in /sys/devices/virtual/thermal/thermal_zone*/; do
   type=$(cat "${zone}type" 2>/dev/null)
   case "${type}" in
-    cpu-*|cpuss-*|gpuss-*)
+    cpu*|gpuss*)
       DEVICE_TEMP_SENSOR="${DEVICE_TEMP_SENSOR} ${zone}temp"
       ;;
   esac

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8650/005-thermal_path
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8650/005-thermal_path
@@ -7,7 +7,7 @@ DEVICE_TEMP_SENSOR=""
 for zone in /sys/devices/virtual/thermal/thermal_zone*/; do
   type=$(cat "${zone}type" 2>/dev/null)
   case "${type}" in
-    cpu-*|cpuss-*|gpuss-*)
+    cpu*|gpuss*)
       DEVICE_TEMP_SENSOR="${DEVICE_TEMP_SENSOR} ${zone}temp"
       ;;
   esac


### PR DESCRIPTION
### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
