### PR TITLE
SM6115: GPU max clock speed limiting

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/400-set_gpu_max_clock
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/400-set_gpu_max_clock
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+# Get GPU max clock speed - default to 1050 MHz
+GPU_MAX_CLOCK_SPEED=$(get_setting "gpu-max-clock-speed")
+
+if [ -z "${GPU_MAX_CLOCK_SPEED}" ]; then
+  GPU_MAX_CLOCK_SPEED=1050
+  set_setting "gpu-max-clock-speed" "${GPU_MAX_CLOCK_SPEED}"
+fi
+
+# Set GPU max clock speed
+/usr/lib/autostart/quirks/platforms/SM6115/bin/gpu_max_clock "${GPU_MAX_CLOCK_SPEED}"

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/bin/gpu_max_clock
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM6115/bin/gpu_max_clock
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+if [ -z "${GPU_FREQ}" ]; then
+  . /etc/profile
+fi
+
+# Set max gpu freq
+case $1 in
+  320)
+    echo 320000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 320
+  ;;
+  465)
+    echo 465000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 465
+  ;;
+  600)
+    echo 600000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 600
+  ;;
+  745)
+    echo 745000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 745
+  ;;
+  820)
+    echo 820000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 820
+  ;;
+  900)
+    echo 900000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 900
+  ;;
+  950)
+    echo 950000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 950
+  ;;
+  980)
+    echo 980000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 980
+  ;;
+  1050)
+    echo 1050000000 > $GPU_FREQ/max_freq
+    set_setting gpu-max-clock-speed 1050
+  ;;
+esac

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="091d77ac621b5adce540b55b62a8cd4c095b7502"
+PKG_VERSION="542ecfb73c51da54bb9d9a3fc425fd99b3cee9ba"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
## Summary

SM6115 - support max GPU clock limiting

## Testing

Tested on my Air X

## Additional Context

Dependent on ES PR: https://github.com/ROCKNIX/emulationstation-next/pull/15

---

### AI Usage

**Did you use AI tools to help write this code?** NO
