### PR TITLE
RGDS: revert back to old panel setup

### DIFF
--- a/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
+++ b/projects/ROCKNIX/devices/RK3566/linux/dts/rockchip/rk3568-anbernic-rg-ds.dts
@@ -444,15 +444,82 @@
 
 &cru {
 	assigned-clocks = <&pmucru CLK_RTC_32K>, <&cru PLL_GPLL>,
-			  <&pmucru PLL_PPLL>, <&cru PLL_VPLL>;
+			  <&pmucru PLL_PPLL>, <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
 	assigned-clock-rates = <32768>, <1200000000>,
-			       <200000000>, <292500000>;
+			       <200000000>, <126400000>, <126400000>;
 };
 
 &dsi0 {
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
+
+	dsi0_panel: panel@0 {
+		compatible = "rocknix,generic-dsi";
+		reg = <0>;
+		backlight = <&backlight0>;
+		reset-gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_LOW>;
+		vdd-supply = <&vdd_lcd0>;
+		iovcc-supply = <&vccio_lcd0>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd0_rst>;
+		panel_description =
+			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
+
+			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
+
+			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
+			"I seq=8003",
+			"I seq=e001",
+			"I seq=0000", "I seq=016a", "I seq=0310", "I seq=046a",
+			"I seq=0c74",
+			"I seq=1700",
+			"I seq=18bf", "I seq=1901", "I seq=1a00", "I seq=1bbf", "I seq=1c01",
+			"I seq=24fe",
+			"I seq=3709",
+			"I seq=3802", "I seq=3908", "I seq=3a1f", "I seq=3cf7", "I seq=3dff", "I seq=3eff", "I seq=3fff",
+			"I seq=4003", "I seq=413c", "I seq=42ff", "I seq=430a", "I seq=4411", "I seq=4578",
+			"I seq=5502", "I seq=576d",
+			"I seq=580a", "I seq=590a", "I seq=5a1f", "I seq=5b1f", "I seq=5d7f", "I seq=5e56", "I seq=5f43",
+			"I seq=6034", "I seq=612f", "I seq=6220", "I seq=6322", "I seq=640c", "I seq=6524", "I seq=6624", "I seq=6725",
+			"I seq=6843", "I seq=6933", "I seq=6a3a", "I seq=6b2d", "I seq=6c28", "I seq=6d1b", "I seq=6e0b", "I seq=6f00",
+			"I seq=707f", "I seq=7156", "I seq=7243", "I seq=7334", "I seq=742f", "I seq=7520", "I seq=7622", "I seq=770c",
+			"I seq=7824", "I seq=7924", "I seq=7a25", "I seq=7b43", "I seq=7c33", "I seq=7d3a", "I seq=7e2d", "I seq=7f28",
+			"I seq=801b", "I seq=810b", "I seq=8200",
+			"I seq=e002",
+			"I seq=005f", "I seq=015f", "I seq=025f", "I seq=035e", "I seq=0450", "I seq=0540", "I seq=065f", "I seq=0757",
+			"I seq=0877", "I seq=0948", "I seq=0a48", "I seq=0b4a", "I seq=0c4a", "I seq=0d44", "I seq=0e44", "I seq=0f46",
+			"I seq=1046", "I seq=115f", "I seq=125f", "I seq=135f", "I seq=145f", "I seq=155f", "I seq=165f", "I seq=175f",
+			"I seq=185f", "I seq=195e", "I seq=1a50", "I seq=1b41", "I seq=1c5f", "I seq=1d57", "I seq=1e77", "I seq=1f49",
+			"I seq=2049", "I seq=214b", "I seq=224b", "I seq=2345", "I seq=2445", "I seq=2547", "I seq=2647", "I seq=275f",
+			"I seq=285f", "I seq=295f", "I seq=2a5f", "I seq=2b5f", "I seq=2c1f", "I seq=2d1f", "I seq=2e1e", "I seq=2f1f",
+			"I seq=3010", "I seq=3101", "I seq=321f", "I seq=3317", "I seq=3417", "I seq=3507", "I seq=3607", "I seq=3705",
+			"I seq=3805", "I seq=390b", "I seq=3a0b", "I seq=3b09", "I seq=3c09", "I seq=3d1f", "I seq=3e1f", "I seq=3f1f",
+			"I seq=401f", "I seq=411f", "I seq=421f", "I seq=431f", "I seq=441e", "I seq=451f", "I seq=4610", "I seq=4700",
+			"I seq=481f", "I seq=4917", "I seq=4a17", "I seq=4b06", "I seq=4c06", "I seq=4d04", "I seq=4e04", "I seq=4f0a",
+			"I seq=500a", "I seq=5108", "I seq=5208", "I seq=531f", "I seq=541f", "I seq=551f", "I seq=561f", "I seq=571f",
+			"I seq=5840", "I seq=5900", "I seq=5a00", "I seq=5b10", "I seq=5c07", "I seq=5d30", "I seq=5e01", "I seq=5f02",
+			"I seq=6030", "I seq=6101", "I seq=6202", "I seq=6306", "I seq=64e9", "I seq=6540", "I seq=6602", "I seq=6773",
+			"I seq=680b", "I seq=6906", "I seq=6ae9", "I seq=6b08",
+			"I seq=75da", "I seq=7600", "I seq=7701",
+			"I seq=78fc",
+			"I seq=8108", "I seq=83f4", "I seq=8710",
+			"I seq=e004",
+			"I seq=000e", "I seq=02b3",
+			"I seq=0960", "I seq=0e48",
+			"I seq=1e00",
+			"I seq=3758",
+			"I seq=2b0f",
+			"I seq=e005",
+			"I seq=151d",
+			"I seq=e000";
+
+		port {
+			mipi_in_panel0: endpoint {
+				remote-endpoint = <&mipi_out_panel0>;
+			};
+		};
+	};
 
 	ports {
 		dsi0_in: port@0 {
@@ -469,29 +536,79 @@
 			};
 		};
 	};
