### PR TITLE
Ayaneo Pocket DS: Lowerdeck orientation

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
@@ -110,8 +110,14 @@ elif [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ] && [ "${EXTERNAL_DISPLAY_CONNECTED
         fi
 
         case "${QUIRK_DEVICE}" in
-            "AYANEO Pocket DS"|"AYN Thor Lite") OUTPUT="DSI-2" ;;
-            *)                  OUTPUT="DSI-1" ;;
+            "AYANEO Pocket DS")
+                OUTPUT="DSI-2"
+                swaymsg output ${OUTPUT} transform 270
+                ;;
+            "AYN Thor Lite")
+                OUTPUT="DSI-2" ;;
+            *)
+                OUTPUT="DSI-1" ;;
         esac
 
         swaymsg "output ${OUTPUT} power on" >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Add rotate bottom screen swaymsg command to vertical-check script that starts lowerdeck, otherwise lowerdeck is displayed sideway (unless you start a dual-screen game that also set the rotation of the bottom screen beforehand). Same kind of change as a9657dd .

(Don't know why sway forgets the rotation set in the device tree but this seems to work)

## Testing

Tested on Pocket DS

## Additional Context

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
