### PR TITLE
Make sure PPSSPP conf dir exists when launching from tools

### DIFF
--- a/projects/ROCKNIX/packages/virtual/emulators/sources/Start PPSSPP.sh
+++ b/projects/ROCKNIX/packages/virtual/emulators/sources/Start PPSSPP.sh
@@ -7,6 +7,15 @@ source /etc/profile
 
 set_kill set "ppsspp"
 
+SOURCE_DIR="/usr/config/ppsspp"
+CONF_DIR="/storage/.config/ppsspp"
+
+# Check if conf dir exists
+if [ ! -d "${CONF_DIR}" ]
+then
+  cp -rf ${SOURCE_DIR} ${CONF_DIR}
+fi
+
 cp -f /storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt /storage/.config/ppsspp/assets/gamecontrollerdb.txt
 
 /usr/bin/ppsspp >/dev/null 2>&1


### PR DESCRIPTION
Fixes a bug where if you launch PPSSPP from the tools menu where the config folder doesnt exist (this should not happen under normal circumstances as it should be created during first install or launching a game). 