### PR TITLE
sm6115: add gamepadtester and qterminal

### DIFF
--- a/projects/ROCKNIX/packages/misc/modules/package.mk
+++ b/projects/ROCKNIX/packages/misc/modules/package.mk
@@ -11,7 +11,7 @@ PKG_LONGDESC="OS Modules Package"
 PKG_TOOLCHAIN="manual"
 
 case ${DEVICE} in
-  RK3399|RK3588|SM8250|SM8550|SM8650|SM8750)
+  RK3399|RK3588|SM8250|SM8550|SM8650|SM8750|SM6115)
     PKG_DEPENDS_TARGET+=" gamepadtester qterminal"
     ;;
 esac
@@ -30,4 +30,3 @@ post_makeinstall_target() {
     rm -f ${INSTALL}/usr/config/modules/Install*
   fi
 }
-


### PR DESCRIPTION
### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
