### PR TITLE
Update VPN services (Tailscale & ZeroTier) to wait for network connectivity before starting

### DIFF
--- a/projects/ROCKNIX/packages/network/tailscale/system.d/tailscaled.service
+++ b/projects/ROCKNIX/packages/network/tailscale/system.d/tailscaled.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Tailscale node agent
 Documentation=https://tailscale.com/kb/
-Wants=network-pre.target
-After=network-pre.target systemd-resolved.service
+Wants=network-online.target
+After=network-online.target systemd-resolved.service
 
 [Service]
 EnvironmentFile=/storage/.config/tailscaled.defaults

--- a/projects/ROCKNIX/packages/network/zerotier-one/system.d/zerotier-one.service
+++ b/projects/ROCKNIX/packages/network/zerotier-one/system.d/zerotier-one.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=zerotier-one
-Wants=network-pre.target
-After=network-pre.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/sbin/zerotier-one /storage/.config/zerotier/


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Fix VPN services coming up before Network connectivity, causing connection failures and the services to disable themselves.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Built and tested on AYN Thor (SM8550), rebooting device and observing tailscaled service starts properly and automatically connects to Tailnet, instead of failing and disabling the service.

This works in conjunction with a PR I will open momentarily on emulationstation-next that properly persists Tailscale VPN state between reboots.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

I do not have access to a Zero Tier One VPN, but the concept is the same -- you need internet connectivity to establish the VPN access, so why try to connect to the service before the network is up?

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

**NO**
