### PR TITLE
modules: add Switch Gamepad Profile tool to toggle DualSense/Xbox emulation

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 3/020-set-inputplumber-profile
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 3/020-set-inputplumber-profile
@@ -1,0 +1,40 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
+
+# Apply the user's saved InputPlumber gamepad profile preference at boot.
+# The preference (ds5 or xbox-series) is stored via the ROCKNIX settings system.
+# ds5 is the default for this device; only a bind-mount override is needed for xbox-series.
+
+. /etc/profile.d/001-functions
+
+SETTING="inputplumber.profile"
+DEVICE_YAML="/usr/share/inputplumber/devices/01-ayn-controller.yaml"
+OVERRIDE_YAML="/run/inputplumber-profile.yaml"
+
+[ -f "${DEVICE_YAML}" ] || exit 0
+
+TARGET=$(get_setting "${SETTING}")
+[ -z "${TARGET}" ] && TARGET="ds5"
+
+# ds5 is already the compiled-in default — no override needed
+[ "${TARGET}" = "ds5" ] && exit 0
+
+# Generate override YAML with the stored target device
+awk -v target="${TARGET}" '
+/^target_devices:/ {
+    print "target_devices:"
+    print "  - " target
+    print "  - keyboard"
+    in_targets = 1
+    next
+}
+in_targets && /^  - / { next }
+{ in_targets = 0; print }
+' "${DEVICE_YAML}" > "${OVERRIDE_YAML}"
+
+# InputPlumber is already running (multi-user.target); stop it, apply the
+# bind-mount override over the read-only system file, then restart before the UI starts.
+systemctl stop inputplumber
+mount --bind "${OVERRIDE_YAML}" "${DEVICE_YAML}"
+systemctl start inputplumber

--- a/projects/ROCKNIX/packages/misc/modules/sources/Switch Gamepad Profile.sh
+++ b/projects/ROCKNIX/packages/misc/modules/sources/Switch Gamepad Profile.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
+
+# Toggle InputPlumber target device between DualSense (ds5) and Xbox Series (xbox-series).
+# DualSense enables gyroscope support; Xbox Series improves compatibility with some games.
+# Preference persists across reboots via the ROCKNIX settings system.
+
+source /etc/profile
+
+SETTING="inputplumber.profile"
+OVERRIDE_YAML="/run/inputplumber-profile.yaml"
+
+# Find the InputPlumber device config that matches this hardware.
+# Configs live in /usr/share/inputplumber/devices/ and match via devicetree or DMI model name.
+MODEL=$(tr -d '\0' < /sys/firmware/devicetree/base/model 2>/dev/null || \
+        cat /sys/class/dmi/id/product_name 2>/dev/null)
+
+DEVICE_YAML=""
+if [ -n "$MODEL" ]; then
+    DEVICE_YAML=$(grep -rl "value: ${MODEL}" /usr/share/inputplumber/devices/ 2>/dev/null | head -1)
+fi
+
+if [ -z "$DEVICE_YAML" ]; then
+    zenity --error --timeout=4 \
+        --text="No InputPlumber device config found for this hardware." 2>/dev/null || \
+    notify-send "Gamepad Profile" "No InputPlumber device config found." 2>/dev/null
+    exit 0
+fi
+
+# Read current preference (default: ds5, which is the ROCKNIX default for DualSense-capable devices)
+CURRENT=$(get_setting "${SETTING}")
+[ -z "$CURRENT" ] && CURRENT="ds5"
+
+# Toggle between the two profiles
+if [ "$CURRENT" = "ds5" ]; then
+    NEW_TARGET="xbox-series"
+    LABEL="Xbox Series"
+else
+    NEW_TARGET="ds5"
+    LABEL="DualSense (PS5)"
+fi
+
+set_setting "${SETTING}" "${NEW_TARGET}"
+
+# Remove any existing bind mount so we read the original file for the awk transform
+grep -qF " ${DEVICE_YAML} " /proc/mounts && umount "${DEVICE_YAML}"
+
+# Generate override YAML: replace only the target_devices block, keep everything else intact
+awk -v target="${NEW_TARGET}" '
+/^target_devices:/ {
+    print "target_devices:"
+    print "  - " target
+    print "  - keyboard"
+    in_targets = 1
+    next
+}
+in_targets && /^  - / { next }
+{ in_targets = 0; print }
+' "${DEVICE_YAML}" > "${OVERRIDE_YAML}"
+
+# Bind-mount the override over the read-only system file, then restart InputPlumber
+systemctl stop inputplumber
+mount --bind "${OVERRIDE_YAML}" "${DEVICE_YAML}"
+systemctl start inputplumber
+
+# Notify user of the new active profile
+zenity --info --timeout=4 \
+    --text="Gamepad profile switched to:\n<b>${LABEL}</b>" 2>/dev/null || \
+notify-send "Gamepad Profile" "Switched to: ${LABEL}" 2>/dev/null || true

