### PR TITLE
bugfix: aethersx2 - restore MESA_GLSL_VERSION_OVERRIDE for panfrost

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/aethersx2-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/aethersx2-sa/package.mk
@@ -35,7 +35,7 @@ makeinstall_target() {
 post_install() {
   case ${GRAPHICS_DRIVER} in
     panfrost)
-      GRAPHICS="export MESA_GL_VERSION_OVERRIDE=3.3"
+      GRAPHICS="export MESA_GL_VERSION_OVERRIDE=3.3 MESA_GLSL_VERSION_OVERRIDE=330"
     ;;
     freedreno)
       case ${DEVICE} in


### PR DESCRIPTION
## Summary

Fixes aethersx2 on S922X with panfrost

## Testing

Tested on my OGU

## Additional Context

PR https://github.com/ROCKNIX/distribution/pull/2637 removed the `MESA_GLSL_VERSION_OVERRIDE=330` export (unintentionally). This causes errors with aethersx2 requesting GLSL version 330, but mesa reporting that it is not supported.

---

### AI Usage

**Did you use AI tools to help write this code?** NO
