### PR TITLE
[Mangmi Air X] Update Fuel Gauge for average current usage, add software thermistor …

### DIFF
--- a/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
+++ b/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
@@ -32,7 +32,7 @@
 		charge-full-design-microamp-hours = <5000000>;
 		voltage-min-design-microvolt = <3400000>;
 		voltage-max-design-microvolt = <4350000>;
-		constant-charge-current-max-microamp = <2040000>;
+		constant-charge-current-max-microamp = <3000000>;
 		constant-charge-voltage-max-microvolt = <4350000>;
 		precharge-current-microamp = <180000>;
 		charge-term-current-microamp = <180000>;
@@ -301,10 +301,11 @@
 		#sound-dai-cells = <0>;
 	};
 
-	fuel-gauge@64 {
+	fuel_gauge: fuel-gauge@64 {
 		compatible = "cellwise,cw221x";
 		reg = <0x64>;
 		monitored-battery = <&battery>;
+		#thermal-sensor-cells = <0>;
 		cellwise,sense-resistor-micro-ohms = <10000>;
 		cellwise,monitor-interval-ms = <5000>;
 		cellwise,battery-profile = /bits/ 8 <
@@ -373,7 +374,8 @@
 		monitored-battery = <&battery>;
 		interrupts-extended = <&tlmm 70 IRQ_TYPE_EDGE_FALLING>;
 		pinctrl-names = "default";
-		pinctrl-0 = <&chg_int_default>;
+		pinctrl-0 = <&chg_int_default>, <&chg_en_default>;
+		wakeup-source;
 
 		input-voltage-limit-microvolt = <4500000>;
 		input-current-limit-microamp = <2400000>;
@@ -1119,10 +1121,19 @@
 		bias-pull-up;
 		input-enable;
 	};
+
+	chg_en_default: chg-en-default-state {
+		pins = "gpio85";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
 };
 
 &usb {
 	status = "okay";
+	assigned-clock-rates = <19200000>, <133333333>;
 };
 
 &usb_dwc3 {
@@ -1322,6 +1333,30 @@
 		opp-1804800000 { opp-hz = /bits/ 64 <1804800000>; opp-peak-kBps = < 6220000>; };
 		opp-2016000000 { opp-hz = /bits/ 64 <2016000000>; opp-peak-kBps = < 7216000>; };
 		opp-2112000000 { opp-hz = /bits/ 64 <2112000000>; opp-peak-kBps = < 8368000>; };
+	};
+
+	thermal-zones {
+		battery-thermal {
+			polling-delay-passive = <5000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&fuel_gauge>;
+			linux,governor = "bang_bang";
+
+			trips {
+				battery_fan_on: battery-fan-on {
+					temperature = <40000>;
+					hysteresis = <5000>;
+					type = "active";
+				};
+			};
+
+			cooling-maps {
+				map0 {
+					trip = <&battery_fan_on>;
+					cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
 	};
 };
 

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0008-power-supply-add-cx221x-battery-gauge.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0008-power-supply-add-cx221x-battery-gauge.patch
@@ -9,8 +9,8 @@ reworked to use regmap and devm managed resources.
 ---
  drivers/power/supply/Kconfig          |  11 +
  drivers/power/supply/Makefile         |   1 +
- drivers/power/supply/cw221x_battery.c | 548 ++++++++++++++++++++++++++++
- 3 files changed, 560 insertions(+)
+ drivers/power/supply/cw221x_battery.c | 554 ++++++++++++++++++++++++++++
+ 3 files changed, 566 insertions(+)
  create mode 100644 drivers/power/supply/cw221x_battery.c
 
 diff --git a/drivers/power/supply/Kconfig b/drivers/power/supply/Kconfig
@@ -52,7 +52,7 @@ new file mode 100644
 index 000000000000..a1b2c3d4e5f6
 --- /dev/null
 +++ b/drivers/power/supply/cw221x_battery.c
-@@ -0,0 +1,548 @@
+@@ -0,0 +1,597 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Battery gauge driver for CellWise CW2215/CW2217/CW2218
@@ -69,6 +69,7 @@ index 000000000000..a1b2c3d4e5f6
 +#include <linux/power_supply.h>
 +#include <linux/regmap.h>
 +#include <linux/workqueue.h>
++#include <linux/thermal.h>
 +
 +#define CW221X_REG_CHIP_ID		0x00
 +#define CW221X_REG_VCELL_H		0x02
@@ -82,6 +83,7 @@ index 000000000000..a1b2c3d4e5f6
 +#define CW221X_REG_CYCLE_H		0xA4
 +#define CW221X_REG_SOH			0xA6
 +#define CW221X_REG_IC_STATE		0xA7
++#define CW221X_REG_STB_CUR_H		0xA8
 +#define CW221X_REG_FW_VERSION		0xAB
 +
 +#define CW221X_MODE_RESTART		0x30
@@ -118,7 +120,8 @@ index 000000000000..a1b2c3d4e5f6
 +	int voltage_uv;
 +	int soc;
 +	int temp_decidegc;
-+	long current_ua;
++	int current_ua;
++	int stb_current_ua;
 +	int cycle;
 +	int soh;
 +	int last_soc;
@@ -213,17 +216,23 @@ index 000000000000..a1b2c3d4e5f6
 +	int ret, i;
 +
 +	ret = regmap_read(cw->regmap, CW221X_REG_MODE_CONFIG, &reg_val);
-+	if (ret || reg_val != CW221X_MODE_ACTIVE)
++	if (ret)
++		return false;
++	if (reg_val != CW221X_MODE_ACTIVE)
 +		return true;
 +
 +	ret = regmap_read(cw->regmap, CW221X_REG_SOC_ALERT, &reg_val);
-+	if (ret || !(reg_val & CW221X_UPDATE_FLAG))
++	if (ret)
++		return false;
++	if (!(reg_val & CW221X_UPDATE_FLAG))
 +		return true;
 +
 +	for (i = 0; i < CW221X_PROFILE_SIZE; i++) {
 +		ret = regmap_read(cw->regmap, CW221X_REG_BAT_PROFILE + i,
 +				  &reg_val);
-+		if (ret || cw->profile[i] != (u8)reg_val)
++		if (ret)
++			return false;
++		if (cw->profile[i] != (u8)reg_val)
 +			return true;
 +	}
 +
@@ -268,19 +277,41 @@ index 000000000000..a1b2c3d4e5f6
 +	switch (cw->fw_version & CW221X_FW_VARIANT_MASK) {
 +	case CW2215_VARIANT:
 +	case CW2217_VARIANT:
-+		cw->current_ua = (long)((s16)raw * 1600000LL /
-+				  cw->rsense_uohm);
++		cw->current_ua = (int)((s16)raw * 1600000LL /
++				 cw->rsense_uohm);
 +		break;
 +	case CW2218_VARIANT:
 +		if (!cw->fw_version) {
 +			cw->current_ua = 0;
 +			break;
 +		}
-+		cw->current_ua = (long)((s16)raw * 3815000LL /
-+				  cw->rsense_uohm);
++		cw->current_ua = (int)((s16)raw * 3815000LL /
++				 cw->rsense_uohm);
 +		break;
 +	default:
 +		cw->current_ua = 0;
++		break;
++	}
++
++	ret = cw221x_read_word(cw, CW221X_REG_STB_CUR_H, &raw);
++	if (ret)
++		return ret;
++	switch (cw->fw_version & CW221X_FW_VARIANT_MASK) {
++	case CW2215_VARIANT:
++	case CW2217_VARIANT:
++		cw->stb_current_ua = (int)((s16)raw * 1600000LL /
++					   cw->rsense_uohm);
++		break;
++	case CW2218_VARIANT:
++		if (!cw->fw_version) {
++			cw->stb_current_ua = 0;
++			break;
++		}
++		cw->stb_current_ua = (int)((s16)raw * 3815000LL /
++					   cw->rsense_uohm);
++		break;
++	default:
++		cw->stb_current_ua = 0;
 +		break;
 +	}
 +
@@ -296,7 +327,7 @@ index 000000000000..a1b2c3d4e5f6
 +		return ret;
 +	cw->soh = reg_val;
 +
-+	dev_dbg(cw->dev, "V=%duV SOC=%d%% T=%ddC I=%lduA cyc=%d soh=%d%%\n",
++	dev_dbg(cw->dev, "V=%duV SOC=%d%% T=%ddC I=%duA cyc=%d soh=%d%%\n",
 +		cw->voltage_uv, cw->soc, cw->temp_decidegc,
 +		cw->current_ua, cw->cycle, cw->soh);
 +
@@ -370,6 +401,9 @@ index 000000000000..a1b2c3d4e5f6
 +	case POWER_SUPPLY_PROP_CURRENT_NOW:
 +		val->intval = cw->current_ua;
 +		break;
++	case POWER_SUPPLY_PROP_CURRENT_AVG:
++		val->intval = cw->stb_current_ua;
++		break;
 +	case POWER_SUPPLY_PROP_CAPACITY:
 +		val->intval = cw->soc;
 +		break;
@@ -413,11 +447,24 @@ index 000000000000..a1b2c3d4e5f6
 +	return 0;
 +}
 +
++static int cw221x_get_temp(struct thermal_zone_device *tzd, int *temp)
++{
++	struct cw221x *cw = thermal_zone_device_priv(tzd);
++
++	*temp = cw->temp_decidegc * 100;
++	return 0;
++}
++
++static const struct thermal_zone_device_ops cw221x_thermal_ops = {
++	.get_temp = cw221x_get_temp,
++};
++
 +static enum power_supply_property cw221x_properties[] = {
 +	POWER_SUPPLY_PROP_STATUS,
 +	POWER_SUPPLY_PROP_PRESENT,
 +	POWER_SUPPLY_PROP_VOLTAGE_NOW,
 +	POWER_SUPPLY_PROP_CURRENT_NOW,
++	POWER_SUPPLY_PROP_CURRENT_AVG,
 +	POWER_SUPPLY_PROP_CAPACITY,
 +	POWER_SUPPLY_PROP_CAPACITY_LEVEL,
 +	POWER_SUPPLY_PROP_TEMP,
@@ -532,6 +579,8 @@ index 000000000000..a1b2c3d4e5f6
 +		return dev_err_probe(cw->dev, PTR_ERR(cw->battery),
 +				     "failed to register battery\n");
 +
++	devm_thermal_of_zone_register(cw->dev, 0, cw, &cw221x_thermal_ops);
++
 +	/* Read battery design capacity from monitored-battery phandle */
 +	if (!power_supply_get_battery_info(cw->battery, &bat_info)) {
 +		if (bat_info->charge_full_design_uah > 0)
@@ -601,5 +650,3 @@ index 000000000000..a1b2c3d4e5f6
 +MODULE_AUTHOR("Xu Shengfei <xsf@rock-chips.com>");
 +MODULE_DESCRIPTION("CellWise CW2215/CW2217/CW2218 battery gauge driver");
 +MODULE_LICENSE("GPL");
---
-

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0063-power-supply-bq256xx-add-sgm41515-alias.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0063-power-supply-bq256xx-add-sgm41515-alias.patch
@@ -1,19 +1,21 @@
---- a/drivers/power/supply/bq256xx_charger.c	2026-03-24 17:36:43
-+++ b/drivers/power/supply/bq256xx_charger.c	2026-03-24 17:37:53
-@@ -1776,6 +1776,8 @@
+---
+ drivers/power/supply/bq256xx_charger.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/power/supply/bq256xx_charger.c
++++ b/drivers/power/supply/bq256xx_charger.c
+@@ -1775,6 +1775,7 @@ static const struct i2c_device_id bq256xx_i2c_ids[] = {
  	{ "bq25611d", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25611D] },
  	{ "bq25618", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25618] },
  	{ "bq25619", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25619] },
-+	{ "sgm41511", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25601] },
 +	{ "sgm41515", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25601D] },
  	{}
  };
  MODULE_DEVICE_TABLE(i2c, bq256xx_i2c_ids);
