### PR TITLE
Add decky-loader and nodejs

### DIFF
--- a/projects/ROCKNIX/packages/devel/nodejs/package.mk
+++ b/projects/ROCKNIX/packages/devel/nodejs/package.mk
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="nodejs"
+PKG_VERSION="v22.22.3"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/nodejs/node"
+PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain bzip2:host"
+PKG_LONGDESC="Open-source, cross-platform JavaScript runtime environment."
+PKG_TOOLCHAIN="configure"
+
+pre_build_target() {
+	mkdir -p ${PKG_BUILD}/.${TARGET_NAME}
+	cp -RP ${PKG_BUILD}/* ${PKG_BUILD}/.${TARGET_NAME}
+}
+
+pre_build_host() {
+	mkdir -p ${PKG_BUILD}/.${HOST_NAME}
+	cp -RP ${PKG_BUILD}/* ${PKG_BUILD}/.${HOST_NAME}
+}
+
+configure_target() {
+	case ${ARCH} in
+		aarch64)
+			PKG_ARCH_NAME_NODEJS="arm64"
+		;;
+		arm)
+			PKG_ARCH_NAME_NODEJS="arm"
+		;;
+		x86_64)
+			PKG_ARCH_NAME_NODEJS="x86_64"
+		;;
+	esac
+
+	export CC_target=${TARGET_NAME}-gcc
+  	export CXX_target=${TARGET_NAME}-g++
+	export AR_target=${TARGET_NAME}-ar
+	export LD_target=${TARGET_NAME}-ld
+
+	export CC_host=/usr/bin/gcc
+  	export CXX_host=/usr/bin/g++
+	export AR_host=/usr/bin/ar
+	export LD_host=/usr/bin/ld
+
+  	/usr/bin/python3 ./configure.py \
+		--cross-compiling \
+		--dest-cpu ${PKG_ARCH_NAME_NODEJS} \
+		--shared \
+		--prefix /usr
+}
+
+configure_host() {
+	/usr/bin/python3 ./configure.py \
+		--shared \
+		--prefix ${TOOLCHAIN}
+}
+
+post_makeinstall_host() {
+	mkdir -p ${TOOLCHAIN}/usr/{lib,bin,include}
+}

--- a/projects/ROCKNIX/packages/emulators/standalone/steam/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/steam/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION="1.0.0.85"
 PKG_LICENSE="proprietary"
 PKG_SITE="https://steampowered.com"
 PKG_URL="https://repo.steampowered.com/steam/archive/stable/steam-launcher_${PKG_VERSION}_amd64.deb"
-PKG_DEPENDS_TARGET="mesa:host fex-emu gamescope nss networkmanager"
+PKG_DEPENDS_TARGET="mesa:host fex-emu gamescope nss networkmanager decky-loader"
 PKG_LONGDESC="Steam is the ultimate destination for playing, discussing, and creating games"
 PKG_TOOLCHAIN="manual"
 

--- a/projects/ROCKNIX/packages/lang/Python3/package.mk
+++ b/projects/ROCKNIX/packages/lang/Python3/package.mk
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+. ${ROOT}/packages/lang/Python3/package.mk
+
+PKG_CONFIGURE_OPTS_HOST="ac_cv_prog_HAS_HG=/bin/false
+                         ac_cv_prog_SVNVERSION=/bin/false
+                         py_cv_module_unicodedata=yes
+                         py_cv_module__codecs_cn=n/a
+                         py_cv_module__codecs_hk=n/a
+                         py_cv_module__codecs_iso2022=n/a
+                         py_cv_module__codecs_jp=n/a
+                         py_cv_module__codecs_kr=n/a
+                         py_cv_module__codecs_tw=n/a
+                         py_cv_module__decimal=n/a
+                         py_cv_module__lzma=n/a
+                         py_cv_module_nis=n/a
+                         py_cv_module_ossaudiodev=n/a
+                         py_cv_module__dbm=n/a
+                         py_cv_module__gdbm=n/a
+                         --without-readline
+                         --disable-tk
+                         --disable-curses
+                         --disable-pydoc
+                         --disable-idle3
+                         --with-expat=builtin
+                         --with-doc-strings
+                         --without-pymalloc
+                         --with-ensurepip=yes
+                         --enable-shared
+"
+
+post_makeinstall_target() {
+  ln -sf ${PKG_PYTHON_VERSION} ${INSTALL}/usr/bin/python
+
+  rm -fr ${PKG_BUILD}/.${TARGET_NAME}/build/temp.*
+
+  PKG_INSTALL_PATH_LIB=${INSTALL}/usr/lib/${PKG_PYTHON_VERSION}
+
+  for dir in config compiler sysconfigdata lib-dynload/sysconfigdata test; do
+    rm -rf ${PKG_INSTALL_PATH_LIB}/${dir}
+  done
+
+  safe_remove ${INSTALL}/usr/bin/python*-config
+
+  find ${INSTALL} -name '*.o' -delete
+  find ${INSTALL}/usr/lib/ | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf
+  
+  # strip
+  chmod u+w ${INSTALL}/usr/lib/libpython*.so.*
+  debug_strip ${INSTALL}/usr
+}

--- a/projects/ROCKNIX/packages/tools/decky-loader/package.mk
+++ b/projects/ROCKNIX/packages/tools/decky-loader/package.mk
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="decky-loader"
+PKG_VERSION="v3.2.3"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/SteamDeckHomebrew/decky-loader"
+PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain nodejs:host Python3:host Python3"
+PKG_LONGDESC="A plugin loader for the Steam Deck."
+PKG_TOOLCHAIN="manual"
+
+makeinstall_target() {
+  # Build the frontend
+  # npm needs a home directory, we can't really do that with our build system (or at least Docker)
+  export PKG_DECKY_LOADER_NPM_HOME="${PKG_BUILD}/npm-home"
+  export PKG_DECKY_LOADER_NPM_CACHE="${PKG_BUILD}/npm-cache"
+  mkdir -p ${PKG_DECKY_LOADER_NPM_HOME}
+  mkdir -p ${PKG_DECKY_LOADER_NPM_CACHE}
+
+  pushd ${PKG_BUILD}/frontend
+    # Remove existing node_modules so we can handle the change from npm to pnpm 
+    rm -rf node_modules
+
+    # Download dependencies
+    HOME="${PKG_DECKY_LOADER_NPM_HOME}" npm install pnpm --cache ${PKG_DECKY_LOADER_NPM_CACHE} --no-save --legacy-peer-deps
+    HOME="${PKG_DECKY_LOADER_NPM_HOME}" npm exec -- pnpm i --frozen-lockfile --dangerously-allow-all-builds
+    
+    # Build
+    HOME="${PKG_DECKY_LOADER_NPM_HOME}" npm exec -- pnpm build
+  popd
+
+  # "Build" the backend
+  # We can't really build it... just install the dependencies preemptively
+  export PKG_DECKY_LOADER_PIP_LIBS="${PKG_BUILD}/backend/lib"
+  pip3 install \
+    --target="${PKG_DECKY_LOADER_PIP_LIBS}" \
+    --platform=manylinux2014_aarch64 \
+    --python-version=313 \
+    --implementation=cp \
+    --only-binary=:all: \
+      aiohttp aiohttp-jinja2 aiohttp-cors \
+      setproctitle watchdog certifi packaging Jinja2 yarl frozenlist attrs multidict
+}
+
+post_makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/share/decky-loader/
+    cp -rf ${PKG_BUILD}/backend ${INSTALL}/usr/share/decky-loader/
+
+  mkdir -p ${INSTALL}/usr/bin/
+    cp -rf ${PKG_DIR}/scripts/* ${INSTALL}/usr/bin/
+  
+  chmod +x ${INSTALL}/usr/bin/*
+}
+
+post_install() {
+  enable_service decky-loader.service
+}

--- a/projects/ROCKNIX/packages/tools/decky-loader/package.mk
+++ b/projects/ROCKNIX/packages/tools/decky-loader/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="decky-loader"
-PKG_VERSION="v3.2.3"
+PKG_VERSION="v3.2.4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/SteamDeckHomebrew/decky-loader"
 PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"

--- a/projects/ROCKNIX/packages/tools/decky-loader/scripts/decky-backend.sh
+++ b/projects/ROCKNIX/packages/tools/decky-loader/scripts/decky-backend.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+
+. /etc/profile
+
+DECKY_LOADER_HOME="/storage/.config/decky-loader"
+mkdir -p $DECKY_LOADER_HOME/data
+mkdir -p $DECKY_LOADER_HOME/plugins
+
+UNPRIVILEGED_PATH="$DECKY_LOADER_HOME/data" \
+    PLUGIN_PATH="$DECKY_LOADER_HOME/plugins" \
+    PYTHONPATH="/usr/share/decky-loader/backend/lib/" python3 /usr/share/decky-loader/backend/main.py

--- a/projects/ROCKNIX/packages/tools/decky-loader/system.d/decky-loader.service
+++ b/projects/ROCKNIX/packages/tools/decky-loader/system.d/decky-loader.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Decky Loader
+
+[Service]
+ExecStart=/bin/bash -c "source /etc/profile && /usr/bin/decky-backend.sh"
+Restart=always
+RestartSec=5
+User=root
+Group=root
+
+[Install]
+WantedBy=rocknix.target


### PR DESCRIPTION
Adds the decky-loader and nodejs packages

Node is being used to build the frontend for decky-loader, so it's only used as a host package currently
It can be built for the target though

**note**: As this is mostly host side changes, I'm not sure if there are libs in my toolchain left from previous attempts... please build this first before merge!! 

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
