### PR TITLE
fix left/right trigger being flipped on retroid

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0008-retroid-gamepad.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0008-retroid-gamepad.patch
@@ -260,8 +260,8 @@ diff -rupbN linux.orig/drivers/input/joystick/retroid.c linux/drivers/input/joys
 +			INT_SIGN(axis_rightz_max) * ( abs(axis_rightz_max) - axis_rightz_antideadzone ),
 +			 0, 0);
 +
-+		input_set_abs_params(indev, ABS_HAT2X, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
-+		input_set_abs_params(indev, ABS_HAT2Y, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
++		input_set_abs_params(indev, ABS_HAT2Y, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
++		input_set_abs_params(indev, ABS_HAT2X, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
 +		update_params = 0;
 +	}
 +
@@ -275,11 +275,11 @@ diff -rupbN linux.orig/drivers/input/joystick/retroid.c linux/drivers/input/joys
 +	int16_t value;
 +
 +	value = (int16_t)(trigger_left_max - (data->data[2] | (data->data[3] << 8)));
-+	input_report_abs(indev, ABS_HAT2X,
++	input_report_abs(indev, ABS_HAT2Y,
 +			 ( value < trigger_left_deadzone )? 0 : value - trigger_left_antideadzone);
 +
 +	value = (int16_t)(trigger_right_max - (data->data[4] | (data->data[5] << 8)));
-+	input_report_abs(indev, ABS_HAT2Y,
++	input_report_abs(indev, ABS_HAT2X,
 +			 ( value < trigger_right_deadzone )? 0 : value - trigger_right_antideadzone);
 +
 +	value = -(int16_t)(data->data[6] | (data->data[7] << 8));
@@ -476,8 +476,8 @@ diff -rupbN linux.orig/drivers/input/joystick/retroid.c linux/drivers/input/joys
 +		INT_SIGN(axis_rightz_max) * ( abs(axis_rightz_max) - axis_rightz_antideadzone ),
 +		0, 0);
 +
-+		input_set_abs_params(gamepad_dev->dev_input, ABS_HAT2X, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
-+		input_set_abs_params(gamepad_dev->dev_input, ABS_HAT2Y, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
++		input_set_abs_params(gamepad_dev->dev_input, ABS_HAT2Y, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
++		input_set_abs_params(gamepad_dev->dev_input, ABS_HAT2X, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
 +
 +	ret = input_register_device(gamepad_dev->dev_input);
 +	if (ret)


### PR DESCRIPTION
## Summary

According to the [kernel doc](https://www.kernel.org/doc/html/latest/input/gamepad.html), left trigger should be `ABS_HAT2Y` not `ABS_HAT2X`.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