-@@ -1788,6 +1790,8 @@
+@@ -1787,6 +1788,7 @@ static const struct of_device_id bq256xx_of_match[] = {
  	{ .compatible = "ti,bq25611d", .data = &bq256xx_chip_info_tbl[BQ25611D] },
  	{ .compatible = "ti,bq25618", .data = &bq256xx_chip_info_tbl[BQ25618] },
  	{ .compatible = "ti,bq25619", .data = &bq256xx_chip_info_tbl[BQ25619] },
-+	{ .compatible = "sgmicro,sgm41511", .data = &bq256xx_chip_info_tbl[BQ25601] },
 +	{ .compatible = "sgmicro,sgm41515", .data = &bq256xx_chip_info_tbl[BQ25601D] },
  	{}
  };

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0064-power-supply-bq256xx-reset-chip-on-init.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0064-power-supply-bq256xx-reset-chip-on-init.patch
@@ -1,31 +1,32 @@
 --- a/drivers/power/supply/bq256xx_charger.c
 +++ b/drivers/power/supply/bq256xx_charger.c
-@@ -1563,6 +1563,11 @@
- 	int wd_reg_val = BQ256XX_WATCHDOG_DIS;
+@@ -1614,6 +1614,11 @@
  	int ret = 0;
  	int i;
