### PR TITLE
h700: fix rg34xx-sp-v2 rocknix-dt-id

### DIFF
--- a/projects/ROCKNIX/devices/H700/linux/dts/allwinner/sun50i-h700-anbernic-rg34xx-sp-v2-panel.dts
+++ b/projects/ROCKNIX/devices/H700/linux/dts/allwinner/sun50i-h700-anbernic-rg34xx-sp-v2-panel.dts
@@ -9,7 +9,7 @@
 / {
 	model = "Anbernic RG34XX-SP";
 	compatible = "anbernic,rg34xx-sp", "allwinner,sun50i-h700";
-	rocknix-dt-id = "sun50i-h700-anbernic-rg34xx-sp";
+	rocknix-dt-id = "sun50i-h700-anbernic-rg34xx-sp-v2-panel";
 };
 
 &panel {


### PR DESCRIPTION
### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
