### PR TITLE
heroic: Add adwaita icons and librsvg for file browser support

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/scripts/start_cemu.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/cemu-sa/scripts/start_cemu.sh
@@ -15,11 +15,6 @@ then
   PASINK=$(pactl info | grep 'Default Sink:' | cut -d ' ' -f 3)
 fi
 
-# Set up mime db
-mkdir -p /storage/.local/share/mime/packages
-cp -rf /usr/share/mime/packages/* /storage/.local/share/mime/packages
-update-mime-database /storage/.local/share/mime
-
 # Set common paths
 CEMU_CONFIG_ROOT="/storage/.config/Cemu"
 CEMU_CACHE_LOG="${CEMU_CONFIG_ROOT}/share/log.txt"

--- a/projects/ROCKNIX/packages/emulators/standalone/heroic/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/heroic/package.mk
@@ -5,6 +5,7 @@ PKG_NAME="heroic"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://heroicgameslauncher.com"
 PKG_LONGDESC="Heroic Games Launcher runtime scripts for ROCKNIX"
+PKG_DEPENDS_TARGET="librsvg adwaita-icon-theme"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {

--- a/projects/ROCKNIX/packages/graphics/adwaita-icon-theme/package.mk
+++ b/projects/ROCKNIX/packages/graphics/adwaita-icon-theme/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2017 Escalade
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="adwaita-icon-theme"
+PKG_VERSION="551245ae75fdc42cde42a8cf24ca2ccab9d3a815"
+PKG_LICENSE="LGPL"
+PKG_SITE="https://gitlab.gnome.org/GNOME/adwaita-icon-theme"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="GNOME standard icons"
+
+makeinstall_target() {
+	meson install --destdir DESTDIR
+	rm -r DESTDIR/usr/share/icons/Adwaita/cursors
+	mkdir -p ${INSTALL}/usr/share/icons
+	cp -LRf {DESTDIR,${INSTALL}}/usr/share/icons/Adwaita
+}

--- a/projects/ROCKNIX/packages/graphics/adwaita-icon-theme/patches/meson-no-gtk-update-icon-cache.patch
+++ b/projects/ROCKNIX/packages/graphics/adwaita-icon-theme/patches/meson-no-gtk-update-icon-cache.patch
@@ -1,0 +1,20 @@
+diff --git a/meson.build b/meson.build
+index d3b3c1352..9bd8184f4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -106,15 +106,3 @@ else
+     endforeach
+   endforeach
+ endif
+-
+-gtk_update_icon_cache = find_program(
+-  'gtk4-update-icon-cache',
+-  'gtk-update-icon-cache',
+-  required : true,
+-)
+-meson.add_install_script(
+-  gtk_update_icon_cache,
+-  '-qtf',
+-  get_option('prefix') / adwaita_dir,
+-  skip_if_destdir: true,
+-)

--- a/projects/ROCKNIX/packages/graphics/gdk-pixbuf/package.mk
+++ b/projects/ROCKNIX/packages/graphics/gdk-pixbuf/package.mk
@@ -26,11 +26,8 @@ pre_configure_target() {
                          -Dman=false \
                          -Drelocatable=false \
                          -Dinstalled_tests=false \
-                         -Dtests=false"
-
-  if [ "${DISPLAYSERVER}" != "x11" ]; then
-    PKG_MESON_OPTS_TARGET+=" -Dbuiltin_loaders=all"
-  fi
+                         -Dtests=false \
+                         -Dbuiltin_loaders=all"
 
   export TARGET_LDFLAGS="-L${SYSROOT_PREFIX}/usr/lib -lz"
 }

--- a/projects/ROCKNIX/packages/graphics/librsvg/package.mk
+++ b/projects/ROCKNIX/packages/graphics/librsvg/package.mk
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2017 Escalade
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="librsvg"
+PKG_VERSION="aa54b088216d7cc42ad9b0978df45fd72db6786d"
+PKG_LICENSE="LGPL"
+PKG_SITE="https://gitlab.gnome.org/GNOME/librsvg"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain cargo:host cargo-c:host rust:host gdk-pixbuf cairo freetype harfbuzz pango libxml2 glib"
+PKG_LONGDESC="SVG rendering library"
+
+PKG_MESON_OPTS_TARGET="-Davif=disabled \
+                       -Dtests=false \
+                       -Dintrospection=disabled \
+                       -Dpixbuf=enabled \
+                       -Drsvg-convert=disabled \
+                       -Dpixbuf-loader=enabled \
+                       -Ddocs=disabled \
+                       -Dvala=disabled \
+                       -Dtriplet=${TARGET_NAME}"
+
+export RUST_TARGET_PATH=${TOOLCHAIN}/lib/rustlib
+
+pre_configure_target() {
+  pushd ${PKG_BUILD}
+
+  mkdir .cargo
+  cat >.cargo/config.toml <<END
+[target.${TARGET_NAME}]
+linker = "${TARGET_PREFIX}gcc"
+END
+  cargo fetch --locked --target host-tuple
+
+  popd
+}
+
+post_makeinstall_target() {
+  mv ${INSTALL}/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader{_,-}svg.so
+}

--- a/projects/ROCKNIX/packages/rocknix/sources/post-update
+++ b/projects/ROCKNIX/packages/rocknix/sources/post-update
@@ -252,3 +252,8 @@ grep -q "^system\.suspend\.enable=" /storage/.config/system/configs/system.cfg |
 # Set the flag to enable timed shutdown after suspend if it doesn't already exist
 grep -q "^system\.suspend\.enable_timed_shutdown=" /storage/.config/system/configs/system.cfg ||
     sed -i '$ a\system.suspend.enable_timed_shutdown=1' /storage/.config/system/configs/system.cfg
+
+# Set up mime db
+mkdir -p /storage/.local/share/mime/packages
+cp -rf /usr/share/mime/packages/* /storage/.local/share/mime/packages
+update-mime-database /storage/.local/share/mime

--- a/projects/ROCKNIX/packages/rust/cargo-c-lock/package.mk
+++ b/projects/ROCKNIX/packages/rust/cargo-c-lock/package.mk
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="cargo-c-lock"
+PKG_VERSION="$(get_pkg_version cargo-c)"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/lu-zero/cargo-c"
+PKG_LONGDESC="cargo-c lock"
+PKG_TOOLCHAIN="manual"
+PKG_URL="${PKG_SITE}/releases/download/v${PKG_VERSION}/Cargo.lock"
+PKG_SOURCE_NAME="${PKG_NAME}-${PKG_VERSION}.Cargo.lock"
+
+unpack() {
+  :
+}

--- a/projects/ROCKNIX/packages/rust/cargo-c/package.mk
+++ b/projects/ROCKNIX/packages/rust/cargo-c/package.mk
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="cargo-c"
+PKG_VERSION="0.10.22"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/lu-zero/cargo-c"
+PKG_URL="${PKG_SITE}/archive/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cargo:host rust:host"
+PKG_DEPENDS_UNPACK="cargo-c-lock"
+PKG_LONGDESC="A cargo subcommand to build and install C-ABI compatible dynamic and static libraries"
+PKG_TOOLCHAIN="manual"
+
+pre_configure_host() {
+  cp ${SOURCES}/cargo-c-lock/cargo-c-lock-${PKG_VERSION}.Cargo.lock Cargo.lock
+}
+
+configure_host() {
+  cargo fetch --locked --target ${RUST_HOST}
+}
+
+make_host() {
+  cargo build --features=vendored-openssl --release --frozen
+}
+
+makeinstall_host() {
+  find ".${RUST_HOST}/target/release" -maxdepth 1 -type f -executable -exec install -D -m755 -t "${TOOLCHAIN}/bin" {} +
+}


### PR DESCRIPTION
## Summary

Add librsvg and adwaita icons to make Heroic file browser work.

## Testing

Fresh clean build on Ayn Thor

## Additional Context

librsvg adds about 6MB before compression, icons adds about 2MB. Should be very small footprint after zstd compression.
Not sure if my `cargo-c` build script is idiomatic but it works.

Set up mime db is moved to `post-update` from `start_cemu.sh`, since existing install won't work without mime update.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
