### PR TITLE
S922X: batteryplus

### DIFF
--- a/projects/ROCKNIX/devices/S922X/options
+++ b/projects/ROCKNIX/devices/S922X/options
@@ -67,7 +67,7 @@
     FIRMWARE=""
 
   # Additional packages to install
-    ADDITIONAL_PACKAGES="libmali"
+    ADDITIONAL_PACKAGES="libmali batteryplus"
 
   # Debug tty path
     DEBUG_TTY="/dev/ttyAML0"

--- a/projects/ROCKNIX/packages/tools/batteryplus/Makefile
+++ b/projects/ROCKNIX/packages/tools/batteryplus/Makefile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+CXX ?= gcc
+
+BINARY = batteryplus
+SOURCES = "BatteryPlus/batteryplus.cpp"
+
+all:
+	$(CXX) $(CFLAGS) $(SOURCES) -o $(BINARY)
+
+clean:
+	rm -f $(BINARY)

--- a/projects/ROCKNIX/packages/tools/batteryplus/config/batteryplus.conf
+++ b/projects/ROCKNIX/packages/tools/batteryplus/config/batteryplus.conf
@@ -1,0 +1,2 @@
+data_dir=/storage/.config/batteryplus
+mode=voltage

--- a/projects/ROCKNIX/packages/tools/batteryplus/package.mk
+++ b/projects/ROCKNIX/packages/tools/batteryplus/package.mk
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="batteryplus"
+PKG_VERSION="0c9d9566c96e8d2c823b44231c16a2290c2a00d4"
+PKG_GIT_CLONE_BRANCH="main"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/Mikhailzrick/knubat.components"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain systemd"
+PKG_LONGDESC="BatteryPlus — battery percentage daemon for handheld Linux systems"
+GET_HANDLER_SUPPORT="git"
+PKG_TOOLCHAIN="make"
+
+pre_make_target() {
+	cp ${PKG_DIR}/Makefile ${PKG_BUILD}
+}
+
+makeinstall_target() {
+	mkdir -p ${INSTALL}/usr/bin
+	cp ${PKG_BUILD}/batteryplus ${INSTALL}/usr/bin
+
+	mkdir -p ${INSTALL}/etc/batteryplus
+	cp -f ${PKG_DIR}/config/batteryplus.conf ${INSTALL}/etc/batteryplus
+
+	# Empty hook dirs
+	mkdir -p ${INSTALL}/etc/batteryplus/charging.d
+	touch ${INSTALL}/etc/batteryplus/charging.d/.keep
+	mkdir -p ${INSTALL}/etc/batteryplus/discharging.d
+	touch ${INSTALL}/etc/batteryplus/discharging.d/.keep
+	mkdir -p ${INSTALL}/etc/batteryplus/state.d
+	touch ${INSTALL}/etc/batteryplus/state.d/.keep
+}
+
+post_install() {
+  enable_service batteryplus.service
+}

--- a/projects/ROCKNIX/packages/tools/batteryplus/system.d/batteryplus.service
+++ b/projects/ROCKNIX/packages/tools/batteryplus/system.d/batteryplus.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=BatteryPlus service
+
+[Service]
+ExecStart=/usr/bin/batteryplus
+
+[Install]
+WantedBy=multi-user.target

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="26ded87813e47f24a116923bdd1fc783ec796f04"
+PKG_VERSION="c415efc8801a219169d33ea46376a7cf2369f3ba"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"
@@ -30,6 +30,8 @@ PKG_CMAKE_OPTS_TARGET+=" -DROCKNIX=1 \
                          -DCEC=0 \
                          -DENABLE_PULSE=1 \
                          -DUSE_SYSTEM_PUGIXML=1"
+
+[ "${DEVICE}" = "S922X" ] && PKG_CMAKE_OPTS_TARGET+=" -DBATTERYPLUS=1"
 
 pre_configure_target() {
   for key in SCREENSCRAPER_DEV_LOGIN \


### PR DESCRIPTION
## Summary

S922X: add batteryplus package for better battery capacity reporting

## Testing

Tested on my OGU

## Additional Context

Source code here: https://github.com/Mikhailzrick/knubat.components/blob/main/BatteryPlus/batteryplus.cpp

Dependent on EmulationStation PR: https://github.com/ROCKNIX/emulationstation-next/pull/20

---

### AI Usage

**Did you use AI tools to help write this code?** NO
