### PR TITLE
gamescope: enable pipewire support

### DIFF
--- a/projects/ROCKNIX/packages/apps/gamescope/package.mk
+++ b/projects/ROCKNIX/packages/apps/gamescope/package.mk
@@ -10,7 +10,7 @@ PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain wayland wayland-protocols libdrm libinput libxkbcommon pixman systemd \
                     libcap luajit libdecor libX11 libXext libXfixes libXdamage libXcomposite \
                     libXrender libXxf86vm libXtst libXi libXcursor libXmu libXres libxcb \
-                    xcb-util-wm seatd hwdata SDL2"
+                    xcb-util-wm seatd hwdata SDL2 pipewire"
 PKG_LONGDESC="SteamOS session compositing window manager (micro-compositor for games / nested Wayland)."
 GET_HANDLER_SUPPORT="git"
 PKG_TOOLCHAIN="meson"
@@ -24,7 +24,7 @@ configure_package() {
 
 pre_configure_target() {
   PKG_MESON_OPTS_TARGET+=" -Ddrm_backend=enabled \
-                           -Dpipewire=disabled \
+                           -Dpipewire=enabled \
                            -Denable_openvr_support=false \
                            -Davif_screenshots=disabled \
                            -Dbenchmark=disabled \


### PR DESCRIPTION
This gets the Game Recording option in Steam working and doesn't seem to need any other dependencies

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
