### PR TITLE
SM8550: Home key mapping for AYN button on Thor

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayn_mcu.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayn_mcu.yaml
@@ -92,6 +92,15 @@ mapping:
     target_event:
       keyboard: KeyF1
 
+  - name: Home Key
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_F24
+          value_type: button
+    target_event:
+      keyboard: KeyHome
+
   - name: Right Trigger
     source_events:
       - evdev:

--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-controller.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-controller.yaml
@@ -55,6 +55,12 @@ source_devices:
       handler: event*
     capability_map_id: ayn_mcu
 
+  - group: gamepad
+    evdev:
+      phys_path: gpio-keys/input0
+      handler: event*
+    capability_map_id: ayn_mcu
+
 # Optional configuration for the composite device
 options:
   # If true, InputPlumber will automatically try to manage the input device. If


### PR DESCRIPTION
## Summary

restore from https://github.com/ROCKNIX/distribution/pull/2793

To add the AYN button (KEY_F24) mapping for SM8550 devices by adding the gpio-keys/input0 input path.

## Testing

Tested on Thor(SM8550).
AYN button is successfully recognized and outputs as a virtual keyboard KeyHome.

## Additional Context

Since the virtual ds  has a strict limit of buttons and no extra empty buttons available for mapping, I had to map this AYN button to the KeyHome, just like how the Back button is mapped.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
