### PR TITLE
steam: add native ARM64 mode via start_steam_native.sh

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam_arm64.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam_arm64.sh
@@ -9,6 +9,16 @@ STEAM_FLAVOR=arm64
 source /etc/profile
 set_kill set "gamescope steam FEX"
 
+# Native ARM64 mode (no FEX) - set STEAM_NATIVE=1 to enable
+if [ "$STEAM_NATIVE" = "1" ]; then
+    killall gamescope steam 2>/dev/null
+    sleep 1
+    SDL_VIDEODRIVER=x11 LD_LIBRARY_PATH=/storage/.local/share/Steam/lib/aarch64-linux-gnu/ \
+      /storage/.local/share/Steam/steamrtarm64/steam -steamdeck -steamos3 -gamepadui \
+      -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles -noshaders "$@"
+    exit 0
+fi
+
 # shellcheck source=start_steam.sh
 . /usr/bin/start_steam.sh
 

--- a/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam_native.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam_native.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export STEAM_NATIVE=1
+exec /usr/bin/start_steam_arm64.sh "$@"


### PR DESCRIPTION
Set STEAM_NATIVE=1 to bypass FEX and use native ARM64 Steam. Adds start_steam_native.sh launcher for EmulationStation menu.

## Summary

This PR is a workaround for FEX+Gamescope bug when screen glitches due to DRM transport conflicts. 

## Testing

Steam Native allows for glitch free screen brightness manipulations on Retroid Pocket 5.

## Additional Context

Steam Mode flag is manipulated with shortcuts from PR #2903 

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO
