### PR TITLE
options: switch SquashFS compression from lzo to zstd

### DIFF
--- a/projects/ROCKNIX/options
+++ b/projects/ROCKNIX/options
@@ -5,8 +5,10 @@
   # Project FLAGS
     PROJECT_CFLAGS=""
 
-  # SquashFS compression method (gzip / lzo / xz)
-    SQUASHFS_COMPRESSION="lzo"
+  # SquashFS compression method (gzip / lzo / xz / zstd).
+  # zstd at level 22 compresses ~25-30% better than lzo while decoding at
+  # comparable speed on aarch64 (decode speed is independent of level).
+    SQUASHFS_COMPRESSION="zstd"
 
 ################################################################################
 # setup project defaults


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Switch SquashFS compression from `lzo` to `zstd`. Comparable decode speed on aarch64.

## Testing

* **How was this tested?** Built and booted on SM8750. All 12 device kernels already enable `CONFIG_SQUASHFS_ZSTD`.

## Additional Context

* ~25–30% smaller image.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY — helped with audit of other platforms.