### PR TITLE
wifi: honor wifi config on boot

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/autostart/080-network
+++ b/projects/ROCKNIX/packages/rocknix/autostart/080-network
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+tocon "Configuring network..."
+
+if [ "$(get_setting wifi.enabled)" == "0" ] || [ "$1" == "disable" ]
+then
+  nohup wifictl disable &
+elif [ "$(get_setting wifi.enabled)" == "1" ] || [ "$1" == "enable" ]
+then
+  nohup wifictl enable &
+fi


### PR DESCRIPTION
### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
