### PR TITLE
mangohud - update battery sysfs patch

### DIFF
--- a/projects/ROCKNIX/packages/apps/mangohud/patches/common/0002-Battery-name.patch
+++ b/projects/ROCKNIX/packages/apps/mangohud/patches/common/0002-Battery-name.patch
@@ -1,25 +1,38 @@
-From aed0afd4578c66194b85587f6904ee6457487d74 Mon Sep 17 00:00:00 2001
+From fc30aa5437bee410ada66244f8e2a163eb58a488 Mon Sep 17 00:00:00 2001
 From: John Williams <porschemad911@gmail.com>
-Date: Wed, 14 Jan 2026 22:18:41 +1100
+Date: Sun, 24 May 2026 22:28:30 +1000
 Subject: [PATCH 2/3] Battery name
 
 ---
- src/battery.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/battery.cpp | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/src/battery.cpp b/src/battery.cpp
-index e5d311b..9cf8e5b 100644
+index 1612bff..16b0355 100644
 --- a/src/battery.cpp
 +++ b/src/battery.cpp
-@@ -13,7 +13,7 @@ void BatteryStats::numBattery() {
-     fs::path path("/sys/class/power_supply/");
-     for (auto& p : fs::directory_iterator(path)) {
-         string fileName = p.path().filename();
+@@ -10,14 +10,16 @@ void BatteryStats::numBattery() {
+     if (!fs::exists("/sys/class/power_supply/")) {
+          batteryCount = 0;
+     }
+-    fs::path path("/sys/class/power_supply/");
+-    for (auto& p : fs::directory_iterator(path)) {
+-        string fileName = p.path().filename();
 -        if (fileName.find("BAT") != std::string::npos) {
-+        if (fileName.find("battery") != std::string::npos) {
-             battPath[batteryCount] = p.path();
+-            battPath[batteryCount] = p.path();
++    
++    else {
++        string battery = "/sys/class/power_supply/battery";
++        
++        if (fs::exists(battery)) {
++            battPath[batteryCount] = battery;
              batteryCount += 1;
          }
+     }
++
+     batt_count = batteryCount;
+     batt_check = true;
+ }
 -- 
 2.47.3
 


### PR DESCRIPTION
## Summary

mangohud - update battery sysfs patch to fix charging status / time remaining detection

## Testing

Tested on my Odin 2 (SM8550) and Mangmi Air X (SM6115). Verified `/sys/class/power_supply/battery` is correct on my RP Mini (SM8250), OGA (RK3326) and OGU (S922X).

---

### AI Usage

**Did you use AI tools to help write this code?** NO