### PR TITLE
sm6115: USB PD 3.0 and match vendor override

### DIFF
--- a/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
+++ b/projects/ROCKNIX/devices/SM6115/linux/dts/qcom/sm6115-mangmi-air-x-base.dtsi
@@ -34,8 +34,8 @@
 		voltage-max-design-microvolt = <4350000>;
 		constant-charge-current-max-microamp = <3000000>;
 		constant-charge-voltage-max-microvolt = <4350000>;
-		precharge-current-microamp = <180000>;
-		charge-term-current-microamp = <180000>;
+		precharge-current-microamp = <200000>;
+		charge-term-current-microamp = <200000>;
 	};
 
 	fan: gpio-fan {
@@ -478,13 +478,24 @@
 		connector {
 			compatible = "usb-c-connector";
 			label = "USB-C";
-			pd-revision = /bits/ 8 <0x2 0x0 0x1 0x20>;
+			pd-revision = /bits/ 8 <0x3 0x0 0x1 0x20>;
+			self-powered;
 			power-role = "dual";
 			data-role = "dual";
 			try-power-role = "sink";
 			op-sink-microwatt = <10000000>;
-			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
-			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_DUAL_ROLE |
+						      PDO_FIXED_USB_COMM |
+						      PDO_FIXED_DATA_SWAP)
+				PDO_PPS_APDO(4000, 11000, 3000)>;
+
+			source-pdos = <PDO_FIXED(5000, 1200,
+						 PDO_FIXED_DUAL_ROLE |
+						 PDO_FIXED_DATA_SWAP |
+						 PDO_FIXED_USB_COMM)>;
+
+			pd-source-inputs = <0x04>;
+			pd-battery-info = <0x01>;
 
 			ports {
 				#address-cells = <1>;
@@ -517,7 +528,6 @@
 		wakeup-source;
 
 		input-voltage-limit-microvolt = <4500000>;
-		input-current-limit-microamp = <2400000>;
 
 		status = "okay";
 

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0063-power-supply-bq256xx-add-sgm41515-alias.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0063-power-supply-bq256xx-add-sgm41515-alias.patch
@@ -1,22 +1,278 @@
+Subject: [PATCH] power: supply: bq256xx: add SGM41515 chip_info
+
+SGMicro SGM41515 is a register-similar to BQ25601D. Tables verified
+from disassembly of SGM41515 datasheet and vendor driver.
+
+
 ---
- drivers/power/supply/bq256xx_charger.c | 2 ++
- 1 file changed, 2 insertions(+)
+ drivers/power/supply/bq256xx_charger.c | 206 +++++++++++++++++++++++++
+ 1 file changed, 206 insertions(+)
 
 --- a/drivers/power/supply/bq256xx_charger.c
 +++ b/drivers/power/supply/bq256xx_charger.c
-@@ -1775,6 +1775,7 @@ static const struct i2c_device_id bq256xx_i2c_ids[] = {
+@@ -113,6 +113,21 @@
+ #define BQ25618_ICHG_THRESH		0x3c
+ #define BQ25618_ICHG_THRESH_uA		1180000
+ 
++#define SGM41515_ICHG_MIN_uA		0
++#define SGM41515_ICHG_MAX_uA		3000000
++#define SGM41515_ICHG_DEF_uA		1980000
++#define SGM41515_IPRECHG_MIN_uA		5000
++#define SGM41515_IPRECHG_MAX_uA		240000
++#define SGM41515_IPRECHG_DEF_uA		120000
++#define SGM41515_ITERM_MIN_uA		5000
++#define SGM41515_ITERM_MAX_uA		240000
++#define SGM41515_ITERM_DEF_uA		120000
++#define SGM41515_VBATREG_MIN_uV		3856000
++#define SGM41515_VBATREG_MAX_uV		4624000
++#define SGM41515_VBATREG_DEF_uV		4208000
++#define SGM41515_VBATREG_SPECIAL_CODE	15
++#define SGM41515_VBATREG_SPECIAL_uV	4350000
++
+ #define BQ256XX_VBUS_STAT_MASK		GENMASK(7, 5)
+ #define BQ256XX_VBUS_STAT_NO_INPUT	0
+ #define BQ256XX_VBUS_STAT_USB_SDP	BIT(5)
+@@ -202,6 +222,7 @@
+ 	BQ25618,
+ 	BQ25619,
+ 	BQ25611D,
++	SGM41515,
+ };
+ 
+ /**
+@@ -333,6 +354,22 @@
+ 	1290000, 1360000, 1430000, 1500000
+ };
+ 
++static const int sgm41515_ichg_values[] = {
++	      0,    5000,   10000,   15000,   20000,   25000,   30000,   35000,
++	  40000,   50000,   60000,   70000,   80000,   90000,  100000,  110000,
++	 130000,  150000,  170000,  190000,  210000,  230000,  250000,  270000,
++	 300000,  330000,  360000,  390000,  420000,  450000,  480000,  510000,
++	 540000,  600000,  660000,  720000,  780000,  840000,  900000,  960000,
++	1020000, 1080000, 1140000, 1200000, 1260000, 1320000, 1380000, 1440000,
++	1500000, 1620000, 1740000, 1860000, 1980000, 2100000, 2220000, 2340000,
++	2460000, 2580000, 2700000, 2820000, 2940000, 3000000, 3000000, 3000000,
++};
++
++static const int sgm41515_prechrg_term_values[] = {
++	  5000,  10000,  15000,  20000,  30000,  40000,  50000,  60000,
++	 80000, 100000, 120000, 140000, 160000, 180000, 200000, 240000,
++};
++
+ static int bq256xx_array_parse(int array_size, int val, const int array[])
+ {
+ 	int i = 0;
+@@ -539,6 +578,35 @@
+ 					BQ256XX_ICHG_MASK, ichg_reg_code);
+ }
+ 
++static int sgm41515_get_ichg_curr(struct bq256xx_device *bq)
++{
++	unsigned int charge_current_limit;
++	unsigned int ichg_reg_code;
++	int ret;
++
++	ret = regmap_read(bq->regmap, BQ256XX_CHARGE_CURRENT_LIMIT,
++			  &charge_current_limit);
++	if (ret)
++		return ret;
++
++	ichg_reg_code = charge_current_limit & BQ256XX_ICHG_MASK;
++	return sgm41515_ichg_values[ichg_reg_code];
++}
++
++static int sgm41515_set_ichg_curr(struct bq256xx_device *bq, int ichg)
++{
++	int array_size = ARRAY_SIZE(sgm41515_ichg_values);
++	unsigned int ichg_reg_code;
++	int ichg_max = bq->init_data.ichg_max;
++
++	ichg = clamp(ichg, SGM41515_ICHG_MIN_uA, ichg_max);
++	ichg_reg_code = bq256xx_array_parse(array_size, ichg,
++					    sgm41515_ichg_values);
++
++	return regmap_update_bits(bq->regmap, BQ256XX_CHARGE_CURRENT_LIMIT,
++				  BQ256XX_ICHG_MASK, ichg_reg_code);
++}
++
+ static int bq25618_619_get_chrg_volt(struct bq256xx_device *bq)
+ {
+ 	unsigned int battery_volt_lim;
+@@ -692,6 +760,45 @@
+ 	return regmap_update_bits(bq->regmap, BQ256XX_BATTERY_VOLTAGE_LIMIT,
+ 				BQ256XX_VBATREG_MASK, vbatreg_reg_code <<
+ 						BQ256XX_VBATREG_BIT_SHIFT);
++}
++
++static int sgm41515_get_chrg_volt(struct bq256xx_device *bq)
++{
++	unsigned int battery_volt_lim;
++	unsigned int vbatreg_reg_code;
++	int ret;
++
++	ret = regmap_read(bq->regmap, BQ256XX_BATTERY_VOLTAGE_LIMIT,
++			  &battery_volt_lim);
++	if (ret)
++		return ret;
++
++	vbatreg_reg_code = (battery_volt_lim & BQ256XX_VBATREG_MASK) >>
++			   BQ256XX_VBATREG_BIT_SHIFT;
++
++	if (vbatreg_reg_code == SGM41515_VBATREG_SPECIAL_CODE)
++		return SGM41515_VBATREG_SPECIAL_uV;
++
++	return SGM41515_VBATREG_MIN_uV +
++	       vbatreg_reg_code * BQ2560X_VBATREG_STEP_uV;
++}
++
++static int sgm41515_set_chrg_volt(struct bq256xx_device *bq, int vbatreg)
++{
++	unsigned int vbatreg_reg_code;
++	int vbatreg_max = bq->init_data.vbatreg_max;
++
++	vbatreg = clamp(vbatreg, SGM41515_VBATREG_MIN_uV, vbatreg_max);
++
++	if (vbatreg == SGM41515_VBATREG_SPECIAL_uV)
++		vbatreg_reg_code = SGM41515_VBATREG_SPECIAL_CODE;
++	else
++		vbatreg_reg_code = (vbatreg - SGM41515_VBATREG_MIN_uV) /
++				   BQ2560X_VBATREG_STEP_uV;
++
++	return regmap_update_bits(bq->regmap, BQ256XX_BATTERY_VOLTAGE_LIMIT,
++				  BQ256XX_VBATREG_MASK,
++				  vbatreg_reg_code << BQ256XX_VBATREG_BIT_SHIFT);
+ }
+ 
+ static int bq256xx_set_ts_ignore(struct bq256xx_device *bq, bool ts_ignore)
+@@ -764,6 +876,38 @@
+ 				BQ256XX_IPRECHG_MASK, iprechg_reg_code);
+ }
+ 
++static int sgm41515_get_prechrg_curr(struct bq256xx_device *bq)
++{
++	unsigned int prechg_and_term_curr_lim;
++	unsigned int iprechg_reg_code;
++	int ret;
++
++	ret = regmap_read(bq->regmap, BQ256XX_PRECHG_AND_TERM_CURR_LIM,
++			  &prechg_and_term_curr_lim);
++	if (ret)
++		return ret;
++
++	iprechg_reg_code = (prechg_and_term_curr_lim & BQ256XX_IPRECHG_MASK)
++			   >> BQ256XX_IPRECHG_BIT_SHIFT;
++
++	return sgm41515_prechrg_term_values[iprechg_reg_code];
++}
++
++static int sgm41515_set_prechrg_curr(struct bq256xx_device *bq, int iprechg)
++{
++	int array_size = ARRAY_SIZE(sgm41515_prechrg_term_values);
++	unsigned int iprechg_reg_code;
++
++	iprechg = clamp(iprechg, SGM41515_IPRECHG_MIN_uA,
++			SGM41515_IPRECHG_MAX_uA);
++	iprechg_reg_code = bq256xx_array_parse(array_size, iprechg,
++					       sgm41515_prechrg_term_values)
++			   << BQ256XX_IPRECHG_BIT_SHIFT;
++
++	return regmap_update_bits(bq->regmap, BQ256XX_PRECHG_AND_TERM_CURR_LIM,
++				  BQ256XX_IPRECHG_MASK, iprechg_reg_code);
++}
++
+ static int bq256xx_get_term_curr(struct bq256xx_device *bq)
+ {
+ 	unsigned int prechg_and_term_curr_lim;
+@@ -822,8 +966,36 @@
+ 
+ 	return regmap_update_bits(bq->regmap, BQ256XX_PRECHG_AND_TERM_CURR_LIM,
+ 				BQ256XX_ITERM_MASK, iterm_reg_code);
++}
++
++static int sgm41515_get_term_curr(struct bq256xx_device *bq)
++{
++	unsigned int prechg_and_term_curr_lim;
++	unsigned int iterm_reg_code;
++	int ret;
++
++	ret = regmap_read(bq->regmap, BQ256XX_PRECHG_AND_TERM_CURR_LIM,
++			  &prechg_and_term_curr_lim);
++	if (ret)
++		return ret;
++
++	iterm_reg_code = prechg_and_term_curr_lim & BQ256XX_ITERM_MASK;
++	return sgm41515_prechrg_term_values[iterm_reg_code];
+ }
+ 
++static int sgm41515_set_term_curr(struct bq256xx_device *bq, int iterm)
++{
++	int array_size = ARRAY_SIZE(sgm41515_prechrg_term_values);
++	unsigned int iterm_reg_code;
++
++	iterm = clamp(iterm, SGM41515_ITERM_MIN_uA, SGM41515_ITERM_MAX_uA);
++	iterm_reg_code = bq256xx_array_parse(array_size, iterm,
++					     sgm41515_prechrg_term_values);
++
++	return regmap_update_bits(bq->regmap, BQ256XX_PRECHG_AND_TERM_CURR_LIM,
++				  BQ256XX_ITERM_MASK, iterm_reg_code);
++}
++
+ static int bq256xx_get_input_volt_lim(struct bq256xx_device *bq)
+ {
+ 	unsigned int charger_control_2;
+@@ -1532,6 +1704,38 @@
+ 		.bq256xx_max_vbatreg = BQ25618_VBATREG_MAX_uV,
+ 
+ 		.has_usb_detect = false,
++	},
++
++	[SGM41515] = {
++		.model_id = SGM41515,
++		.bq256xx_regmap_config = &bq25600_regmap_config,
++		.bq256xx_get_ichg = sgm41515_get_ichg_curr,
++		.bq256xx_get_iindpm = bq256xx_get_input_curr_lim,
++		.bq256xx_get_vbatreg = sgm41515_get_chrg_volt,
++		.bq256xx_get_iterm = sgm41515_get_term_curr,
++		.bq256xx_get_iprechg = sgm41515_get_prechrg_curr,
++		.bq256xx_get_vindpm = bq256xx_get_input_volt_lim,
++
++		.bq256xx_set_ichg = sgm41515_set_ichg_curr,
++		.bq256xx_set_iindpm = bq256xx_set_input_curr_lim,
++		.bq256xx_set_vbatreg = sgm41515_set_chrg_volt,
++		.bq256xx_set_iterm = sgm41515_set_term_curr,
++		.bq256xx_set_iprechg = sgm41515_set_prechrg_curr,
++		.bq256xx_set_vindpm = bq256xx_set_input_volt_lim,
++		.bq256xx_set_charge_type = bq256xx_set_charge_type,
++		.bq256xx_set_ts_ignore = NULL,
++
++		.bq256xx_def_ichg = SGM41515_ICHG_DEF_uA,
++		.bq256xx_def_iindpm = BQ256XX_IINDPM_DEF_uA,
++		.bq256xx_def_vbatreg = SGM41515_VBATREG_DEF_uV,
++		.bq256xx_def_iterm = SGM41515_ITERM_DEF_uA,
++		.bq256xx_def_iprechg = SGM41515_IPRECHG_DEF_uA,
++		.bq256xx_def_vindpm = BQ256XX_VINDPM_DEF_uV,
++
++		.bq256xx_max_ichg = SGM41515_ICHG_MAX_uA,
++		.bq256xx_max_vbatreg = SGM41515_VBATREG_MAX_uV,
++
++		.has_usb_detect = true,
+ 	},
+ };
+ 
+@@ -1775,6 +1979,7 @@
  	{ "bq25611d", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25611D] },
  	{ "bq25618", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25618] },
  	{ "bq25619", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25619] },
-+	{ "sgm41515", (kernel_ulong_t)&bq256xx_chip_info_tbl[BQ25601D] },
++	{ "sgm41515", (kernel_ulong_t)&bq256xx_chip_info_tbl[SGM41515] },
  	{}
  };
  MODULE_DEVICE_TABLE(i2c, bq256xx_i2c_ids);
-@@ -1787,6 +1788,7 @@ static const struct of_device_id bq256xx_of_match[] = {
+@@ -1787,6 +1992,7 @@
  	{ .compatible = "ti,bq25611d", .data = &bq256xx_chip_info_tbl[BQ25611D] },
  	{ .compatible = "ti,bq25618", .data = &bq256xx_chip_info_tbl[BQ25618] },
  	{ .compatible = "ti,bq25619", .data = &bq256xx_chip_info_tbl[BQ25619] },
-+	{ .compatible = "sgmicro,sgm41515", .data = &bq256xx_chip_info_tbl[BQ25601D] },
++	{ .compatible = "sgmicro,sgm41515", .data = &bq256xx_chip_info_tbl[SGM41515] },
  	{}
  };
  MODULE_DEVICE_TABLE(of, bq256xx_of_match);

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0064-power-supply-bq256xx-reset-chip-on-init.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0064-power-supply-bq256xx-reset-chip-on-init.patch
@@ -1,18 +1,27 @@
+Subject: [PATCH] power: supply: bq256xx: reset chip on init + honor DT charge limits
+
+---
+ drivers/power/supply/bq256xx_charger.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/power/supply/bq256xx_charger.c b/drivers/power/supply/bq256xx_charger.c
 --- a/drivers/power/supply/bq256xx_charger.c
 +++ b/drivers/power/supply/bq256xx_charger.c
-@@ -1614,6 +1614,11 @@
+@@ -1614,6 +1614,13 @@ static int bq256xx_hw_init(struct bq256xx_device *bq)
  	int ret = 0;
  	int i;
  
 +	/* Reset chip to clear stale register values (e.g. from Android) */
-+	regmap_update_bits(bq->regmap, BQ256XX_PART_INFORMATION,
-+			   BQ256XX_REG_RST, BQ256XX_REG_RST);
++	ret = regmap_update_bits(bq->regmap, BQ256XX_PART_INFORMATION,
++				 BQ256XX_REG_RST, BQ256XX_REG_RST);
++	if (ret)
++		return ret;
 +	msleep(10);
 +
  	for (i = 0; i < BQ256XX_NUM_WD_VAL; i++) {
  		if (bq->watchdog_timer == bq256xx_watchdog_time[i]) {
  			wd_reg_val = i;
-@@ -1671,7 +1676,7 @@
+@@ -1671,7 +1680,7 @@ static int bq256xx_hw_init(struct bq256xx_device *bq)
  		return ret;
  
  	ret = bq->chip_info->bq256xx_set_ichg(bq,
@@ -21,7 +30,7 @@
  	if (ret)
  		return ret;
  
-@@ -1681,7 +1686,7 @@
+@@ -1681,7 +1690,7 @@ static int bq256xx_hw_init(struct bq256xx_device *bq)
  		return ret;
  
  	ret = bq->chip_info->bq256xx_set_vbatreg(bq,

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0066-power-supply-bq256xx-push-chip-max-on-attach.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0066-power-supply-bq256xx-push-chip-max-on-attach.patch
@@ -1,28 +1,64 @@
+Subject: [PATCH] power: supply: bq256xx: set IINDPM from detected source type
+---
+ drivers/power/supply/bq256xx_charger.c | 28 ++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
 --- a/drivers/power/supply/bq256xx_charger.c
 +++ b/drivers/power/supply/bq256xx_charger.c
-@@ -1246,6 +1246,7 @@
+@@ -41,6 +41,8 @@
+ #define BQ256XX_IINDPM_MIN_uA		100000
+ #define BQ256XX_IINDPM_MAX_uA		3200000
+ #define BQ256XX_IINDPM_DEF_uA		2400000
++#define BQ256XX_IINDPM_SDP_uA		500000
++#define BQ256XX_IINDPM_CDP_uA		1500000
+ 
+ #define BQ256XX_TS_IGNORE		BIT(6)
+ #define BQ256XX_TS_IGNORE_SHIFT		6
+@@ -1412,12 +1414,34 @@
+ 	mutex_unlock(&bq->lock);
+ 
+ 	return memcmp(&old_state, new_state, sizeof(struct bq256xx_state)) != 0;
++}
++
++static void bq256xx_set_iindpm_for_type(struct bq256xx_device *bq, u8 vbus_stat)
++{
++	int iindpm;
++
++	switch (vbus_stat) {
++	case BQ256XX_VBUS_STAT_USB_SDP:
++		iindpm = BQ256XX_IINDPM_SDP_uA;
++		break;
++	case BQ256XX_VBUS_STAT_USB_CDP:
++		iindpm = BQ256XX_IINDPM_CDP_uA;
++		break;
++	case BQ256XX_VBUS_STAT_USB_DCP:
++		iindpm = BQ256XX_IINDPM_MAX_uA;
++		break;
++	default:
++		return;
++	}
++
++	bq->chip_info->bq256xx_set_iindpm(bq, iindpm);
+ }
+ 
+ static irqreturn_t bq256xx_irq_handler_thread(int irq, void *private)
  {
  	struct bq256xx_device *bq = private;
  	struct bq256xx_state state;
-+	bool inserted;
++	u8 prev_vbus_stat;
  	int ret;
  
  	ret = bq256xx_get_state(bq, &state);
-@@ -1256,8 +1257,17 @@
+@@ -1428,8 +1460,12 @@
  		goto irq_out;
  
  	mutex_lock(&bq->lock);
-+	inserted = (bq->state.vbus_stat == BQ256XX_VBUS_STAT_NO_INPUT) &&
-+		   (state.vbus_stat != BQ256XX_VBUS_STAT_NO_INPUT) &&
-+		   (state.vbus_stat != BQ256XX_VBUS_STAT_USB_OTG);
++	prev_vbus_stat = bq->state.vbus_stat;
  	bq->state = state;
  	mutex_unlock(&bq->lock);
 +
-+	if (inserted) {
-+		/* Vendor parity: push to chip max on every adapter attach. */
-+		bq->chip_info->bq256xx_set_iindpm(bq, BQ256XX_IINDPM_MAX_uA);
-+		bq->chip_info->bq256xx_set_ichg(bq, bq->init_data.ichg_max);
-+	}
++	if (state.vbus_stat != prev_vbus_stat)
++		bq256xx_set_iindpm_for_type(bq, state.vbus_stat);
  
  	power_supply_changed(bq->charger);
  

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0067-power-supply-bq256xx-software-jeita.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0067-power-supply-bq256xx-software-jeita.patch
@@ -1,6 +1,6 @@
 --- a/drivers/power/supply/bq256xx_charger.c
 +++ b/drivers/power/supply/bq256xx_charger.c
-@@ -76,6 +76,16 @@
+@@ -78,6 +78,16 @@
  
  #define BQ256XX_CHG_CONFIG_MASK		BIT(4)
  #define BQ256XX_CHG_CONFIG_BIT_SHIFT	4
@@ -17,7 +17,7 @@
  #define BQ256XX_OTG_CONFIG		BIT(5)
  
  #define BQ256XX_ITERM_MASK		GENMASK(3, 0)
-@@ -229,6 +239,16 @@
+@@ -247,6 +257,16 @@
   * @state: device status and faults
   * @watchdog_timer: watchdog timer value in milliseconds
   */
@@ -34,7 +34,7 @@
  struct bq256xx_device {
  	struct i2c_client *client;
  	struct device *dev;
-@@ -249,6 +269,10 @@
+@@ -267,6 +287,10 @@
  	const struct bq256xx_chip_info *chip_info;
  	struct bq256xx_state state;
  	int watchdog_timer;
@@ -45,12 +45,10 @@
  };
  
  /**
-@@ -1228,8 +1252,117 @@
- 	}
- 
+@@ -1392,6 +1416,115 @@
  	return ret;
-+}
-+
+ }
+ 
 +static int bq256xx_jeita_read_temp(struct bq256xx_device *bq, int *temp_dC)
 +{
 +	union power_supply_propval val;
@@ -157,21 +155,25 @@
 +	cancel_delayed_work_sync(&bq->jeita_work);
 +	if (bq->fg_psy)
 +		power_supply_put(bq->fg_psy);
- }
- 
++}
++
 +
  static bool bq256xx_state_changed(struct bq256xx_device *bq,
  				  struct bq256xx_state *new_state)
  {
-@@ -1267,6 +1400,7 @@
- 		/* Vendor parity: push to chip max on every adapter attach. */
- 		bq->chip_info->bq256xx_set_iindpm(bq, BQ256XX_IINDPM_MAX_uA);
- 		bq->chip_info->bq256xx_set_ichg(bq, bq->init_data.ichg_max);
+@@ -1444,8 +1577,10 @@
+ 	bq->state = state;
+ 	mutex_unlock(&bq->lock);
+ 
+-	if (state.vbus_stat != prev_vbus_stat)
++	if (state.vbus_stat != prev_vbus_stat) {
+ 		bq256xx_set_iindpm_for_type(bq, state.vbus_stat);
 +		mod_delayed_work(system_wq, &bq->jeita_work, 0);
- 	}
++	}
  
  	power_supply_changed(bq->charger);
-@@ -1847,6 +1981,14 @@
+ 
+@@ -2059,6 +2194,14 @@
  		return ret;
  	}
  

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0106-fusb302-signal-tx-completion-from-interrupt-bit.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0106-fusb302-signal-tx-completion-from-interrupt-bit.patch
@@ -1,0 +1,46 @@
+Subject: [PATCH] usb: typec: tcpc: fusb302: signal TX completion from IRQ bit
+
+---
+ drivers/usb/typec/tcpm/fusb302.c | 20 +++++++++-----------
+ 1 file changed, 9 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/usb/typec/tcpm/fusb302.c b/drivers/usb/typec/tcpm/fusb302.c
+--- a/drivers/usb/typec/tcpm/fusb302.c
++++ b/drivers/usb/typec/tcpm/fusb302.c
+@@ -1463,20 +1463,17 @@
+ 	fusb302_log(chip, "PD message len: %d", len);
+ 
+ 	/*
+-	 * Check if we've read off a GoodCRC message. If so then indicate to
+-	 * TCPM that the previous transmission has completed. Otherwise we pass
+-	 * the received message over to TCPM for processing.
+-	 *
+-	 * We make this check here instead of basing the reporting decision on
+-	 * the IRQ event type, as it's possible for the chip to report the
+-	 * TX_SUCCESS and GCRCSENT events out of order on occasion, so we need
+-	 * to check the message type to ensure correct reporting to TCPM.
++	 * TX completion is signaled directly from the TX_SUCCESS interrupt
++	 * bit, matching the pattern used by every
++	 * other TCPM-attached driver in tree.
++	 * If a stray GoodCRC ends up in the RX FIFO, silently drop it here
++	 * so it doesn't reach TCPM as a bogus received message.
+ 	 */
+ 	if ((!len) && (pd_header_type_le(msg->header) == PD_CTRL_GOOD_CRC))
+-		tcpm_pd_transmit_complete(chip->tcpm_port, TCPC_TX_SUCCESS);
+-	else
+-		tcpm_pd_receive(chip->tcpm_port, msg, TCPC_TX_SOP);
++		return ret;
+ 
++	tcpm_pd_receive(chip->tcpm_port, msg, TCPC_TX_SOP);
++
+ 	return ret;
+ }
+ 
+@@ -1601,6 +1598,7 @@
+ 
+ 	if (interrupta & FUSB_REG_INTERRUPTA_TX_SUCCESS) {
+ 		fusb302_log(chip, "IRQ: PD tx success");
++		tcpm_pd_transmit_complete(chip->tcpm_port, TCPC_TX_SUCCESS);
+ 		ret = fusb302_pd_read_message(chip, &pd_msg);
+ 		if (ret < 0) {
+ 			fusb302_log(chip,

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0107-fusb302-map-collision-to-tx-discarded.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0107-fusb302-map-collision-to-tx-discarded.patch
@@ -1,0 +1,18 @@
+Subject: [PATCH] usb: typec: tcpc: fusb302: map COLLISION to TCPC_TX_DISCARDED
+
+---
+ drivers/usb/typec/tcpm/fusb302.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/usb/typec/tcpm/fusb302.c b/drivers/usb/typec/tcpm/fusb302.c
+--- a/drivers/usb/typec/tcpm/fusb302.c
++++ b/drivers/usb/typec/tcpm/fusb302.c
+@@ -1581,7 +1581,7 @@
+ 
+ 	if (interrupt & FUSB_REG_INTERRUPT_COLLISION) {
+ 		fusb302_log(chip, "IRQ: PD collision");
+-		tcpm_pd_transmit_complete(chip->tcpm_port, TCPC_TX_FAILED);
++		tcpm_pd_transmit_complete(chip->tcpm_port, TCPC_TX_DISCARDED);
+ 	}
+ 
+ 	if (interrupta & FUSB_REG_INTERRUPTA_RETRYFAIL) {

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0108-tcpm-requeue-control-msg-on-eagain.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0108-tcpm-requeue-control-msg-on-eagain.patch
@@ -1,0 +1,29 @@
+Subject: [PATCH] usb: typec: tcpm: re-queue queued control messages on -EAGAIN
+
+---
+ drivers/usb/typec/tcpm/tcpm.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
+--- a/drivers/usb/typec/tcpm/tcpm.c
++++ b/drivers/usb/typec/tcpm/tcpm.c
+@@ -3868,13 +3868,16 @@
+ 
+ 		switch (queued_message) {
+ 		case PD_MSG_CTRL_WAIT:
+-			tcpm_pd_send_control(port, PD_CTRL_WAIT, TCPC_TX_SOP);
++			if (tcpm_pd_send_control(port, PD_CTRL_WAIT, TCPC_TX_SOP) == -EAGAIN)
++				port->queued_message = queued_message;
+ 			break;
+ 		case PD_MSG_CTRL_REJECT:
+-			tcpm_pd_send_control(port, PD_CTRL_REJECT, TCPC_TX_SOP);
++			if (tcpm_pd_send_control(port, PD_CTRL_REJECT, TCPC_TX_SOP) == -EAGAIN)
++				port->queued_message = queued_message;
+ 			break;
+ 		case PD_MSG_CTRL_NOT_SUPP:
+-			tcpm_pd_send_control(port, PD_CTRL_NOT_SUPP, TCPC_TX_SOP);
++			if (tcpm_pd_send_control(port, PD_CTRL_NOT_SUPP, TCPC_TX_SOP) == -EAGAIN)
++				port->queued_message = queued_message;
+ 			break;
+ 		case PD_MSG_DATA_SINK_CAP:
+ 			ret = tcpm_pd_send_sink_caps(port);

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0109-fusb302-trigger-tx-via-tx-start-bit-not-txon-token.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0109-fusb302-trigger-tx-via-tx-start-bit-not-txon-token.patch
@@ -1,0 +1,27 @@
+Subject: [PATCH] usb: typec: tcpc: fusb302: trigger TX via TX_START bit, not TXON token
+
+---
+ drivers/usb/typec/tcpm/fusb302.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/usb/typec/tcpm/fusb302.c b/drivers/usb/typec/tcpm/fusb302.c
+--- a/drivers/usb/typec/tcpm/fusb302.c
++++ b/drivers/usb/typec/tcpm/fusb302.c
+@@ -997,11 +997,15 @@
+ 	buf[pos++] = FUSB302_TKN_EOP;
+ 	/* turn tx off after sending message */
+ 	buf[pos++] = FUSB302_TKN_TXOFF;
+-	/* start transmission */
+-	buf[pos++] = FUSB302_TKN_TXON;
+ 
+ 	ret = fusb302_i2c_block_write(chip, FUSB_REG_FIFOS, pos, buf);
++	if (ret < 0)
++		return ret;
++
++	ret = fusb302_i2c_set_bits(chip, FUSB_REG_CONTROL0,
++				   FUSB_REG_CONTROL0_TX_START);
+ 	if (ret < 0)
+ 		return ret;
++
+ 	fusb302_log(chip, "sending PD message header: %x", msg->header);
+ 	fusb302_log(chip, "sending PD message len: %d", len);

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0110-fusb302-enable-pd-3-0-message-support-on-aw35615.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0110-fusb302-enable-pd-3-0-message-support-on-aw35615.patch
@@ -1,0 +1,37 @@
+Subject: [PATCH] usb: typec: tcpc: fusb302: enable PD 3.0 message handling on AW35615
+
+---
+ drivers/usb/typec/tcpm/fusb302.c     | 5 +++++
+ drivers/usb/typec/tcpm/fusb302_reg.h | 5 +++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/drivers/usb/typec/tcpm/fusb302.c b/drivers/usb/typec/tcpm/fusb302.c
+--- a/drivers/usb/typec/tcpm/fusb302.c
++++ b/drivers/usb/typec/tcpm/fusb302.c
+@@ -404,6 +404,11 @@
+ 	ret = fusb302_enable_tx_auto_retries(chip, FUSB_REG_CONTROL3_N_RETRIES_3);
+ 	if (ret < 0)
+ 		return ret;
++
++	fusb302_i2c_set_bits(chip, FUSB_REG_CONTROL4,
++			     FUSB_REG_CONTROL4_EN_PAR_CFG);
++	fusb302_i2c_set_bits(chip, FUSB_REG_CONTROL5,
++			     FUSB_REG_CONTROL5_EN_PD3_MSG);
+ 	ret = fusb302_init_interrupt(chip);
+ 	if (ret < 0)
+ 		return ret;
+diff --git a/drivers/usb/typec/tcpm/fusb302_reg.h b/drivers/usb/typec/tcpm/fusb302_reg.h
+--- a/drivers/usb/typec/tcpm/fusb302_reg.h
++++ b/drivers/usb/typec/tcpm/fusb302_reg.h
+@@ -69,6 +69,11 @@
+ #define FUSB_REG_CONTROL3_N_RETRIES_2		(0x4)
+ #define FUSB_REG_CONTROL3_N_RETRIES_1		(0x2)
+ #define FUSB_REG_CONTROL3_AUTO_RETRY		BIT(0)
++#define FUSB_REG_CONTROL4			0x10
++#define FUSB_REG_CONTROL4_EN_PAR_CFG		BIT(1)
++#define FUSB_REG_CONTROL4_TOG_EXIT_AUD		BIT(0)
++#define FUSB_REG_CONTROL5			0x11
++#define FUSB_REG_CONTROL5_EN_PD3_MSG		BIT(0)
+ #define FUSB_REG_MASK				0x0A
+ #define FUSB_REG_MASK_VBUSOK			BIT(7)
+ #define FUSB_REG_MASK_ACTIVITY			BIT(6)


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
1. Fixes USB PD 3.0, sets guards based on devices for current for misbehaving devices.
2. Uses ICHG table for variant, chip is register compatible however ICHG tables are slightly different
## Testing

* **How was this tested?** Tested on Mangmi Air X connected to MBP, prior to this port will power cycle PD 3.0. PPS was also tested, does not give apperciable gains to efficiency or charge speed. May have marginal benefit to battery temp. 

## Additional Context

* **Add any other information that might be helpful for the reviewer** Would like to have this tested on wide varity of devices in host mode/sink mode. 

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