-+
+ 
 +	/* Reset chip to clear stale register values (e.g. from Android) */
 +	regmap_update_bits(bq->regmap, BQ256XX_PART_INFORMATION,
 +			   BQ256XX_REG_RST, BQ256XX_REG_RST);
 +	msleep(10);
-
++
  	for (i = 0; i < BQ256XX_NUM_WD_VAL; i++) {
  		if (bq->watchdog_timer == bq256xx_watchdog_time[i]) {
-@@ -1623,13 +1628,13 @@
+ 			wd_reg_val = i;
+@@ -1671,7 +1676,7 @@
+ 		return ret;
+ 
  	ret = bq->chip_info->bq256xx_set_ichg(bq,
 -				bq->chip_info->bq256xx_def_ichg);
 +				bat_info->constant_charge_current_max_ua);
  	if (ret)
  		return ret;
-
- 	ret = bq->chip_info->bq256xx_set_iprechg(bq,
- 				bat_info->precharge_current_ua);
- 	if (ret)
+ 
+@@ -1681,7 +1686,7 @@
  		return ret;
-
+ 
  	ret = bq->chip_info->bq256xx_set_vbatreg(bq,
 -				bq->chip_info->bq256xx_def_vbatreg);
 +				bat_info->constant_charge_voltage_max_uv);
  	if (ret)
  		return ret;