-
-	panel0: panel@0 {
-		compatible = "anbernic,rg-ds-display-bottom", "jadard,jd9365da-h3";
-		reg = <0>;
-		backlight = <&backlight0>;
-		pinctrl-0 = <&lcd0_rst>;
-		pinctrl-names = "default";
-		reset-gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_LOW>;
-		vdd-supply = <&vdd_lcd0>;
-		vccio-supply = <&vccio_lcd0>;
-
-		port {
-			mipi_in_panel0: endpoint {
-				remote-endpoint = <&mipi_out_panel0>;
-			};
-		};
-	};
 };
 
 &dsi1 {
-	status = "okay";
+    status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
+
+	dsi1_panel: panel@0 {
+		compatible = "rocknix,generic-dsi";
+		reg = <0>;
+		backlight = <&backlight1>;
+		reset-gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_LOW>;
+		vdd-supply = <&vdd_lcd1>;
+		iovcc-supply = <&vccio_lcd1>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd1_rst>;
+		panel_description =
+			"G size=81,61 delays=20,10,50,120,50 format=rgb888 lanes=4 flags=0xc03",
+
+			"M clock=42134 horizontal=640,260,220,260 vertical=480,10,2,16 default=1",
+
+			"I seq=e000", "I seq=e193", "I seq=e265", "I seq=e3f8",
+			"I seq=8003",
+			"I seq=e001",
+			"I seq=0000", "I seq=016a", "I seq=0310", "I seq=046a",
+			"I seq=0c74",
+			"I seq=1700",
+			"I seq=18bf", "I seq=1901", "I seq=1a00", "I seq=1bbf", "I seq=1c01",
+			"I seq=24fe",
+			"I seq=3705",
+			"I seq=3802", "I seq=3908", "I seq=3a1f", "I seq=3cf7", "I seq=3dff", "I seq=3eff", "I seq=3fff",
+			"I seq=4003", "I seq=413c", "I seq=42ff", "I seq=430a", "I seq=4411", "I seq=4578",
+			"I seq=5502", "I seq=576d",
+			"I seq=580a", "I seq=590a", "I seq=5a1f", "I seq=5b1f", "I seq=5d7f", "I seq=5e56", "I seq=5f43",
+			"I seq=6034", "I seq=612f", "I seq=6220", "I seq=6322", "I seq=640c", "I seq=6524", "I seq=6624", "I seq=6725",
+			"I seq=6843", "I seq=6933", "I seq=6a3a", "I seq=6b2d", "I seq=6c28", "I seq=6d1b", "I seq=6e0b", "I seq=6f00",
+			"I seq=707f", "I seq=7156", "I seq=7243", "I seq=7334", "I seq=742f", "I seq=7520", "I seq=7622", "I seq=770c",
+			"I seq=7824", "I seq=7924", "I seq=7a25", "I seq=7b43", "I seq=7c33", "I seq=7d3a", "I seq=7e2d", "I seq=7f28",
+			"I seq=801b", "I seq=810b", "I seq=8200",
+			"I seq=e002",
+			"I seq=005f", "I seq=015f", "I seq=025f", "I seq=035e", "I seq=0450", "I seq=0540", "I seq=065f", "I seq=0757",
+			"I seq=0877", "I seq=0948", "I seq=0a48", "I seq=0b4a", "I seq=0c4a", "I seq=0d44", "I seq=0e44", "I seq=0f46",
+			"I seq=1046", "I seq=115f", "I seq=125f", "I seq=135f", "I seq=145f", "I seq=155f", "I seq=165f", "I seq=175f",
+			"I seq=185f", "I seq=195e", "I seq=1a50", "I seq=1b41", "I seq=1c5f", "I seq=1d57", "I seq=1e77", "I seq=1f49",
+			"I seq=2049", "I seq=214b", "I seq=224b", "I seq=2345", "I seq=2445", "I seq=2547", "I seq=2647", "I seq=275f",
+			"I seq=285f", "I seq=295f", "I seq=2a5f", "I seq=2b5f", "I seq=2c1f", "I seq=2d1f", "I seq=2e1e", "I seq=2f1f",
+			"I seq=3010", "I seq=3101", "I seq=321f", "I seq=3317", "I seq=3417", "I seq=3507", "I seq=3607", "I seq=3705",
+			"I seq=3805", "I seq=390b", "I seq=3a0b", "I seq=3b09", "I seq=3c09", "I seq=3d1f", "I seq=3e1f", "I seq=3f1f",
+			"I seq=401f", "I seq=411f", "I seq=421f", "I seq=431f", "I seq=441e", "I seq=451f", "I seq=4610", "I seq=4700",
+			"I seq=481f", "I seq=4917", "I seq=4a17", "I seq=4b06", "I seq=4c06", "I seq=4d04", "I seq=4e04", "I seq=4f0a",
+			"I seq=500a", "I seq=5108", "I seq=5208", "I seq=531f", "I seq=541f", "I seq=551f", "I seq=561f", "I seq=571f",
+			"I seq=5840", "I seq=5900", "I seq=5a00", "I seq=5b10", "I seq=5c07", "I seq=5d30", "I seq=5e01", "I seq=5f02",
+			"I seq=6030", "I seq=6101", "I seq=6202", "I seq=6306", "I seq=64e9", "I seq=6540", "I seq=6602", "I seq=6773",
+			"I seq=680b", "I seq=6906", "I seq=6ae9", "I seq=6b08",
+			"I seq=75da", "I seq=7600", "I seq=7701",
+			"I seq=78fc",
+			"I seq=8108", "I seq=83f4", "I seq=8710",
+			"I seq=e004",
+			"I seq=000e", "I seq=02b3",
+			"I seq=0960", "I seq=0e48",
+			"I seq=1e00",
+			"I seq=3758",
+			"I seq=2b0f",
+			"I seq=e005",
+			"I seq=151d",
+			"I seq=e000";
+
+		port {
+			mipi_in_panel1: endpoint {
+				remote-endpoint = <&mipi_out_panel1>;
+			};
+		};
+	};
 
 	ports {
 		dsi1_in: port@0 {
@@ -505,23 +622,6 @@
 			reg = <1>;
 			mipi_out_panel1: endpoint {
 				remote-endpoint = <&mipi_in_panel1>;
-			};
-		};
-	};
-
-	panel1: panel@0 {
-		compatible = "anbernic,rg-ds-display-top", "jadard,jd9365da-h3";
-		reg = <0>;
-		backlight = <&backlight1>;
-		pinctrl-0 = <&lcd1_rst>;
-		pinctrl-names = "default";
-		reset-gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_LOW>;
-		vdd-supply = <&vdd_lcd1>;
-		vccio-supply = <&vccio_lcd1>;
-
-		port {
-			mipi_in_panel1: endpoint {
-				remote-endpoint = <&mipi_out_panel1>;
 			};
 		};
 	};
@@ -824,7 +924,6 @@
 		interrupt-parent = <&gpio0>;
 		interrupts = <RK_PC0 IRQ_TYPE_LEVEL_LOW>;
 		irq-gpios = <&gpio0 RK_PC0 GPIO_ACTIVE_HIGH>;
-		panel = <&panel1>;
 		reset-gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
 		touchscreen-size-x = <640>;
 		touchscreen-size-y = <480>;
@@ -849,7 +948,6 @@
 		interrupt-parent = <&gpio0>;
 		interrupts = <RK_PB6 IRQ_TYPE_LEVEL_LOW>;
 		irq-gpios = <&gpio0 RK_PB6 GPIO_ACTIVE_HIGH>;
-		panel = <&panel0>;
 		reset-gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
 		touchscreen-size-x = <640>;
 		touchscreen-size-y = <480>;
@@ -1170,7 +1268,7 @@
 
 &vop {
 	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
-	assigned-clock-parents = <&cru PLL_VPLL>, <&cru PLL_VPLL>;
+	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
 	status = "okay";
 };
 


### PR DESCRIPTION


## Summary

* **What is the goal of this PR?**
The mainline panel driver and/or PLL clock configuration are increasing amount audio popping Drastic, for unknown reason.

Switching back to the original PLL configuration and generic dsi driver setup improves this significantly.
## Testing
Tested and confirmed by **inteyes** and **Lucifonz** on discord.


---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?**  NO