--- a/projects/ROCKNIX/packages/misc/modules/sources/gamelist.xml
+++ b/projects/ROCKNIX/packages/misc/modules/sources/gamelist.xml
@@ -447,6 +447,18 @@ it's recommended to have a mouse and keyboard to modify settings.</desc>
         <image>./images/scummvm.svg</image>
     </game>
     <game>
+        <path>./Switch Gamepad Profile.sh</path>
+        <name>Switch Gamepad Profile</name>
+        <desc>Toggle the emulated gamepad between DualSense (PS5) and Xbox Series controller. DualSense enables gyroscope support; Xbox Series improves compatibility with some games and applications.</desc>
+        <developer>ROCKNIX</developer>
+        <publisher>ROCKNIX</publisher>
+        <rating>5.0</rating>
+        <releasedate>2025</releasedate>
+        <genre>tool</genre>
+        <players>1</players>
+        <image>./images/switch-gamepad-profile.svg</image>
+    </game>
+    <game>
         <path>./Test Gamepad.sh</path>
         <name>Test Gamepad</name>
         <desc>A simple SDL GUI gamepad tester to help validate gamepad inputs.</desc>

--- a/projects/ROCKNIX/packages/misc/modules/sources/images/switch-gamepad-profile.svg
+++ b/projects/ROCKNIX/packages/misc/modules/sources/images/switch-gamepad-profile.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="100%" height="100%" viewBox="0 0 1200 1080" version="1.1" xmlns="http://www.w3.org/2000/svg" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+  <!-- Background -->
+  <rect x="0" y="0" width="1200" height="1080" style="fill:rgb(46,46,46);"/>
+
+  <!-- Gamepad body -->
+  <path d="M 320 420 Q 320 340 400 340 L 800 340 Q 880 340 880 420 L 900 620 Q 920 720 860 740 Q 800 760 740 700 L 700 680 L 500 680 L 460 700 Q 400 760 340 740 Q 280 720 300 620 Z"
+        style="fill:rgb(80,80,80);"/>
+
+  <!-- Left d-pad vertical bar -->
+  <rect x="390" y="480" width="30" height="80" rx="4" style="fill:white;"/>
+  <!-- Left d-pad horizontal bar -->
+  <rect x="370" y="500" width="70" height="40" rx="4" style="fill:white;"/>
+
+  <!-- Right face buttons (circle cluster) -->
+  <circle cx="760" cy="500" r="16" style="fill:rgb(100,180,255);"/>  <!-- North -->
+  <circle cx="790" cy="530" r="16" style="fill:rgb(255,100,100);"/>  <!-- East -->
+  <circle cx="760" cy="560" r="16" style="fill:rgb(100,255,100);"/>  <!-- South -->
+  <circle cx="730" cy="530" r="16" style="fill:rgb(255,200,50);"/>   <!-- West -->
+
+  <!-- Left analog stick -->
+  <circle cx="480" cy="580" r="36" style="fill:rgb(60,60,60);stroke:rgb(130,130,130);stroke-width:4;"/>
+  <circle cx="480" cy="580" r="20" style="fill:rgb(100,100,100);"/>
+
+  <!-- Right analog stick -->
+  <circle cx="680" cy="580" r="36" style="fill:rgb(60,60,60);stroke:rgb(130,130,130);stroke-width:4;"/>
+  <circle cx="680" cy="580" r="20" style="fill:rgb(100,100,100);"/>
+
+  <!-- Center home/select buttons -->
+  <circle cx="570" cy="450" r="18" style="fill:rgb(60,60,60);stroke:rgb(130,130,130);stroke-width:3;"/>
+  <circle cx="630" cy="450" r="18" style="fill:rgb(60,60,60);stroke:rgb(130,130,130);stroke-width:3;"/>
+
+  <!-- Swap arrows: two curved arrows indicating toggle/switch -->
+  <!-- Top arrow: left to right (curved arc with arrowhead) -->
+  <path d="M 480 250 A 120 80 0 0 1 720 250"
+        style="fill:none;stroke:rgb(100,200,255);stroke-width:18;stroke-linecap:round;"/>
+  <!-- Top arrowhead pointing right -->
+  <polygon points="720,220 755,250 720,280" style="fill:rgb(100,200,255);"/>
+
+  <!-- Bottom arrow: right to left (curved arc with arrowhead) -->
+  <path d="M 720 295 A 120 80 0 0 1 480 295"
+        style="fill:none;stroke:rgb(255,150,80);stroke-width:18;stroke-linecap:round;"/>
+  <!-- Bottom arrowhead pointing left -->
+  <polygon points="480,265 445,295 480,325" style="fill:rgb(255,150,80);"/>
+
+  <!-- Label text -->
+  <text x="600" y="820" style="font-family:Arial,sans-serif;font-size:52px;font-weight:bold;fill:white;text-anchor:middle;">Switch Gamepad Profile</text>
+  <text x="600" y="880" style="font-family:Arial,sans-serif;font-size:36px;fill:rgb(180,180,180);text-anchor:middle;">DualSense  ⇄  Xbox Series</text>
+</svg>