+ 

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0065-power-supply-bq256xx-add-otg-vbus-regulator.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0065-power-supply-bq256xx-add-otg-vbus-regulator.patch
@@ -1,7 +1,7 @@
---- a/drivers/power/supply/bq256xx_charger.c	2026-03-24 17:36:43
-+++ b/drivers/power/supply/bq256xx_charger.c	2026-03-24 18:36:27
-@@ -11,6 +11,8 @@
- #include <linux/gpio/consumer.h>
+--- a/drivers/power/supply/bq256xx_charger.c
++++ b/drivers/power/supply/bq256xx_charger.c
+@@ -10,6 +10,8 @@
+ #include <linux/module.h>
  #include <linux/power_supply.h>
  #include <linux/regmap.h>
 +#include <linux/regulator/driver.h>
@@ -9,18 +9,16 @@
  #include <linux/types.h>
  #include <linux/usb/phy.h>
  #include <linux/device.h>
-@@ -75,6 +77,9 @@
-
+@@ -74,6 +76,7 @@
+ 
  #define BQ256XX_CHG_CONFIG_MASK		BIT(4)
  #define BQ256XX_CHG_CONFIG_BIT_SHIFT	4
 +#define BQ256XX_OTG_CONFIG		BIT(5)
-+#define BQ256XX_BOOSTV_MASK		GENMASK(5, 4)
-+#define BQ256XX_BOOST_LIM		BIT(7)
-
+ 
  #define BQ256XX_ITERM_MASK		GENMASK(3, 0)
  #define BQ256XX_ITERM_STEP_uA		60000
