### PR TITLE
bugfix: rocknix-fake-suspend - fix slow resume, fix suspend in Steam

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -48,11 +48,37 @@ check_charging() {
 }
 
 check_es_running_game() {
-  local HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1234/runningGame")
-  ${DEBUG} && log $0 "ES runningGame HTTP_STATUS - ${HTTP_STATUS}"
-  test $? != 0 && return 1 # call failed, assume no game running
-  test "${HTTP_STATUS}" = 201 && return 1 # 201 when no game running
-  test "${HTTP_STATUS}" = 200 && return 0 # 200 when game running
+  # Check whether ES API endpoint is up
+  local endpoint_up=1 # default to endpoint down
+  test "$(nc -vz -w5 localhost 1234 2>&1 | grep 'open')" && endpoint_up=0
+  
+  if [[ $endpoint_up -eq 0 ]]; then
+    ${DEBUG} && log $0 "ES API endpoint up - querying"
+    local HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1234/runningGame")
+    ${DEBUG} && log $0 "ES runningGame HTTP_STATUS - ${HTTP_STATUS}"
+    test $? != 0 && return 1 # call failed, assume no game running
+    test "${HTTP_STATUS}" = 201 && return 1 # 201 when no game running
+    test "${HTTP_STATUS}" = 200 && return 0 # 200 when game running
+  else
+    ${DEBUG} && log $0 "ES API endpoint down"
+    return 0 # assume a game is running
+  fi
+}
+
+backlight_off() {
+  ${DEBUG} && log $0 "Backlight off"
+
+  for BL_POWER_DEVICE in "${BL_POWER_DEVICES[@]}"; do
+    echo 4 > "${BL_POWER_DEVICE}"
+  done
+}
+
+backlight_on() {
+  ${DEBUG} && log $0 "Backlight on"
+
+  for BL_POWER_DEVICE in "${BL_POWER_DEVICES[@]}"; do
+    echo 0 > "${BL_POWER_DEVICE}"
+  done
 }
 
 display_off() {
@@ -60,19 +86,18 @@ display_off() {
     # DPMS enabled, use it to turn off the display
     ${DEBUG} && log $0 "DPMS - display off"
 
-    if echo "${UI_SERVICE}" | grep "sway"; then
+    if [[ -n $(echo "${UI_SERVICE}" | grep "sway") && -n $(pgrep "sway") ]]; then
       ${DEBUG} && log $0 "Display power off"
       swaymsg "output * power off"
-    elif echo "${UI_SERVICE}" | grep "weston"; then
+    elif [[ -n $(echo "${UI_SERVICE}" | grep "weston") && -n $(pgrep "weston") ]]; then
       weston-dpms -m off
+    else
+      # Fallback - just turn off the backlight
+      backlight_off
     fi
   else
     # DPMS disabled, just turn off the backlight
-    ${DEBUG} && log $0 "Backlight off"
-
-    for BL_POWER_DEVICE in "${BL_POWER_DEVICES[@]}"; do
-      echo 4 > "${BL_POWER_DEVICE}"
-    done
+    backlight_off
   fi
 }
 
@@ -81,19 +106,17 @@ display_on() {
     # DPMS enabled, use it to turn on the display
     ${DEBUG} && log $0 "DPMS - display on"
 
-    if echo "${UI_SERVICE}" | grep "sway"; then
+    if [[  -n $(echo "${UI_SERVICE}" | grep "sway") && -n $(pgrep "sway") ]]; then
       ${DEBUG} && log $0 "Display power on"
       swaymsg "output * power on"
-    elif echo "${UI_SERVICE}" | grep "weston"; then
+    elif [[ -n $(echo "${UI_SERVICE}" | grep "weston") && -n $(pgrep "weston") ]]; then
       weston-dpms -m on
+    else
+      backlight_on
     fi
   else
-    # DPMS disabled, just turn on the backlight
-    ${DEBUG} && log $0 "Backlight on"
-
-    for BL_POWER_DEVICE in "${BL_POWER_DEVICES[@]}"; do
-      echo 0 > "${BL_POWER_DEVICE}"
-    done
+    # Fallback - just turn on the backlight
+    backlight_on
   fi
 }
 
@@ -196,43 +219,47 @@ unblock_input() {
   done
 }
 
+freeze_processes() {
+  ${DEBUG} && log $0 "Freezing processes"
+
+  # Grab the process to freeze from the set_kill call
+  process_kill_data=$(</tmp/.process-kill-data)
+  process_kill_data=$(echo "${process_kill_data}" | sed 's/-9//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+  if [[ -n "${process_kill_data}" ]]; then
+    ${DEBUG} && log $0 "Freezing '${process_kill_data}' processes"
+
+    for process_cmd in ${process_kill_data}; do
+      for pid in $(pgrep -f "${process_cmd}"); do
+        ${DEBUG} && log $0 "Freezing ${process_cmd} process ${pid}"
+        kill -STOP ${pid}
+      done
+    done
+  fi
+}
+
+unfreeze_processes() {
+  ${DEBUG} && log $0 "Unfreezing processes"
+  kill -CONT -1
+}
+
 do_suspend_actions() {
-  # Disable LEDs
   disable_leds
-
-  # Mute audio
   mute_audio
-
-  # Block input
   block_input
-  
-  # Turn off display
   display_off
-
-  # Set CPU / GPU governors
+  freeze_processes
   powersave_governors
-
-  # CPU core parking (if enabled)
   [[ "${ENABLE_CORE_PARKING}" == "1" ]] && park_cores
 }
 
 do_resume_actions() {
-  # Undo CPU core parking (if enabled)
   [[ "${ENABLE_CORE_PARKING}" == "1" ]] && unpark_cores
-
-  # Restore CPU / GPU governors
   restore_governors
-
-  # Turn on display
+  unfreeze_processes
   display_on
-
-  # Unblock input
   unblock_input
-
-  # Unmute audio
   unmute_audio
-
-  # Restore LEDs
   enable_leds
 }
 


### PR DESCRIPTION
## Summary

rocknix-fake-suspend - add process freeze / unfreeze to fix slow resume, fix suspend when running Steam with DPMS enabled

## Testing

Tested on my Mangmi Air X (SM6115), AYN Odin 2 (SM8550) and Odroid Go Ultra (S922X)

## Additional Context

Resuming after suspending while in game, with the game running on one small core on the powersave governor is very slow. Freezing the game process on suspend massively speeds up resume (and conserves even more power while suspended).

When Steam is running, ES and sway are stopped, so have to fallback to backlight on / off and are unable to query the 'game running' API.

Also clean up some unnecessary comments (code is self-documenting).

---

### AI Usage

**Did you use AI tools to help write this code?** NO
