### PR TITLE
sm8250 XBL/ABL workaround: opt-in reformat boot partition each update

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/bootloader/update.sh
+++ b/projects/ROCKNIX/devices/SM8250/bootloader/update.sh
@@ -16,6 +16,106 @@ fi
 # mount $BOOT_ROOT rw
 mount -o remount,rw $BOOT_ROOT
 
+# User must touch this file to opt-in to ROCKNIX ABL with direct boot
+UPDATE_ABL="/storage/update.abl"
+
+# Figure out UPDATE_DIR
+[ -z "$UPDATE_DIR" ] && UPDATE_DIR="/storage/.update"
+if ls -d ${UPDATE_DIR}/.tmp/avfs/*/target 1>/dev/null 2>/dev/null; then
+  UPDATE_DIR=$(ls -d -1 "${UPDATE_DIR}"/.tmp/avfs/*/target 2>/dev/null | head -n 1)
+elif ls -d ${UPDATE_DIR}/.tmp/*/target 1>/dev/null 2>/dev/null; then
+  UPDATE_DIR=$(ls -d -1 "${UPDATE_DIR}"/.tmp/*/target 2>/dev/null | head -n 1)
+elif ls -d ${UPDATE_DIR}/.tmp/mnt 1>/dev/null 2>/dev/null; then
+  UPDATE_DIR=$(ls -d -1 "${UPDATE_DIR}"/.tmp/mnt 2>/dev/null | head -n 1)
+fi
+
+# Opt-in Workaround for sm8250 XBL/ABL bug: reformat BOOT partition each update
+if [ -f $UPDATE_ABL -a -f $UPDATE_DIR/KERNEL ]; then
+
+  # Backup ABLs if not already present
+  if [ ! -f "/storage/backup/abl_a.img" ]; then
+    echo "Backing up ABL A to /storage/backup ..."
+    ABL_A="$($SYSTEM_ROOT/usr/sbin/blkid -t PARTLABEL=abl_a -o device)"
+    mkdir -p /storage/backup
+    dd if="${ABL_A}" of="/storage/backup/abl_a.img" bs=1M
+  fi
+  if [ ! -f "/storage/backup/abl_b.img" ]; then
+    echo "Backing up ABL B to /storage/backup ..."
+    ABL_B="$($SYSTEM_ROOT/usr/sbin/blkid -t PARTLABEL=abl_b -o device)"
+    mkdir -p /storage/backup
+    dd if="${ABL_B}" of="/storage/backup/abl_b.img" bs=1M
+  fi
+
+  # Update ABL
+  . $SYSTEM_ROOT/usr/bin/updateabl
+
+  # Go ahead and free up SYSTEM to avoid copying it to RAM
+  umount /sysroot
+  rm -f $BOOT_ROOT/SYSTEM $BOOT_ROOT/SYSTEM.md5
+
+  echo "Copying Boot Files to RAM..."
+  cp -a $BOOT_ROOT /run/flash
+  umount $BOOT_ROOT
+  echo "Updating Boot Files in RAM..."
+  cp -a $UPDATE_DIR/. /run/flash/
+
+  # Convert KERNEL to bootimg
+  . $SYSTEM_ROOT/etc/os-release
+  DISTRO_BOOTLABEL="ROCKNIX"
+  DISTRO_DISKLABEL="STORAGE"
+  # Get extra cmdline values from grub.cfg
+  EXTRA_CMDLINE=$(sed -n '/^\s*linux\s/ { s/^\s*linux\s\+\S\+\s\+//; s/\<\(\(boot\|disk\)=\S*\|grub_portable\)\>\s*//g; p; q; }' "$SYSTEM_ROOT/usr/share/bootloader/boot/grub/grub.cfg")
+  # Generate a patch level from the OS_VERSION
+  PATCH_LEVEL="2026-05"
+  if echo "$OS_VERSION" | grep -qE '^[0-9]{6}'; then
+    PATCH_LEVEL="${OS_VERSION:0:4}-${OS_VERSION:4:2}"
+  fi
+
+  echo "Building bootimg KERNEL..."
+  mkdir -p /run/mkbootimg
+  gzip -c /run/flash/KERNEL > /run/mkbootimg/kernel.gz
+  for dtb in $SYSTEM_ROOT/usr/share/bootloader/boot/grub/*.dtb; do
+    if [ -f ${dtb} ]; then
+      cat "$dtb" >> /run/mkbootimg/kernel.gz
+    fi
+  done
+
+  echo -n "dummy" > /run/mkbootimg/ramdisk
+  # Run python mkbootimg from inside the update path
+  $SYSTEM_ROOT/lib/ld.so --library-path $SYSTEM_ROOT/usr/lib $SYSTEM_ROOT/usr/bin/python3 $SYSTEM_ROOT/usr/bin/mkbootimg/mkbootimg.py \
+    --kernel /run/mkbootimg/kernel.gz --ramdisk /run/mkbootimg/ramdisk \
+    --kernel_offset 0x00000000 --ramdisk_offset 0x00000000 --tags_offset 0x00000000 \
+    --os_version 12.0.0 --os_patch_level "${PATCH_LEVEL}" --header_version 0 \
+    --cmdline "boot=LABEL=${DISTRO_BOOTLABEL} disk=LABEL=${DISTRO_DISKLABEL} ${EXTRA_CMDLINE}" \
+    -o /run/flash/KERNEL
+
+  # md5 no longer accurate/needed
+  rm -f /run/flash/KERNEL.md5
+
+  echo "Reformatting Boot Partition..."
+  UUID_SYSTEM=$(blkid $BOOT_PART -s UUID -o value)
+  $SYSTEM_ROOT/usr/sbin/mkfs.vfat -F 32 -S 512 -s 32 -i "${UUID_SYSTEM//-/}" -n "${DISTRO_BOOTLABEL}" $BOOT_PART >/dev/null
+  mount $BOOT_PART $BOOT_ROOT
+
+  echo "Restoring KERNEL from RAM..."
+  # Explicitly restore KERNEL first
+  cp -a /run/flash/KERNEL $BOOT_ROOT/KERNEL
+  rm -f /run/flash/KERNEL
+  # Remove grub/dtbs from RAM as they aren't needed
+  rm -rf /run/flash/EFI/
+  rm -rf /run/flash/boot/
+  # Copy the rest (use spinner as this will take a while)
+  . /functions 2>/dev/null
+  StartProgress spinner "Updating SYSTEM and restoring Boot Files from RAM... "
+    cp -a /run/flash/. $BOOT_ROOT
+    sync
+  StopProgress "done"
+
+  # Update was finished above, this skips further updates
+  umount $BOOT_ROOT
+
+else # Stick with stock/grub boot, update all necessary files as usual
+
 if [ -d "$SYSTEM_ROOT/usr/share/bootloader/rocknix_abl" ]; then
   mkdir -p $BOOT_ROOT/rocknix_abl
   echo "Updating ROCKNIX ABL on SD..."
@@ -59,5 +159,7 @@ fi
 # mount $BOOT_ROOT ro
 sync
 mount -o remount,ro $BOOT_ROOT
+
+fi
 
 echo "UPDATE" > /storage/.boot.hint

--- a/projects/ROCKNIX/devices/SM8250/options
+++ b/projects/ROCKNIX/devices/SM8250/options
@@ -63,7 +63,7 @@
     FIRMWARE="extra-firmware"
 
   # Additional packages to install
-    ADDITIONAL_PACKAGES="gamepadcalibration inputplumber rocknix-abl"
+    ADDITIONAL_PACKAGES="gamepadcalibration inputplumber rocknix-abl mkbootimg"
 
   # Debug tty path
     DEBUG_TTY="/dev/ttyMSM0"

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/updateabl
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/updateabl
@@ -60,15 +60,14 @@ echo "Checksum update: ${SUM_UPDATE:0:7}"
 
 # ---- Compare ----
 if [ "${SUM_A}" = "${SUM_UPDATE}" ] && [ "${SUM_B}" = "${SUM_UPDATE}" ]; then
-    echo "ABL_A and ABL_B match update version — skipping flash."
-    exit 0
+  echo "ABL_A and ABL_B match update version — skipping flash."
+else # Flash
+  echo "Checksums differ — flashing ABL partitions..."
+
+  # ---- Flash ----
+  dd if="${ELF}" of="${ABL_A}" bs="${SS}" conv=fsync,notrunc status=none
+  dd if="${ELF}" of="${ABL_B}" bs="${SS}" conv=fsync,notrunc status=none
 fi
-
-echo "Checksums differ — flashing ABL partitions..."
-
-# ---- Flash ----
-dd if="${ELF}" of="${ABL_A}" bs="${SS}" conv=fsync,notrunc status=none
-dd if="${ELF}" of="${ABL_B}" bs="${SS}" conv=fsync,notrunc status=none
 
 sync
 

--- a/projects/ROCKNIX/packages/sysutils/busybox/scripts/init
+++ b/projects/ROCKNIX/packages/sysutils/busybox/scripts/init
@@ -1119,6 +1119,7 @@ check_update() {
 
   # all ok, update
   display_versions
+  update_bootloader
   if [ -b "/${IMAGE_KERNEL}" ]; then
     update_partition "Kernel" "${UPDATE_KERNEL}" "/${IMAGE_KERNEL}"
   else
@@ -1126,7 +1127,6 @@ check_update() {
   fi
   umount /sysroot &>/dev/null
   update_file "System" "${UPDATE_SYSTEM}" "/flash/${IMAGE_SYSTEM}"
-  update_bootloader
   echo "UPDATE" >/storage/.boot.hint
   sync
   StartProgress countdown "Update complete. Reboot in 5s... " 5 "NOW"

--- a/projects/ROCKNIX/packages/tools/mkbootimg/package.mk
+++ b/projects/ROCKNIX/packages/tools/mkbootimg/package.mk
@@ -9,9 +9,14 @@ PKG_URL="${PKG_SITE}.git"
 PKG_LONGDESC="mkbootimg: Creates kernel boot images for Android"
 PKG_TOOLCHAIN="manual"
 PKG_DEPENDS_HOST="toolchain Python3:host"
+PKG_DEPENDS_TARGET="toolchain Python3:target"
 
 makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/mkbootimg
   cp -r gki/ mkbootimg.py $TOOLCHAIN/mkbootimg/
 }
 
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin/mkbootimg
+  cp -r gki/ mkbootimg.py ${INSTALL}/usr/bin/mkbootimg
+}


### PR DESCRIPTION
## Summary

Enable sm8250 users to opt-in to using the ROCKNIX ABL with direct bootimg KERNEL boot  using a workaround which reformats the boot partition every update - ensuring the KERNEL is the first file written every time seems to prevent the XBL/ABL bug from being an issue.

## Testing

Tested using EMULATION_DEVICE=no builds on sm8250 (rpflip2). Both tar and img.gz updates were tested multiple times, but the case where AVFS fails during the update process was not tested as this never happened for me - but I think even that case should work if it ever happens.

## Additional Context

I've made all efforts to make this change low-impact with minimal changes other than if the user opts in to this workaround.

The only changes that I believe could affect other platforms are:

Moving update_bootloader to happen first during the update process, but I do not believe this order should matter.

Fixed a minor logic bug in updateabl script: the explicit "exit 0" when skipping ABL update due to checksums matching can cause the script that sourced this script to exit without fully completing. I do not think this minor bug was causing any issues in the other scripts I checked, but this should be an improvement.

For sm8250 it adds mkbootimg as a target package now so that it can build the bootimg kernel as part of the update process. Initially I wanted this to be another opt-in step, but I've found grub booting with the ROCKNIX ABL to be  the most fragile (just involves too many file reads that could hit the bug - direct boot with the single KERNEL file to read is much more reliable).

To opt-in to this workaround, the user must touch "/storage/update.abl" - if there is a better place to put this, this can be changed, but I wanted it to be very visible and explicit for the user to opt-in. I initially put it in the .update folder, but it will get wiped there - it does need to stay so that each update the abl can be updated if needed and a new bootimg kernel can be generated from the kernel update.

Unfortunately if the user wishes to opt back out, removing the update.abl file from storage will attempt that, but may or may not break the boot process and it will not revert the ABL - though I did have the update script backup the original ABL to /storage/backup. I do not recommend this, but the user should always be able to recover or revert with factory images/backups.

At the risk of jixing it, using this workaround has not failed me as long as I opt-in and stick to ROCKNIX ABL+direct boot which is what it does (I had some previous versions with multiple levels of opt-in and trying to make it easier to go back and forth, but that proved overly complex and problematic). It seems solid across multiple updates in my testing, but I recommend some brave users try this with multiple nightlies before recommending it more broadly. I have not tried this with internal install, but it should theoretically work.

If this works out, I think this pattern (without reformatting since that part is a workaround for sm8250, but the opt-in to ROCKNIX ABL + bootimg kernels) may be worth considering for the other Qualcomm platforms with stock ABLs capable of booting Linux as this lowers the barrier to entry by making the ROCKNIX ABL optional (though still preferable for the RAM freed by direct boot), allowing the user to test ROCKNIX and decide if it is something they want to continue to use - if they do decide to stick to Android, they don't need to figure out how to revert the ABL. I'm not sure if having to install the ROCKNIX ABL has actually turned away users, but just touching a file to opt-in may be easier than using Android or fastboot.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

PARTIALLY - I used AI just by Googling and using the AI response, but I used it just like we used to Google how to do things and then had to read through other sites to figure it out - I manually copied and pasted the code snippets from the AI, but modified them, tested them, worked through them just like those or us who coded before AI always (hopefully) did when using code from various sites on the internet.
