### PR TITLE
RK3588: include 32-bit libmali

### DIFF
--- a/projects/ROCKNIX/devices/RK3588/options
+++ b/projects/ROCKNIX/devices/RK3588/options
@@ -73,6 +73,7 @@
 
   # Additional packages to install
     ADDITIONAL_PACKAGES="libmali weston-kiosk-shell-dpms libmali-vulkan ap6611s"
+    ADDITIONAL_PACKAGES_32BIT="libmali"
 
   # Debug tty path
     DEBUG_TTY="/dev/ttyFIQ0"


### PR DESCRIPTION
## Description

RK3588 currently installs `libmali` for the main aarch64 image, but does not include `libmali` in `ADDITIONAL_PACKAGES_32BIT`. Other Rockchip Mali targets that ship `libmali` for the main image, such as RK3326, RK3566, and RK3576, also include `ADDITIONAL_PACKAGES_32BIT="libmali"`.

Add the same 32-bit package dependency for RK3588 so the 32-bit userland gets the Mali GLES userspace driver instead of falling back to the Mesa 32-bit DRI stack.

## Context

On a GameForce ACE/RK3588 device, a 32-bit GLES PortMaster title was observed loading `/usr/lib32/libEGL_mesa.so` and `/usr/lib32/libGLESv2.so` with `/usr/lib32/dri` Mesa drivers, while the 64-bit RK3588 image already includes the Mali userspace package. Runtime logs showed severe frame timing misses despite the launcher not forcing a Mesa driver override.

## Testing

Not locally built. Validated by comparing RK3588 package options against existing RK3326/RK3566/RK3576 ROCKNIX device options and inspecting the affected device runtime library paths.