### PR TITLE
bugfix: Disable speaker compression for Pocket ACE

### DIFF
--- a/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8550/0003_Add-AYANEO-Pocket-ACE.patch
+++ b/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8550/0003_Add-AYANEO-Pocket-ACE.patch
@@ -17,17 +17,25 @@ index 0000000..e4054ba
 +Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
 diff --git a/ucm2/AYANEO/Pocket/HiFi.conf b/ucm2/AYANEO/Pocket/HiFi.conf
 new file mode 100644
-index 0000000..dc5211e
+index 0000000..f8e3a2c
 --- /dev/null
 +++ b/ucm2/AYANEO/Pocket/HiFi.conf
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,68 @@
 +SectionVerb {
 +	EnableSequence [
 +		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 +		cset "name='MultiMedia3 Mixer VA_CODEC_DMA_TX_0' 1"
++		cset "name='SpkrLeft COMP Switch' 0"
++		cset "name='SpkrLeft BOOST Switch' 1"
++		cset "name='SpkrLeft DAC Switch' 1"
++		cset "name='SpkrLeft VISENSE Switch' 0"
++		cset "name='SpkrLeft WSA MODE' 0"
++		cset "name='SpkrRight COMP Switch' 0"
++		cset "name='SpkrRight BOOST Switch' 1"
++		cset "name='SpkrRight DAC Switch' 1"
++		cset "name='SpkrRight VISENSE Switch' 0"
++		cset "name='SpkrRight WSA MODE' 0"
 + 	]
-+
-+	Include.wsae.File "/codecs/wsa884x/two-speakers/DefaultEnableSeq.conf"
 +
 +	Value {
 +		TQ "HiFi"
@@ -37,46 +45,64 @@ index 0000000..dc5211e
 +SectionDevice."Speaker" {
 +	Comment "Speaker playback"
 +
-+        Include.wsmspk1e.File "/codecs/qcom-lpass/wsa-macro/SpeakerEnableSeq.conf"
-+        Include.wsmspk1d.File "/codecs/qcom-lpass/wsa-macro/SpeakerDisableSeq.conf"
-+        Include.wsaspkd.File "/codecs/wsa884x/two-speakers/SpeakerSeq.conf"
++	EnableSequence [
++		cset "name='WSA RX0 MUX' AIF1_PB"
++		cset "name='WSA RX1 MUX' AIF1_PB"
++		cset "name='WSA_RX0 INP0' RX0"
++		cset "name='WSA_RX1 INP0' RX1"
++		cset "name='WSA_COMP1 Switch' 0"
++		cset "name='WSA_COMP2 Switch' 0"
++		cset "name='SpkrLeft COMP Switch' 0"
++		cset "name='SpkrLeft BOOST Switch' 1"
++		cset "name='SpkrLeft DAC Switch' 1"
++		cset "name='SpkrLeft PBR Switch' 0"
++		cset "name='SpkrLeft VISENSE Switch' 0"
++		cset "name='SpkrLeft WSA MODE' 0"
++		cset "name='SpkrLeft PA Volume' 17"
++		cset "name='SpkrRight COMP Switch' 0"
++		cset "name='SpkrRight BOOST Switch' 1"
++		cset "name='SpkrRight DAC Switch' 1"
++		cset "name='SpkrRight PBR Switch' 0"
++		cset "name='SpkrRight VISENSE Switch' 0"
++		cset "name='SpkrRight WSA MODE' 0"
++		cset "name='SpkrRight PA Volume' 17"
++	]
++
++	DisableSequence [
++		cset "name='SpkrLeft COMP Switch' 0"
++		cset "name='SpkrLeft BOOST Switch' 0"
++		cset "name='SpkrLeft DAC Switch' 0"
++		cset "name='SpkrLeft PBR Switch' 0"
++		cset "name='SpkrLeft VISENSE Switch' 0"
++		cset "name='SpkrRight COMP Switch' 0"
++		cset "name='SpkrRight BOOST Switch' 0"
++		cset "name='SpkrRight DAC Switch' 0"
++		cset "name='SpkrRight PBR Switch' 0"
++		cset "name='SpkrRight VISENSE Switch' 0"
++	]
 +
 +	Value {
 +		PlaybackChannels 2
 +		PlaybackPriority 100
 +		PlaybackPCM "hw:${CardId},1"
 +		PlaybackMixer "default:${CardId}"
-+                PlaybackMixerElem "Speakers"
++		PlaybackMixerElem "Speakers"
 +	}
 +}
 +
 +SectionDevice."Mic1" {
-+        Comment "Top microphones"
++	Comment "Top microphones"
 +
-+        Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
-+        Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
-+        Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
-+        Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
++	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
++	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
++	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
++	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
 +
-+        Value {
-+                CapturePriority 100
-+                CapturePCM "hw:${CardId},2"
-+        }
++	Value {
++		CapturePriority 100
++		CapturePCM "hw:${CardId},2"
++	}
 +}
-+
-+#SectionDevice."Mic2" {
-+#        Comment "Bottom microphones"
-+#
-+#        Include.vadm2e.File "/codecs/qcom-lpass/va-macro/DMIC2EnableSeq.conf"
-+#        Include.vadm2d.File "/codecs/qcom-lpass/va-macro/DMIC2DisableSeq.conf"
-+#        Include.vadm3e.File "/codecs/qcom-lpass/va-macro/DMIC3EnableSeq.conf"
-+#        Include.vadm3d.File "/codecs/qcom-lpass/va-macro/DMIC3DisableSeq.conf"
-+#
-+#        Value {
-+#                CapturePriority 100
-+#                CapturePCM "hw:${CardId},4"
-+#        }
-+#}
 diff --git a/ucm2/conf.d/sm8550/SM8550-APS.conf b/ucm2/conf.d/sm8550/SM8550-APS.conf
 new file mode 120000
 index 0000000..414976a


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
There was strange pumping effect when there is some bass / low end frequency being played.  
Main suspicion was compression / limiter, since entire volume went down as that happen.  
Goal was to get rid of that and get clean audio for Pocket ACE.

## Testing

* **How was this tested?** Tested in Pocket ACE
* **Test results:** Clean audio, no more pumping effect.

## Additional Context

* **Add any other information that might be helpful for the reviewer**
Disable compander (DRC), WSA macro compression, and PBR limiter.
Boost PA Volume to 17 to compensate for reduced loudness without compression.  
Most likely still have enough headroom for higher number.  

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