### PR DESCRIPTION

Adds a Tools menu entry that toggles InputPlumber's emulated gamepad between DualSense (ds5) and Xbox Series (xbox-series) at runtime without requiring a full reboot.

Mechanism:
- The tool script detects the active InputPlumber device config by matching the hardware model string from devicetree/DMI against the configs in /usr/share/inputplumber/devices/.
- It rewrites only the target_devices block via awk, then bind-mounts the generated override over the read-only system file and restarts InputPlumber.
- The preference is stored via ROCKNIX's standard settings system (inputplumber.profile in system.cfg) and survives reboots.

Boot-time persistence for AYN Odin 3 (SM8750):
- A device quirk script (020-set-inputplumber-profile) reads the stored preference at boot and applies the bind-mount override before the UI starts, so the chosen profile is active from first use.

DualSense enables gyroscope/motion support via InputPlumber's ds5 target; Xbox Series provides broader compatibility with games and applications that rely on XInput.

## Summary

Adds a Tools menu entry that toggles InputPlumber's emulated gamepad between **DualSense (ds5)** and **Xbox Series (xbox-series)** at runtime, with persistence across reboots.

## Motivation

InputPlumber on AYN Odin 3 (SM8750) currently emulates a DualSense (`ds5`) by default, which exposes the gyroscope/motion sensors — great for games that support it. However, some games and Electron-based launchers (cloud gaming clients, web frontends) have better compatibility with an XInput/Xbox controller. Switching today requires manually editing `/usr/share/inputplumber/devices/01-ayn-controller.yaml`, which lives on the read-only system partition.

This PR ships a one-click toggle.

## Implementation

**Tool script** — `projects/ROCKNIX/packages/misc/modules/sources/Switch Gamepad Profile.sh`:
- Detects the active InputPlumber device config generically by matching the hardware model string (from devicetree or DMI) against the configs in `/usr/share/inputplumber/devices/` — not hardcoded to a single device.
- Rewrites only the `target_devices:` block via `awk` (no YAML parser dependency), then `mount --bind`s the generated override over the read-only system file and restarts InputPlumber.
- Stores the preference via the standard ROCKNIX `set_setting`/`get_setting` system (`inputplumber.profile` in `system.cfg`).

**Boot-time persistence for AYN Odin 3** — `projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 3/020-set-inputplumber-profile`:
- New device quirk script (the `AYN Odin 3` quirks directory didn't exist yet).
- Reads the stored preference at boot and applies the bind-mount override before the UI starts, so the chosen profile is active from first use.
- No-op if the preference is `ds5` (the compiled-in default), so users not using this tool pay nothing.

**Menu entry** — added to `projects/ROCKNIX/packages/misc/modules/sources/gamelist.xml` next to the other gamepad tools (Test Gamepad, Calibrate Gamepad).

**Icon** — `projects/ROCKNIX/packages/misc/modules/sources/images/switch-gamepad-profile.svg`.

## Testing

Tested on **AYN Odin 3 (SM8750)**:

- ✅ Toggle from ES-DE Tools menu switches between `ds5` and `xbox-series` immediately (verified via `cat /usr/share/inputplumber/devices/01-ayn-controller.yaml` and `mount | grep inputplumber`).
- ✅ InputPlumber restarts cleanly with the new target device.
- ✅ Games detect the controller correctly under each profile (DualSense exposes gyro via `/dev/input/by-id/*-motion-sensors`, Xbox Series is recognized as XInput).
- ✅ Boot-time quirk reapplies the stored preference after reboot.

Not tested on other devices, but the tool script is device-agnostic (it discovers the right config file by model match), so it should work for any device whose InputPlumber config matches via devicetree/DMI model. The boot-time quirk is intentionally scoped to AYN Odin 3 only.

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES 
