### PR TITLE
Ayn Thor: fix touchscreen in gamescope/steam

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
@@ -272,6 +272,8 @@
 		touchscreen-size-y = <1920>;
 		touchscreen-swapped-x-y;
 		touchscreen-inverted-x;
+
+		label = "top_touchscreen";
 	};
 };
 
@@ -388,6 +390,8 @@
 		touchscreen-size-y = <1240>;
 		touchscreen-swapped-x-y;
 		touchscreen-inverted-x;
+
+		label = "bottom_touchscreen";
 
 		no-regmap-bulk-read;
 	};

--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0015-touchscreen-edt-ft5x06-allow-to-override-input-name.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0015-touchscreen-edt-ft5x06-allow-to-override-input-name.patch
@@ -1,0 +1,35 @@
+From 23b054596a266e21a4fc9915138b49d5cfe9f6a7 Mon Sep 17 00:00:00 2001
+From: Philippe Simons <simons.philippe@gmail.com>
+Date: Thu, 14 May 2026 15:15:36 +0200
+Subject: [PATCH] touchscreen:edt-ft5x06: allow to override input name
+
+---
+ drivers/input/touchscreen/edt-ft5x06.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/input/touchscreen/edt-ft5x06.c b/drivers/input/touchscreen/edt-ft5x06.c
+index d0ab644be006..dabc1b11bb5a 100644
+--- a/drivers/input/touchscreen/edt-ft5x06.c
++++ b/drivers/input/touchscreen/edt-ft5x06.c
+@@ -1139,6 +1139,7 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client)
+ 	const struct edt_i2c_chip_data *chip_data;
+ 	struct edt_ft5x06_ts_data *tsdata;
+ 	unsigned int val;
++	const char *label;
+ 	struct input_dev *input;
+ 	unsigned long irq_flags;
+ 	int error;
+@@ -1310,6 +1311,10 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client)
+ 		"Model \"%s\", Rev. \"%s\", %dx%d sensors\n",
+ 		tsdata->name, tsdata->fw_version, tsdata->num_x, tsdata->num_y);
+ 
++	/* Allow device tree to override the input device name */
++	if (!device_property_read_string(&client->dev, "label", &label))
++		strscpy(tsdata->name, label, EDT_NAME_LEN);
++
+ 	input->name = tsdata->name;
+ 	input->id.bustype = BUS_I2C;
+ 	input->dev.parent = &client->dev;
+-- 
+2.54.0
+

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/touchcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/touchcontrol
@@ -6,12 +6,12 @@ cat <<EOF >/run/udev/rules.d/99-touchscreen-calibration.rules
 # left panel (ID_PATH=platform-a90000.i2c) -> (0 .. 1920) x (0 .. 1080)
 SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_TOUCHSCREEN}=="1", \
   ENV{ID_PATH}=="platform-a90000.i2c", \
-  ENV{LIBINPUT_CALIBRATION_MATRIX}="0.607595 0 0 0 1 0"
+  ENV{LIBINPUT_CALIBRATION_MATRIX}="0 -1 1 1 0 0"
 
 # right panel (ID_PATH=platform-98c000.i2c) -> (1920 .. 3160) x (0 .. 1080)
 SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_TOUCHSCREEN}=="1", \
   ENV{ID_PATH}=="platform-98c000.i2c", \
-  ENV{LIBINPUT_CALIBRATION_MATRIX}="0.392405 0 0.607595 0 1 0"
+  ENV{LIBINPUT_CALIBRATION_MATRIX}="0 -1 1 1 0 0"
 EOF
 udevadm control --reload
 udevadm trigger -s input

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
@@ -49,9 +49,6 @@ if [ "${IS_VERTICAL}" = "true" ]; then
         # Needs two separate swaymsg calls. Screen cannot move and have windows moved to it in the same line.
         swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 pos 340 1080'
         swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 1240 2160, move to output DSI-2, move absolute position 340 0'
-        # Additionally fix touch mapping for vertical stack.
-        swaymsg input "0:0:generic_ft5x06_(8d)" map_to_output DSI-1
-        swaymsg -- input "0:0:generic_ft5x06_(8d)" calibration_matrix 0 -1 1 1 0 0
     elif [ "${QUIRK_DEVICE}" = "AYN Thor Lite" ]; then
         # Same notes from above apply here.
         swaymsg '[title="RetroArch.*"] output DSI-1 pos 0 0, output DSI-2 power on pos 340 1080'

--- a/projects/ROCKNIX/packages/sysutils/systemd/hwdb.d/61-thor-ft5x06.hwdb
+++ b/projects/ROCKNIX/packages/sysutils/systemd/hwdb.d/61-thor-ft5x06.hwdb
@@ -2,6 +2,6 @@
 # Touchscreens expose BTN_TOUCH (EV_KEY) which inflates wlroots seat capabilities.
 # Explicitly mark as touchscreen-only to prevent seat capability 4 (Keyboard) hijacking.
 
-evdev:name:*ft5x06*:*
+evdev:name:*_touchscreen:*
  ID_INPUT_KEYBOARD=0
  ID_INPUT_TOUCHSCREEN=1

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -146,7 +146,10 @@ fi
 if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}" >> $SWAY_HOME/config
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:generic_ft5x06_(8d)\"" >> $SWAY_HOME/config
+  echo 'exec_always swaymsg input "0:0:top_touchscreen" map_to_output DSI-2' >> $SWAY_HOME/config
+  echo 'exec_always swaymsg input "0:0:bottom_touchscreen" map_to_output DSI-1' >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:top_touchscreen\"" >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:bottom_touchscreen\"" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"4660:22136:InputPlumber_Keyboard\"" >> $SWAY_HOME/config
 fi
 


### PR DESCRIPTION
## Summary

Touchscreen had wrong input scale in steam (due to calibration matrix), this change uses the same method as Ayn Thor Lite change by loki666, separate the two touchscreens inputs, and update the calibration matrix.

## Testing

Tested on Ayn Thor in Steam with Gamescope enabled. Tested some NDS games and those still work (bottom touchscreen).

## Additional Context

Based on https://github.com/ROCKNIX/distribution/commit/9b703b01994c382a410172d734671fe45b57cfe3

which has a rather clean way of making the two touchscreens separately identifiable.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
