### PR TITLE
sdl_controllers.txt handling in start_pico8.sh

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/pico-8/sources/start_pico8.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/pico-8/sources/start_pico8.sh
@@ -40,7 +40,9 @@ else
 fi
 
 # store sdl_controllers in root directory so its shared across devices - will look to revisit this with controller refactor work
-cp --update=none /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${GAME_DIR}/sdl_controllers.txt
+if [ ! -f "${GAME_DIR}/sdl_controllers.txt" ]; then
+  cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt "${GAME_DIR}/sdl_controllers.txt"
+fi
 
 # mark the binary executable to cover cases where the user adding the binaries doesn't know or forgets.
 chmod 0755 ${LAUNCH_DIR}/${STATIC_BIN}

--- a/projects/ROCKNIX/packages/emulators/standalone/pico-8/sources/start_pico8.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/pico-8/sources/start_pico8.sh
@@ -40,7 +40,7 @@ else
 fi
 
 # store sdl_controllers in root directory so its shared across devices - will look to revisit this with controller refactor work
-cp -f /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${GAME_DIR}/sdl_controllers.txt
+cp --update=none /usr/config/SDL-GameControllerDB/gamecontrollerdb.txt ${GAME_DIR}/sdl_controllers.txt
 
 # mark the binary executable to cover cases where the user adding the binaries doesn't know or forgets.
 chmod 0755 ${LAUNCH_DIR}/${STATIC_BIN}


### PR DESCRIPTION
## Summary

This change would enable users to modify the sdl_controllers.txt file in GAME_DIR for custom keymapping
if they wish to without needing to mess with the global configuration.

Instead of forcibly rewriting the file, it would only copy it if it does not exist so modifications would be possible,
and resetting to default would be a simple matter of manually removing the file.

## Testing

I implemented the same modification on local installations of other handheld OSs where this file was not write protected.

## Additional Context

Should not affect existing behaviour, only enable manual modifications.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
