### PR TITLE
Disable bottom screen UI when HDMI is connected

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
@@ -22,6 +22,10 @@ if [ -z "${CURRENT_CORE}" ] || [ -z "${ROM_PATH}" ]; then
 fi
 
 ROM_NAME=$(basename "${ROM_PATH}" | sed 's/\.[^.]*$//')
+EXTERNAL_DISPLAY_CONNECTED=false
+if grep -q "^connected$" /sys/class/drm/card*-HDMI*/status 2>/dev/null || grep -q "^connected$" /sys/class/drm/card*-DP*/status 2>/dev/null; then
+    EXTERNAL_DISPLAY_CONNECTED=true
+fi
 IS_VERTICAL=false
 
 case "${CURRENT_CORE}" in
@@ -90,7 +94,7 @@ if [ "${IS_VERTICAL}" = "true" ]; then
         swaymsg input "0:0:generic_ft5x06_(8d)" map_to_output DSI-1
         swaymsg input "0:0:generic_ft5x06_(8d)" events enabled
     fi
-elif [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ]; then
+elif [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ] && [ "${EXTERNAL_DISPLAY_CONNECTED}" = "false" ]; then
     BOTTOM_SCREEN_TYPE=$(get_setting rocknix.bottomscreen.type 2>/dev/null)
     if [ -z "${BOTTOM_SCREEN_TYPE}" ]; then
         set_setting rocknix.bottomscreen.type vc 2>/dev/null


### PR DESCRIPTION
## Summary

Disable bottom screen UI when HDMI is connected.
Prevents HDMI connection issues on single-screen devices. 

issue : https://discord.com/channels/948029830325235753/1075906301705601044/1504342065499340890
issue2: https://discord.com/channels/948029830325235753/1075906301705601044/1505209703947571210


## Testing

Tested with HDMI on the RG35XXSP

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
