### PR TITLE
sm8250 ch13726a: add mipi_dsi_msleep(120) after exit_sleep_mode

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0058_DDIC-CH13726A-panel.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0058_DDIC-CH13726A-panel.patch
@@ -105,6 +105,7 @@ index 000000000000..946ad32f9b82
 +	mipi_dsi_generic_write_seq_multi(&dsi_ctx, 0xb9, 0x00);
 +	
 +	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++	mipi_dsi_msleep(&dsi_ctx, 120);
 +
 +	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
 +


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Add 120ms delay after exit_sleep_mode per MIPI DCS specification, matching the icna35xx panel driver.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)

Full build for SM8250 Retroid Pocket 5.

* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Nothing visible changed, everything working just as before. 

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

I'll just cp what I wrote on a Retroid Pocket 5 screen glitching issue at Discord server:

I tested panel driver delays (mipi_dsi_msleep(120) in ch13726a), Gamescope flags (--adaptive-sync, --disable-vsync), disabling Gamescope entirely, FEX thunk configuration (DRM/Vulkan passthrough), XRandR disable, and Steam backlight/fade disable. Kernel DRM debug logs showed only DRM_IOCTL_SYNCOBJ_QUERY during wake — no panel or blank errors. Steam logs revealed [display] Fade from queried backlight on resume. None of the fixes eliminated the glitches.

Conclusion: This is a FEX bug with freedreno on Qualcomm SM8250. FEX emulates x86 DRM ioctls, and during wake (blank/unblank/gamma operations) a race condition occurs between FEX and Gamescope/Steam over DRM buffers. The panel driver and kernel work correctly. A systemd service was created to automate double-wake as a temporary workaround, but it doesn't fix the problem every time somehow.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

Partially