### PR TITLE
SM8250: enable parents for display pixel clocks

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0002-qcom-dispcc-sm8250-enable-parents-for-pixel-clocks.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0002-qcom-dispcc-sm8250-enable-parents-for-pixel-clocks.patch
@@ -1,0 +1,21 @@
+diff --git a/drivers/clk/qcom/dispcc-sm8250.c b/drivers/clk/qcom/dispcc-sm8250.c
+--- a/drivers/clk/qcom/dispcc-sm8250.c
++++ b/drivers/clk/qcom/dispcc-sm8250.c
+@@ -579,7 +579,7 @@ static struct clk_rcg2 disp_cc_mdss_pclk0_clk_src = {
+ 		.name = "disp_cc_mdss_pclk0_clk_src",
+ 		.parent_data = disp_cc_parent_data_6,
+ 		.num_parents = ARRAY_SIZE(disp_cc_parent_data_6),
+-		.flags = CLK_SET_RATE_PARENT,
++		.flags = CLK_SET_RATE_PARENT | CLK_OPS_PARENT_ENABLE,
+ 		.ops = &clk_pixel_ops,
+ 	},
+ };
+@@ -593,7 +593,7 @@ static struct clk_rcg2 disp_cc_mdss_pclk1_clk_src = {
+ 		.name = "disp_cc_mdss_pclk1_clk_src",
+ 		.parent_data = disp_cc_parent_data_6,
+ 		.num_parents = ARRAY_SIZE(disp_cc_parent_data_6),
+-		.flags = CLK_SET_RATE_PARENT,
++		.flags = CLK_SET_RATE_PARENT | CLK_OPS_PARENT_ENABLE,
+ 		.ops = &clk_pixel_ops,
+ 	},
+ };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

Enable parent clocks for the SM8250 display pixel-clock RCGs by adding `CLK_OPS_PARENT_ENABLE` to `disp_cc_mdss_pclk0_clk_src` and `disp_cc_mdss_pclk1_clk_src`.

On the Retroid Pocket 5, display bring-up intermittently hit:

```text
disp_cc_mdss_pclk0_clk_src: rcg didn't update its configuration.
```

The failure occurred while setting DSI link clocks during `msm_dsi_host_power_on`, leaving the panel blank/backlit until display bring-up was retried. The SM8250 pixel clocks derive from the DSI PHY PLL path, so this mirrors the existing SM8550 ROCKNIX patch that uses `CLK_OPS_PARENT_ENABLE` to ensure the parent is prepared/enabled before the RCG is updated.

## Testing

* **How was this tested?**

Built a ROCKNIX SM8250 image from `next` and tested it on a Retroid Pocket 5.

Tested build:

```text
OS_VERSION="20260520"
BUILD_ID="6e4a2504a546206a813937ac63ddd287490b5d46"
HW_DEVICE="SM8250"
Linux SM8250 7.0.2 #1 SMP PREEMPT Wed May 20 12:41:33 EDT 2026 aarch64
```

Test coverage:

* Booted patched image from SD.
* Rebooted and checked a second boot.
* Installed the patched build to internal storage and booted from internal.
* Verified EmulationStation/Sway display bring-up.
* Verified Steam/gamescope launch after the display fix.

* **Test results:**

Post-patch logs show `rcg didn't update` absent across checked boots and Steam launch log capture.

Relevant display clocks settled correctly after boot:

```text
dsi0vco_clk                    777017871 Hz
dsi0_phy_pll_out_dsiclk        129502979 Hz
disp_cc_mdss_pclk0_clk_src     129502979 Hz
disp_cc_mdss_pclk0_clk         129502979 Hz
dsi0_phy_pll_out_byteclk        97127233 Hz
disp_cc_mdss_byte0_clk_src      97127233 Hz
disp_cc_mdss_byte0_intf_clk     48563617 Hz
```

## Additional Context

This is intentionally scoped to the SM8250 display-clock race only. It does not include local bootloader polish, Steam/gamescope launch changes, panel timing experiments, storage changes, or build-host workarounds.

Residual note: early boot can still log a `DSI PLL(0) lock failed` retry before the panel binds. That appears separate from the pixel-clock RCG update failure addressed here.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY

AI assistance was used to organize logs, compare the local diff, and draft this PR description. The code change is a two-line kernel clock-flag patch and was tested on-device.