-@@ -883,6 +888,73 @@
-
+@@ -898,8 +901,69 @@
+ 
  	return regmap_update_bits(bq->regmap, BQ256XX_INPUT_CURRENT_LIMIT,
  					BQ256XX_IINDPM_MASK, iindpm_reg_code);
 +}
@@ -52,8 +50,8 @@
 +		return ret;
 +
 +	return !!(val & BQ256XX_OTG_CONFIG);
-+}
-+
+ }
+ 
 +static const struct regulator_ops bq256xx_vbus_ops = {
 +	.enable = bq256xx_enable_vbus,
 +	.disable = bq256xx_disable_vbus,
@@ -78,25 +76,21 @@
 +	};
 +	struct regulator_dev *rdev;
 +
-+	/* Set boost voltage to 5.15V and current limit to 1.2A */
-+	regmap_update_bits(bq->regmap, BQ256XX_CHARGER_CONTROL_2,
-+			   BQ256XX_BOOSTV_MASK, 0x20);
-+	regmap_update_bits(bq->regmap, BQ256XX_CHARGER_CONTROL_2,
-+			   BQ256XX_BOOST_LIM, BQ256XX_BOOST_LIM);
-+
 +	rdev = devm_regulator_register(bq->dev, &bq256xx_vbus_desc, &cfg);
 +	if (IS_ERR(rdev))
 +		return dev_err_probe(bq->dev, PTR_ERR(rdev),
 +				     "Failed to register VBUS regulator\n");
 +
 +	return 0;
- }
-
++}
++
  static void bq256xx_charger_reset(void *data)
-@@ -1759,6 +1831,10 @@
- 		return ret;
+ {
+ 	struct bq256xx_device *bq = data;
+@@ -1814,6 +1877,10 @@
+ 		}
  	}
