### PR TITLE
rocknix-fake-suspend - sensible suspend / resume action order

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -197,40 +197,40 @@ unblock_input() {
 }
 
 do_suspend_actions() {
-  # Turn off display
-  display_off
+  # Disable LEDs
+  disable_leds
 
   # Mute audio
   mute_audio
+
+  # Block input
+  block_input
+  
+  # Turn off display
+  display_off
 
   # Set CPU / GPU governors
   powersave_governors
 
   # CPU core parking (if enabled)
   [[ "${ENABLE_CORE_PARKING}" == "1" ]] && park_cores
-
-  # Block input
-  block_input
-
-  # Disable LEDs
-  disable_leds
 }
 
 do_resume_actions() {
-  # Turn on display
-  display_on
-
-  # Unmute audio
-  unmute_audio
+  # Undo CPU core parking (if enabled)
+  [[ "${ENABLE_CORE_PARKING}" == "1" ]] && unpark_cores
 
   # Restore CPU / GPU governors
   restore_governors
 
-  # Undo CPU core parking (if enabled)
-  [[ "${ENABLE_CORE_PARKING}" == "1" ]] && unpark_cores
+  # Turn on display
+  display_on
 
   # Unblock input
   unblock_input
+
+  # Unmute audio
+  unmute_audio
 
   # Restore LEDs
   enable_leds


### PR DESCRIPTION
## Summary

rocknix-fake-suspend - sensible suspend / resume action order

## Testing

Tested on my Mangmi Air X

## Additional Context

Speeds up suspend / resume actions, particularly on platforms where powersave governors really throttle the CPU down low

---

### AI Usage

**Did you use AI tools to help write this code?** NO