### PR TITLE
lib32: add 32-bit Vulkan ICD manifests

### DIFF
--- a/projects/ROCKNIX/packages/compat/lib32/package.mk
+++ b/projects/ROCKNIX/packages/compat/lib32/package.mk
@@ -29,6 +29,15 @@ makeinstall_target() {
   mkdir -p "${INSTALL}/etc/ld.so.conf.d"
   echo "/usr/lib32" > "${INSTALL}/etc/ld.so.conf.d/${LIBARCH}-lib32.conf"
 
+  if [ -d "${LIBROOT}/usr/share/vulkan/icd.d" ]; then
+    mkdir -p ${INSTALL}/usr/share/vulkan/icd.d
+    for json in ${LIBROOT}/usr/share/vulkan/icd.d/*.json; do
+      [ -f "${json}" ] || continue
+      sed -e 's#"/usr/lib/#"/usr/lib32/#g' -e 's#"library_arch": *"64"#"library_arch": "32"#' \
+        "${json}" > "${INSTALL}/usr/share/vulkan/icd.d/$(basename "${json}" .json).lib32.json"
+    done
+  fi
+
   mkdir -p ${INSTALL}/usr/bin
   cp ${LIBROOT}/usr/bin/ldd ${INSTALL}/usr/bin/ldd32
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
* Generate *.lib32.json box86's 32-bit Vulkan loader finds the turnip driver.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