-
+ 
 +	ret = bq256xx_register_vbus_regulator(bq);
 +	if (ret)
 +		return ret;

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0066-power-supply-bq256xx-push-chip-max-on-attach.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0066-power-supply-bq256xx-push-chip-max-on-attach.patch
@@ -1,0 +1,28 @@
+--- a/drivers/power/supply/bq256xx_charger.c
++++ b/drivers/power/supply/bq256xx_charger.c
+@@ -1246,6 +1246,7 @@
+ {
+ 	struct bq256xx_device *bq = private;
+ 	struct bq256xx_state state;
++	bool inserted;
+ 	int ret;
+ 
+ 	ret = bq256xx_get_state(bq, &state);
+@@ -1256,8 +1257,17 @@
+ 		goto irq_out;
+ 
+ 	mutex_lock(&bq->lock);
++	inserted = (bq->state.vbus_stat == BQ256XX_VBUS_STAT_NO_INPUT) &&
++		   (state.vbus_stat != BQ256XX_VBUS_STAT_NO_INPUT) &&
++		   (state.vbus_stat != BQ256XX_VBUS_STAT_USB_OTG);
+ 	bq->state = state;
+ 	mutex_unlock(&bq->lock);
++
++	if (inserted) {
++		/* Vendor parity: push to chip max on every adapter attach. */
++		bq->chip_info->bq256xx_set_iindpm(bq, BQ256XX_IINDPM_MAX_uA);
++		bq->chip_info->bq256xx_set_ichg(bq, bq->init_data.ichg_max);
++	}
+ 
+ 	power_supply_changed(bq->charger);
+ 

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0067-power-supply-bq256xx-software-jeita.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0067-power-supply-bq256xx-software-jeita.patch
@@ -1,0 +1,188 @@
+--- a/drivers/power/supply/bq256xx_charger.c
++++ b/drivers/power/supply/bq256xx_charger.c
+@@ -76,6 +76,16 @@
+ 
+ #define BQ256XX_CHG_CONFIG_MASK		BIT(4)
+ #define BQ256XX_CHG_CONFIG_BIT_SHIFT	4
++#define BQ256XX_JEITA_POLL_MS		5000
++#define BQ256XX_JEITA_T_HOT_dC		500
++#define BQ256XX_JEITA_T_HOT_REL_dC	480
++#define BQ256XX_JEITA_T_WARM_dC		450
++#define BQ256XX_JEITA_T_COOL_ENTER_dC	150
++#define BQ256XX_JEITA_T_COOL_EXIT_dC	200
++#define BQ256XX_JEITA_T_COLD_dC		0
++#define BQ256XX_JEITA_T_COLD_REL_dC	20
++#define BQ256XX_JEITA_ICHG_EDGE_uA	1000000
++#define BQ256XX_JEITA_VBATREG_WARM_uV	4100000
+ #define BQ256XX_OTG_CONFIG		BIT(5)
+ 
+ #define BQ256XX_ITERM_MASK		GENMASK(3, 0)
+@@ -229,6 +239,16 @@
+  * @state: device status and faults
+  * @watchdog_timer: watchdog timer value in milliseconds
+  */
++
++enum bq256xx_jeita_band {
++	BQ256XX_JEITA_BAND_UNKNOWN = -1,
++	BQ256XX_JEITA_BAND_COLD,
++	BQ256XX_JEITA_BAND_COOL,
++	BQ256XX_JEITA_BAND_NORMAL,
++	BQ256XX_JEITA_BAND_WARM,
++	BQ256XX_JEITA_BAND_HOT,
++};
++
+ struct bq256xx_device {
+ 	struct i2c_client *client;
+ 	struct device *dev;
+@@ -249,6 +269,10 @@
+ 	const struct bq256xx_chip_info *chip_info;
+ 	struct bq256xx_state state;
+ 	int watchdog_timer;
++
++	struct delayed_work jeita_work;
++	struct power_supply *fg_psy;
++	enum bq256xx_jeita_band jeita_band;
+ };
+ 
+ /**
+@@ -1228,8 +1252,117 @@
+ 	}
+ 
+ 	return ret;
++}
++
++static int bq256xx_jeita_read_temp(struct bq256xx_device *bq, int *temp_dC)
++{
++	union power_supply_propval val;
++	int ret;
++
++	if (!bq->fg_psy) {
++		bq->fg_psy = power_supply_get_by_name("battery");
++		if (!bq->fg_psy)
++			return -EAGAIN;
++	}
++
++	ret = power_supply_get_property(bq->fg_psy, POWER_SUPPLY_PROP_TEMP, &val);
++	if (ret)
++		return ret;
++
++	*temp_dC = val.intval;
++	return 0;
++}
++
++static enum bq256xx_jeita_band
++bq256xx_jeita_classify(int temp_dC, enum bq256xx_jeita_band prev)
++{
++	bool was_cool = (prev == BQ256XX_JEITA_BAND_COLD ||
++			 prev == BQ256XX_JEITA_BAND_COOL);
++
++	if (temp_dC >= BQ256XX_JEITA_T_HOT_dC)
++		return BQ256XX_JEITA_BAND_HOT;
++	if (prev == BQ256XX_JEITA_BAND_HOT &&
++	    temp_dC > BQ256XX_JEITA_T_HOT_REL_dC)
++		return BQ256XX_JEITA_BAND_HOT;
++	if (temp_dC >= BQ256XX_JEITA_T_WARM_dC)
++		return BQ256XX_JEITA_BAND_WARM;
++	if ((was_cool && temp_dC < BQ256XX_JEITA_T_COOL_EXIT_dC) ||
++	    (!was_cool && temp_dC <= BQ256XX_JEITA_T_COOL_ENTER_dC)) {
++		if (temp_dC <= BQ256XX_JEITA_T_COLD_dC)
++			return BQ256XX_JEITA_BAND_COLD;
++		if (prev == BQ256XX_JEITA_BAND_COLD &&
++		    temp_dC < BQ256XX_JEITA_T_COLD_REL_dC)
++			return BQ256XX_JEITA_BAND_COLD;
++		return BQ256XX_JEITA_BAND_COOL;
++	}
++	return BQ256XX_JEITA_BAND_NORMAL;
++}
++
++static int bq256xx_jeita_apply(struct bq256xx_device *bq,
++			       enum bq256xx_jeita_band band)
++{
++	int ichg, vbatreg;
++
++	switch (band) {
++	case BQ256XX_JEITA_BAND_COLD:
++	case BQ256XX_JEITA_BAND_HOT:
++		return bq256xx_set_charge_type(bq, POWER_SUPPLY_CHARGE_TYPE_NONE);
++	case BQ256XX_JEITA_BAND_COOL:
++		ichg = min(BQ256XX_JEITA_ICHG_EDGE_uA, bq->init_data.ichg_max);
++		vbatreg = bq->init_data.vbatreg_max;
++		break;
++	case BQ256XX_JEITA_BAND_WARM:
++		ichg = min(BQ256XX_JEITA_ICHG_EDGE_uA, bq->init_data.ichg_max);
++		vbatreg = min(BQ256XX_JEITA_VBATREG_WARM_uV,
++			      bq->init_data.vbatreg_max);
++		break;
++	case BQ256XX_JEITA_BAND_NORMAL:
++		ichg = bq->init_data.ichg_max;
++		vbatreg = bq->init_data.vbatreg_max;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	bq->chip_info->bq256xx_set_ichg(bq, ichg);
++	bq->chip_info->bq256xx_set_vbatreg(bq, vbatreg);
++	return bq256xx_set_charge_type(bq, POWER_SUPPLY_CHARGE_TYPE_FAST);
++}
++
++static void bq256xx_jeita_work(struct work_struct *work)
++{
++	struct bq256xx_device *bq = container_of(to_delayed_work(work),
++					struct bq256xx_device, jeita_work);
++	enum bq256xx_jeita_band band;
++	int temp_dC, ret;
++
++	ret = bq256xx_jeita_read_temp(bq, &temp_dC);
++	if (ret)
++		goto reschedule;
++
++	band = bq256xx_jeita_classify(temp_dC, bq->jeita_band);
++	if (band != bq->jeita_band) {
++		dev_info(bq->dev, "JEITA: %d.%dC, band %d -> %d\n",
++			 temp_dC / 10, abs(temp_dC % 10), bq->jeita_band, band);
++		if (!bq256xx_jeita_apply(bq, band))
++			bq->jeita_band = band;
++	}
++
++reschedule:
++	schedule_delayed_work(&bq->jeita_work,
++			      msecs_to_jiffies(BQ256XX_JEITA_POLL_MS));
++}
++
++static void bq256xx_jeita_cleanup(void *data)
++{
++	struct bq256xx_device *bq = data;
++
++	cancel_delayed_work_sync(&bq->jeita_work);
++	if (bq->fg_psy)
++		power_supply_put(bq->fg_psy);
+ }
+ 
++
+ static bool bq256xx_state_changed(struct bq256xx_device *bq,
+ 				  struct bq256xx_state *new_state)
+ {
+@@ -1267,6 +1400,7 @@
+ 		/* Vendor parity: push to chip max on every adapter attach. */
+ 		bq->chip_info->bq256xx_set_iindpm(bq, BQ256XX_IINDPM_MAX_uA);
+ 		bq->chip_info->bq256xx_set_ichg(bq, bq->init_data.ichg_max);
++		mod_delayed_work(system_wq, &bq->jeita_work, 0);
+ 	}
+ 
+ 	power_supply_changed(bq->charger);
+@@ -1847,6 +1981,14 @@
+ 		return ret;
+ 	}
+ 
++	INIT_DELAYED_WORK(&bq->jeita_work, bq256xx_jeita_work);
++	bq->jeita_band = BQ256XX_JEITA_BAND_UNKNOWN;
++	ret = devm_add_action_or_reset(dev, bq256xx_jeita_cleanup, bq);
++	if (ret)
++		return ret;
++	schedule_delayed_work(&bq->jeita_work,
++			      msecs_to_jiffies(BQ256XX_JEITA_POLL_MS));
++
+ 	return ret;
+ }
+ 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 

Bring charger/Fuel gauge and USB making it feature complete compared to Android:
1. Added custom software thermistor that limits charge based on battery temp
2. Battery temp is tied into fan controls
3. Enables charging as fast as vendor does
4. Other minor changes include averge current usage which is useful for checking power usage

## Testing

* **How was this tested?** Tested on Mangmi Air X

## Additional Context

* **Add any other information that might be helpful for the reviewer** Have only tested with updated usbgadget script, should likely be merged together

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
