### PR TITLE
Upgrade heroic games launcher to 2.22.0

### DIFF
--- a/projects/ROCKNIX/packages/virtual/emulators/sources/Install Heroic Games Launcher.sh
+++ b/projects/ROCKNIX/packages/virtual/emulators/sources/Install Heroic Games Launcher.sh
@@ -5,12 +5,17 @@
 source /etc/profile
 
 HEROIC_BASE="/storage/.local/share/heroic-arm64"
-HEROIC_TAR_URL="https://codeberg.org/trescenzi/rocknix-ports/raw/branch/main/heroic/Heroic-2.21.0-linux-arm64.tar.xz"
+HEROIC_VERSION="2.22.0"
+HEROIC_TAR_URL="https://codeberg.org/trescenzi/rocknix-ports/raw/branch/main/heroic/Heroic-${HEROIC_VERSION}-linux-arm64.tar.xz"
 HEROIC_BIN=""
 
+# This heroic resolve checks for the latest version others just use the one the fine.
+# Running install with heroic already installed will trigger an upgrade.
+# Because all of the other scripts use a similar resolve they will pick up
+# the latest version on next use.
 resolve_heroic_bin() {
   HEROIC_BIN=""
-  for candidate in "${HEROIC_BASE}"/Heroic*/heroic "${HEROIC_BASE}"/heroic; do
+  for candidate in "${HEROIC_BASE}"/Heroic*${HEROIC_VERSION}*/heroic; do
     [ -x "${candidate}" ] || continue
     HEROIC_BIN="${candidate}"
     return 0
@@ -56,14 +61,14 @@ if ! resolve_heroic_bin; then
   mkdir -p "${HEROIC_BASE}"
   TMP_ARCHIVE="/tmp/heroic-arm64.tar.xz"
   wget -c -t 5 -O "${TMP_ARCHIVE}" "${HEROIC_TAR_URL}" || exit 1
-  rm -rf "${HEROIC_BASE}/Heroic-Games-Launcher"
   tar -xJf "${TMP_ARCHIVE}" -C "${HEROIC_BASE}" || exit 1
   rm -f "${TMP_ARCHIVE}"
+  find /storage/.local/share/heroic-arm64 -maxdepth 1 -name "Heroic-*" ! -name "*${HEROIC_VERSION}*" -type d -exec rm -rv {} \;
   resolve_heroic_bin || exit 1
   chmod +x "${HEROIC_BIN}" || true
 fi
 
 heroic_seed_rom_launchers
 echo ""
-echo "Heroic installed successfully. You can now launch it from EmulationStation in the Heroic section."
+echo "Heroic ${HEROIC_VERSION} installed successfully. You can now launch it from EmulationStation in the Heroic section."
 sleep 10

--- a/projects/ROCKNIX/packages/virtual/emulators/sources/Install Heroic Games Launcher.sh
+++ b/projects/ROCKNIX/packages/virtual/emulators/sources/Install Heroic Games Launcher.sh
@@ -6,7 +6,7 @@ source /etc/profile
 
 HEROIC_BASE="/storage/.local/share/heroic-arm64"
 HEROIC_VERSION="2.22.0"
-HEROIC_TAR_URL="https://codeberg.org/trescenzi/rocknix-ports/raw/branch/main/heroic/Heroic-${HEROIC_VERSION}-linux-arm64.tar.xz"
+HEROIC_TAR_URL="https://github.com/trescenzi/heroic_builder/releases/download/v${HEROIC_VERSION}/Heroic-${HEROIC_VERSION}-linux-arm64.tar.xz"
 HEROIC_BIN=""
 
 # This heroic resolve checks for the latest version others just use the one the fine.


### PR DESCRIPTION
## Summary

- Alters `Install Heroic Games Launcher.sh` to upgrade the installed version if different from the one specified.
- Upgrades heroic games launcher to 2.22.0

## Testing

- I installed heroic games launcher from the current nightly and confirmed it worked
- Made a build of this pr
- Installed that build to my Retroid Pocket 6
- Ran `Install Heroic Games Launcher.sh` again and saw it upgrade
- Confirmed that games installed previously still worked

## Additional Context

Currently this is downloading a build I'm hosting on my ~~Codeberg(I'm on of those "leaving github" people)~~ Github. I switched to the Github version since I created the build repo. I did retest to confirm the url is correct for github. I don't think it would be hard to host a build under the ROCKNIX org. ~~I'm happy to make a repo that you could fork into the ROCKNIX org which uses github actions to do the build when Heroic releases another.~~(see other comment)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
