### PR TITLE
Add CJK font support

### DIFF
--- a/projects/ROCKNIX/packages/fonts/noto-sans-cjk/package.mk
+++ b/projects/ROCKNIX/packages/fonts/noto-sans-cjk/package.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="noto-sans-cjk"
+PKG_VERSION="2.004"
+PKG_LICENSE="OFL-1.1"
+PKG_SITE="https://github.com/notofonts/noto-cjk"
+PKG_URL="https://raw.githubusercontent.com/notofonts/noto-cjk/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"
+PKG_SOURCE_NAME="NotoSansCJKsc-Regular-${PKG_VERSION}.otf"
+PKG_SHA256="2c76254f6fc379fddfce0a7e84fb5385bb135d3e399294f6eeb6680d0365b74b"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Noto Sans CJK Simplified Chinese font"
+PKG_TOOLCHAIN="manual"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  cp -f ${SOURCES}/${PKG_NAME}/${PKG_SOURCE_NAME} ${PKG_BUILD}/NotoSansCJKsc-Regular.otf
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/share/fonts/truetype/noto-cjk
+  cp -f ${PKG_BUILD}/NotoSansCJKsc-Regular.otf \
+    ${INSTALL}/usr/share/fonts/truetype/noto-cjk/
+}

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -7,7 +7,7 @@ PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"
 PKG_URL="${PKG_SITE}.git"
-PKG_DEPENDS_TARGET="boost toolchain SDL2 freetype curl freeimage bash rapidjson SDL2_mixer fping p7zip alsa vlc drm_tool pugixml"
+PKG_DEPENDS_TARGET="boost toolchain SDL2 freetype curl freeimage bash rapidjson SDL2_mixer fping p7zip alsa vlc drm_tool pugixml noto-sans-cjk"
 PKG_NEED_UNPACK="busybox"
 PKG_LONGDESC="Emulationstation emulator frontend"
 PKG_BUILD_FLAGS="-gold"
@@ -61,6 +61,8 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/config/emulationstation/resources
   cp -rf ${PKG_BUILD}/resources/* ${INSTALL}/usr/config/emulationstation/resources/
   rm -rf ${INSTALL}/usr/config/emulationstation/resources/logo.png
+  cp -f $(get_install_dir noto-sans-cjk)/usr/share/fonts/truetype/noto-cjk/NotoSansCJKsc-Regular.otf \
+    ${INSTALL}/usr/config/emulationstation/resources/DroidSansFallbackFull.ttf
 
   mkdir -p ${INSTALL}/usr/bin
   cp ${PKG_BUILD}/es_settings ${INSTALL}/usr/bin

--- a/projects/ROCKNIX/packages/virtual/image/package.mk
+++ b/projects/ROCKNIX/packages/virtual/image/package.mk
@@ -21,7 +21,7 @@ PKG_UI_TOOLS="fbgrab grim"
 
 PKG_GRAPHICS="imagemagick"
 
-PKG_FONTS="corefonts"
+PKG_FONTS="corefonts noto-sans-cjk"
 
 PKG_MULTIMEDIA="ffmpeg vlc mpv gmu m8c"
 


### PR DESCRIPTION
## Summary

Add Simplified Chinese font support to ROCKNIX by packaging Noto Sans CJK and wiring it into EmulationStation's existing fallback font mechanism.

## Changes

- Add a new `noto-sans-cjk` font package using `NotoSansCJKsc-Regular.otf`
- Include `noto-sans-cjk` in ROCKNIX image fonts
- Install the CJK font as `DroidSansFallbackFull.ttf` for EmulationStation fallback rendering

## Validation

- Ran `bash -n` on modified package scripts
- Verified Noto Sans CJK source SHA256: `2c76254f6fc379fddfce0a7e84fb5385bb135d3e399294f6eeb6680d0365b74b`
