### PR TITLE
rocknix-fake-suspend: unfreeze before shutdown

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -285,6 +285,9 @@ do_shutdown() {
   # Unmute audio - otherwise wireplumber will keep it muted on next boot
   unmute_audio
 
+  # Unfreeze prococesses - otherwise ES will be unable to respond to API calls
+  unfreeze_processes
+
   # Check whether a game is running
   check_es_running_game
   local RUNNING_GAME=$?


### PR DESCRIPTION
## Summary

rocknix-fake-suspend: unfreeze processes before shutdown

## Testing

Tested on my OGU

## Additional Context

Timed shutdown was broken when ES processes were frozen as they were unable to respond to web API calls

---

### AI Usage

**Did you use AI tools to help write this code?** NO
