### PR TITLE
apps: qterminal terminal-friendly keyboard + dedicated workspace

### DIFF
--- a/projects/ROCKNIX/packages/apps/qterminal/scripts/qterminal.sh
+++ b/projects/ROCKNIX/packages/apps/qterminal/scripts/qterminal.sh
@@ -10,7 +10,36 @@ if [ ! -d "/storage/.config/qterminal.org" ]; then
      cp -r "/usr/config/qterminal.org" "/storage/.config/"
 fi
 
-sway_fullscreen "qterminal" &
+# wvkbd default layout (`simple`) lacks Ctrl/Alt and arrows, useless in a
+# terminal. We want `full,nav,special`. Also, sway fullscreen ignores layer-
+# shell exclusive_zone, and plain tiled puts qterminal next to ES/foot in the
+# same workspace. Solution: dedicate workspace 99 to qterminal so it's the
+# sole tiled window there — sway then fills the workspace area minus wvkbd's
+# exclusive_zone, giving us no overlap and no side-by-side tile.
+prior_tskb=$(get_setting "rocknix.touchscreen-keyboard.enabled")
+set_setting "rocknix.touchscreen-keyboard.enabled" "0"
+pkill wvkbd-mobintl 2>/dev/null
+sleep 0.2
+
+# -H is portrait height, -L is landscape height. SM8750 boots landscape via
+# sway transform=90, so -L is what matters here; without it wvkbd falls back
+# to a tiny default (~120 px) and the keys end up squished. -fn 32 fits the
+# 5-row `full` layout at 380 px without overflow.
+/usr/bin/wvkbd-mobintl -H 380 -L 380 -fg 6b6b75 -fg-sp 6b6b75 -bg 1d1d1d \
+  --text ffffff --text-sp ffffff -press 000000 --press-sp 000000 -fn 32 \
+  -l full,nav,special &
+
+# Stash the workspace we came from, so we can return there on exit.
+prior_ws=$(swaymsg -t get_workspaces | jq -r '.[] | select(.focused) | .name')
+swaymsg "workspace 99:qterminal"
+swaymsg 'for_window [app_id="qterminal"] move container to workspace 99:qterminal, focus'
+
+cleanup_osk() {
+  pkill wvkbd-mobintl 2>/dev/null
+  set_setting "rocknix.touchscreen-keyboard.enabled" "${prior_tskb:-1}"
+  [ -n "${prior_ws}" ] && swaymsg "workspace ${prior_ws}" 2>/dev/null
+}
+trap cleanup_osk EXIT INT TERM
 
 cd ~/
 /usr/bin/qterminal

--- a/projects/ROCKNIX/packages/apps/rocknix-touchscreen-keyboard/patches/004-full-layout-terminal-friendly.patch
+++ b/projects/ROCKNIX/packages/apps/rocknix-touchscreen-keyboard/patches/004-full-layout-terminal-friendly.patch
@@ -1,0 +1,46 @@
+Rework the `full` layout for terminal use: Tab and 123 swap positions in
+the top row so the layer-switch key is far away from the cursor keys; Ctrl
+moves from the top row to the bottom row (the slot 123 vacated) so it sits
+directly under Shift for one-handed terminal modifiers; and the comma and
+period are placed side-by-side after the spacebar instead of flanking it.
+
+Row widths are preserved (top row stays 10.0, bottom row stays 10.0).
+
+---
+ layout.mobintl.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/layout.mobintl.h b/layout.mobintl.h
+--- a/layout.mobintl.h
++++ b/layout.mobintl.h
+@@ -174,7 +174,7 @@ static struct key keys_arrows[] = {
+
+ static struct key keys_full[] = {
+   {"Esc", "Esc", 1.0, Code, KEY_ESC, .scheme = 1},
+-  {"Ctr", "Ctr", 1.0, Mod, Ctrl, .scheme = 1},
++  {"Tab", "Tab", 1.0, Code, KEY_TAB, .scheme = 1},
+   {"↑", "↑", 1.0, Code, KEY_UP, .scheme = 1},
+   {"↓", "↓", 1.0, Code, KEY_DOWN, .scheme = 1},
+   {"←", "←", 1.0, Code, KEY_LEFT, .scheme = 1},
+@@ -182,7 +182,7 @@ static struct key keys_full[] = {
+   {"'", "\"", 1.0, Code, KEY_APOSTROPHE, &layouts[ComposeBracket] },
+   {"-", "_", 1.0, Code, KEY_MINUS, &layouts[ComposeMath] },
+   {"/", ">", 1.0, Code, KEY_SLASH,  &layouts[ComposePunctuation] },
+-  {"Tab", "Tab", 1.0, Code, KEY_TAB, .scheme = 1},
++  {"123", "123", 1.0, NextLayer, .scheme = 1},
+   {"", "", 0.0, EndRow},
+
+   {"1", "!", 1.0, Code, KEY_1},
+@@ -233,11 +233,11 @@ static struct key keys_full[] = {
+   {"Back", "Back", 1.5, Code, KEY_BACKSPACE, .scheme = 1},
+   {"", "", 0.0, EndRow},
+
+-  {"123", "123", 1.5, NextLayer, .scheme = 1},
++  {"Ctr", "Ctr", 1.5, Mod, Ctrl, .scheme = 1},
+   {"Cmp", "Cmp", 1.0, Compose, .scheme = 1},
+-  {",", "'", 1.0, Code, KEY_COMMA, &layouts[ComposeMath]},
+   {"", "Tab", 4.0, Code, KEY_SPACE},
++  {",", "'", 1.0, Code, KEY_COMMA, &layouts[ComposeMath]},
+   {".", "?", 1.0, Code, KEY_DOT, &layouts[ComposePunctuation]},
+   {"Enter", "Enter", 1.5, Code, KEY_ENTER, .scheme = 1},
+


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make qterminal usable on touch. The default `simple` wvkbd layout lacks necessary affordances for terminal work.

## Testing

* **How was this tested?** Tested on Odin 3.

## Additional Context

* Spawns `wvkbd-mobintl` with `full,nav,special` and reworks the `full` layout (Tab top-left, Ctrl under Shift, arrows clear of the layer-switch key). qterminal gets a dedicated workspace so it tiles cleanly above the keyboard's exclusive zone instead of fighting it.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY — helped with the Sway workspace/layout side.