### PR TITLE
sm6115: gamepad improvements

### DIFF
--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0005-input-joystick-add-mangmi-airx-driver.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0005-input-joystick-add-mangmi-airx-driver.patch
@@ -41,7 +41,7 @@ diff --git a/drivers/input/joystick/mangmi.c b/drivers/input/joystick/mangmi.c
 new file mode 100644
 --- /dev/null
 +++ b/drivers/input/joystick/mangmi.c
-@@ -0,0 +1,531 @@
+@@ -0,0 +1,646 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * MANGMI Air X Joypad Driver
@@ -66,12 +66,16 @@ new file mode 100644
 +#include <linux/slab.h>
 +#include <linux/delay.h>
 +#include <linux/unaligned.h>
++#include <linux/workqueue.h>
 +
 +#define DRIVER_NAME         "mangmi-air-x-joypad"
 +#define MCU_PKT_LEN         64
 +#define MCU_HEADER_BYTE     0x00
 +#define MCU_PKT_TIMEOUT_MS  100
 +#define MCU_BAUDRATE        4000000
++#define MCU_INIT_RETRIES    3
++#define MCU_INIT_RETRY_MS   100
++#define MCU_WARMUP_MS       100
 +
 +#define MANGMI_ADC_LO       900
 +#define MANGMI_ADC_HI       3300
@@ -142,19 +146,15 @@ new file mode 100644
 +module_param(axis_righty_antideadzone, int, 0660);
 +
 +
-+/* UART Packet Bitmasks (Bytes 2 & 3) */
 +#define MASK_HAT_RIGHT      0x08
 +#define MASK_HAT_LEFT       0x04
 +#define MASK_HAT_DOWN       0x02
 +#define MASK_HAT_UP         0x01
-+#define MASK_BTN_START      0x10 /* Unused (GPIO) */
-+#define MASK_BTN_SELECT     0x20 /* Unused (GPIO) */
 +#define MASK_BTN_THUMBL     0x40
 +#define MASK_BTN_THUMBR     0x80
 +
 +#define MASK_BTN_TL         0x01
 +#define MASK_BTN_TR         0x02
-+#define MASK_BTN_MODE       0x04 /* Unused (GPIO) */
 +#define MASK_BTN_A          0x10
 +#define MASK_BTN_B          0x20
 +#define MASK_BTN_X          0x40
@@ -180,6 +180,16 @@ new file mode 100644
 +	u8 rx_buf[MCU_PKT_LEN];
 +	int rx_idx;
 +	unsigned long rx_start;
++	unsigned long warmup_until;
++
++	struct workqueue_struct *init_wq;
++	struct work_struct init_work;
++	bool mcu_ready;
++
++	u8 last_pkt[MCU_PKT_LEN];
++	bool last_pkt_valid;
++
++	u8 last_btn_state;
 +};
 +
 +static void mangmi_set_axis_absinfo(struct input_dev *idev)
@@ -187,21 +197,21 @@ new file mode 100644
 +	input_set_abs_params(idev, ABS_X,
 +			     INT_SIGN(axis_leftx_min) * (abs(axis_leftx_min) - axis_leftx_antideadzone),
 +			     INT_SIGN(axis_leftx_max) * (abs(axis_leftx_max) - axis_leftx_antideadzone),
-+			     0, 0);
++			     4, 0);
 +	input_set_abs_params(idev, ABS_Y,
 +			     INT_SIGN(axis_lefty_min) * (abs(axis_lefty_min) - axis_lefty_antideadzone),
 +			     INT_SIGN(axis_lefty_max) * (abs(axis_lefty_max) - axis_lefty_antideadzone),
-+			     0, 0);
++			     4, 0);
 +	input_set_abs_params(idev, ABS_RX,
 +			     INT_SIGN(axis_rightx_min) * (abs(axis_rightx_min) - axis_rightx_antideadzone),
 +			     INT_SIGN(axis_rightx_max) * (abs(axis_rightx_max) - axis_rightx_antideadzone),
-+			     0, 0);
++			     4, 0);
 +	input_set_abs_params(idev, ABS_RY,
 +			     INT_SIGN(axis_righty_min) * (abs(axis_righty_min) - axis_righty_antideadzone),
 +			     INT_SIGN(axis_righty_max) * (abs(axis_righty_max) - axis_righty_antideadzone),
-+			     0, 0);
-+	input_set_abs_params(idev, ABS_Z, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
-+	input_set_abs_params(idev, ABS_RZ, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
++			     4, 0);
++	input_set_abs_params(idev, ABS_Z, 0, trigger_left_max - trigger_left_antideadzone, 2, 30);
++	input_set_abs_params(idev, ABS_RZ, 0, trigger_right_max - trigger_right_antideadzone, 2, 30);
 +	input_set_abs_params(idev, ABS_HAT0X, -1, 1, 0, 0);
 +	input_set_abs_params(idev, ABS_HAT0Y, -1, 1, 0, 0);
 +}
@@ -219,21 +229,36 @@ new file mode 100644
 +	return (int32_t)DIV_ROUND_CLOSEST(adc * (int64_t)0x580, MANGMI_ADC_HALFSPAN);
 +}
 +
-+static irqreturn_t mcu_gpio_btn_handler(int irq, void *dev_id)
++static void mcu_report_gpio_buttons(struct mcu_joy_drv *drv)
 +{
-+	struct mcu_joy_drv *drv = dev_id;
 +	struct input_dev *dev = drv->input;
++	u8 state = 0, changed;
 +
-+	if (drv->btn_start)
-+		input_report_key(dev, BTN_START, gpiod_get_value(drv->btn_start));
-+	if (drv->btn_select)
-+		input_report_key(dev, BTN_SELECT, gpiod_get_value(drv->btn_select));
-+	if (drv->btn_mode)
-+		input_report_key(dev, BTN_MODE, gpiod_get_value(drv->btn_mode));
-+	if (drv->btn_back)
-+		input_report_key(dev, BTN_BACK, gpiod_get_value(drv->btn_back));
++	if (drv->btn_start  && gpiod_get_value_cansleep(drv->btn_start))  state |= BIT(0);
++	if (drv->btn_select && gpiod_get_value_cansleep(drv->btn_select)) state |= BIT(1);
++	if (drv->btn_mode   && gpiod_get_value_cansleep(drv->btn_mode))   state |= BIT(2);
++	if (drv->btn_back   && gpiod_get_value_cansleep(drv->btn_back))   state |= BIT(3);
++
++	changed = state ^ drv->last_btn_state;
++	if (!changed)
++		return;
++
++	if (changed & BIT(0))
++		input_report_key(dev, BTN_START,  !!(state & BIT(0)));
++	if (changed & BIT(1))
++		input_report_key(dev, BTN_SELECT, !!(state & BIT(1)));
++	if (changed & BIT(2))
++		input_report_key(dev, BTN_MODE,   !!(state & BIT(2)));
++	if (changed & BIT(3))
++		input_report_key(dev, BTN_BACK, !!(state & BIT(3)));
 +
 +	input_sync(dev);
++	drv->last_btn_state = state;
++}
++
++static irqreturn_t mcu_gpio_btn_handler(int irq, void *dev_id)
++{
++	mcu_report_gpio_buttons(dev_id);
 +	return IRQ_HANDLED;
 +}
 +
@@ -248,10 +273,21 @@ new file mode 100644
 +	if (!dev)
 +		return;
 +
++	/* Drop settling frames after (re)init to avoid a phantom trigger. */
++	if (time_before(jiffies, drv->warmup_until))
++		return;
++
 +	if (update_params) {
 +		mangmi_set_axis_absinfo(dev);
 +		update_params = 0;
++		drv->last_pkt_valid = false;
 +	}
++
++	if (drv->last_pkt_valid &&
++	    !memcmp(data, drv->last_pkt, MCU_PKT_LEN))
++		return;
++	memcpy(drv->last_pkt, data, MCU_PKT_LEN);
++	drv->last_pkt_valid = true;
 +
 +	/* D-Pad */
 +	{
@@ -326,6 +362,9 @@ new file mode 100644
 +	struct mcu_joy_drv *drv = serdev_device_get_drvdata(serdev);
 +	size_t i;
 +
++	if (!READ_ONCE(drv->mcu_ready))
++		return count;
++
 +	if (drv->rx_idx > 0 &&
 +	    time_after(jiffies, drv->rx_start + msecs_to_jiffies(MCU_PKT_TIMEOUT_MS)))
 +		drv->rx_idx = 0;
@@ -339,10 +378,11 @@ new file mode 100644
 +
 +		drv->rx_buf[drv->rx_idx++] = data[i];
 +
-+		if (drv->rx_idx == MCU_PKT_LEN) {
-+			mcu_process_packet(drv, drv->rx_buf);
-+			drv->rx_idx = 0;
-+		}
++		if (drv->rx_idx < MCU_PKT_LEN)
++			continue;
++
++		mcu_process_packet(drv, drv->rx_buf);
++		drv->rx_idx = 0;
 +	}
 +
 +	return count;
@@ -353,49 +393,9 @@ new file mode 100644
 +	.write_wakeup = serdev_device_write_wakeup,
 +};
 +
-+static int mcu_setup_gpio_irq(struct device *dev, struct gpio_desc *gpiod,
-+			      struct mcu_joy_drv *drv, const char *name)
-+{
-+	int irq, error;
-+
-+	if (!gpiod)
-+		return 0;
-+
-+	irq = gpiod_to_irq(gpiod);
-+	if (irq < 0)
-+		return irq;
-+
-+	error = devm_request_threaded_irq(dev, irq, NULL, mcu_gpio_btn_handler,
-+					  IRQF_TRIGGER_RISING |
-+					  IRQF_TRIGGER_FALLING |
-+					  IRQF_ONESHOT,
-+					  name, drv);
-+	return error;
-+}
-+
 +static int mcu_hw_init(struct mcu_joy_drv *drv)
 +{
 +	int error;
-+
-+	if (drv->power_gpio)
-+		gpiod_set_value_cansleep(drv->power_gpio, 0);
-+	if (drv->stick_en_gpio)
-+		gpiod_set_value_cansleep(drv->stick_en_gpio, 0);
-+	if (drv->reset_gpio)
-+		gpiod_set_value_cansleep(drv->reset_gpio, 1);
-+
-+	msleep(500);
-+
-+	if (drv->power_gpio)
-+		gpiod_set_value_cansleep(drv->power_gpio, 1);
-+	if (drv->stick_en_gpio)
-+		gpiod_set_value_cansleep(drv->stick_en_gpio, 1);
-+
-+	/* Boot pins high = MCU runs from internal flash */
-+	if (drv->boot0_gpio)
-+		gpiod_set_value_cansleep(drv->boot0_gpio, 1);
-+	if (drv->boot1_gpio)
-+		gpiod_set_value_cansleep(drv->boot1_gpio, 1);
 +
 +	error = serdev_device_set_parity(drv->serdev, SERDEV_PARITY_NONE);
 +	if (error)
@@ -404,24 +404,82 @@ new file mode 100644
 +	serdev_device_set_flow_control(drv->serdev, false);
 +	serdev_device_set_baudrate(drv->serdev, MCU_BAUDRATE);
 +
++	if (drv->power_gpio)
++		gpiod_set_value_cansleep(drv->power_gpio, 1);
++	if (drv->stick_en_gpio)
++		gpiod_set_value_cansleep(drv->stick_en_gpio, 1);
++
++	msleep(10);
++
++	if (drv->boot0_gpio)
++		gpiod_set_value_cansleep(drv->boot0_gpio, 1);
++	if (drv->boot1_gpio)
++		gpiod_set_value_cansleep(drv->boot1_gpio, 1);
++
 +	if (drv->reset_gpio) {
++		gpiod_set_value_cansleep(drv->reset_gpio, 1);
 +		msleep(20);
 +		gpiod_set_value_cansleep(drv->reset_gpio, 0);
 +	}
 +
++	msleep(20);
++
 +	drv->rx_idx = 0;
++	drv->warmup_until = jiffies + msecs_to_jiffies(MCU_WARMUP_MS);
++	WRITE_ONCE(drv->mcu_ready, true);
 +
 +	return 0;
 +}
 +
++static int mcu_hw_init_retry(struct mcu_joy_drv *drv)
++{
++	int error, attempt;
++
++	for (attempt = 1; attempt <= MCU_INIT_RETRIES; attempt++) {
++		error = mcu_hw_init(drv);
++		if (!error)
++			return 0;
++		dev_warn(&drv->serdev->dev,
++			 "MCU init attempt %d/%d failed: %d\n",
++			 attempt, MCU_INIT_RETRIES, error);
++		if (attempt < MCU_INIT_RETRIES)
++			msleep(MCU_INIT_RETRY_MS);
++	}
++	return error;
++}
++
++static void mcu_joy_init_work(struct work_struct *work)
++{
++	struct mcu_joy_drv *drv = container_of(work, struct mcu_joy_drv,
++					       init_work);
++	int error;
++
++	error = mcu_hw_init_retry(drv);
++	if (error)
++		dev_err(&drv->serdev->dev,
++			"Deferred MCU init failed after retries: %d\n", error);
++}
++
 +static void mcu_hw_shutdown(struct mcu_joy_drv *drv)
 +{
-+	if (drv->reset_gpio)
-+		gpiod_set_value_cansleep(drv->reset_gpio, 1);
++	WRITE_ONCE(drv->mcu_ready, false);
++	drv->last_pkt_valid = false;
++
 +	if (drv->stick_en_gpio)
 +		gpiod_set_value_cansleep(drv->stick_en_gpio, 0);
 +	if (drv->power_gpio)
 +		gpiod_set_value_cansleep(drv->power_gpio, 0);
++
++	msleep(50);
++}
++
++static void mcu_joy_destroy_init_wq(void *data)
++{
++	struct mcu_joy_drv *drv = data;
++
++	cancel_work_sync(&drv->init_work);
++	if (drv->init_wq)
++		destroy_workqueue(drv->init_wq);
 +}
 +
 +static int mcu_joy_probe(struct serdev_device *serdev)
@@ -435,42 +493,40 @@ new file mode 100644
 +		return -ENOMEM;
 +	serdev_device_set_drvdata(serdev, drv);
 +	drv->serdev = serdev;
++	INIT_WORK(&drv->init_work, mcu_joy_init_work);
 +
-+	drv->boot0_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-boot0", GPIOD_OUT_LOW);
-+	if (IS_ERR(drv->boot0_gpio))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->boot0_gpio), "boot0 GPIO\n");
++	drv->init_wq = alloc_ordered_workqueue("mangmi_airx_init", WQ_FREEZABLE);
++	if (!drv->init_wq)
++		return -ENOMEM;
++	error = devm_add_action_or_reset(&serdev->dev, mcu_joy_destroy_init_wq, drv);
++	if (error)
++		return error;
 +
-+	drv->boot1_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-boot1", GPIOD_OUT_LOW);
-+	if (IS_ERR(drv->boot1_gpio))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->boot1_gpio), "boot1 GPIO\n");
++	{
++		struct { const char *con; struct gpio_desc **out; enum gpiod_flags f; } gpios[] = {
++			{ "mcu-boot0",  &drv->boot0_gpio,    GPIOD_OUT_LOW },
++			{ "mcu-boot1",  &drv->boot1_gpio,    GPIOD_OUT_LOW },
++			{ "mcu-reset",  &drv->reset_gpio,    GPIOD_OUT_LOW },
++			{ "mcu-power",  &drv->power_gpio,    GPIOD_OUT_LOW },
++			{ "stick-en",   &drv->stick_en_gpio, GPIOD_OUT_LOW },
++			{ "mcu-start",  &drv->btn_start,     GPIOD_IN },
++			{ "mcu-select", &drv->btn_select,    GPIOD_IN },
++			{ "mcu-mode",   &drv->btn_mode,      GPIOD_IN },
++			{ "mcu-back",   &drv->btn_back,      GPIOD_IN },
++		};
++		size_t i;
 +
-+	drv->reset_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-reset", GPIOD_OUT_LOW);
-+	if (IS_ERR(drv->reset_gpio))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->reset_gpio), "reset GPIO\n");
-+
-+	drv->power_gpio = devm_gpiod_get_optional(&serdev->dev, "mcu-power", GPIOD_OUT_LOW);
-+	if (IS_ERR(drv->power_gpio))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->power_gpio), "power GPIO\n");
-+
-+	drv->stick_en_gpio = devm_gpiod_get_optional(&serdev->dev, "stick-en", GPIOD_OUT_LOW);
-+	if (IS_ERR(drv->stick_en_gpio))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->stick_en_gpio), "stick-en GPIO\n");
-+
-+	drv->btn_start = devm_gpiod_get_optional(&serdev->dev, "mcu-start", GPIOD_IN);
-+	if (IS_ERR(drv->btn_start))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_start), "start GPIO\n");
-+
-+	drv->btn_select = devm_gpiod_get_optional(&serdev->dev, "mcu-select", GPIOD_IN);
-+	if (IS_ERR(drv->btn_select))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_select), "select GPIO\n");
-+
-+	drv->btn_mode = devm_gpiod_get_optional(&serdev->dev, "mcu-mode", GPIOD_IN);
-+	if (IS_ERR(drv->btn_mode))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_mode), "mode GPIO\n");
-+
-+	drv->btn_back = devm_gpiod_get_optional(&serdev->dev, "mcu-back", GPIOD_IN);
-+	if (IS_ERR(drv->btn_back))
-+		return dev_err_probe(&serdev->dev, PTR_ERR(drv->btn_back), "back GPIO\n");
++		for (i = 0; i < ARRAY_SIZE(gpios); i++) {
++			*gpios[i].out = devm_gpiod_get_optional(&serdev->dev,
++								gpios[i].con,
++								gpios[i].f);
++			if (IS_ERR(*gpios[i].out))
++				return dev_err_probe(&serdev->dev,
++						     PTR_ERR(*gpios[i].out),
++						     "%s GPIO\n",
++						     gpios[i].con);
++		}
++	}
 +
 +	input = devm_input_allocate_device(&serdev->dev);
 +	if (!input)
@@ -503,25 +559,49 @@ new file mode 100644
 +	if (error)
 +		return error;
 +
-+	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_start, drv, "btn-start");
-+	if (error)
-+		return error;
-+	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_select, drv, "btn-select");
-+	if (error)
-+		return error;
-+	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_mode, drv, "btn-mode");
-+	if (error)
-+		return error;
-+	error = mcu_setup_gpio_irq(&serdev->dev, drv->btn_back, drv, "btn-back");
-+	if (error)
-+		return error;
++	{
++		u8 state = 0;
++
++		if (drv->btn_start  && gpiod_get_value_cansleep(drv->btn_start))  state |= BIT(0);
++		if (drv->btn_select && gpiod_get_value_cansleep(drv->btn_select)) state |= BIT(1);
++		if (drv->btn_mode   && gpiod_get_value_cansleep(drv->btn_mode))   state |= BIT(2);
++		if (drv->btn_back   && gpiod_get_value_cansleep(drv->btn_back))   state |= BIT(3);
++		drv->last_btn_state = state;
++	}
++
++	{
++		const struct { struct gpio_desc *gpio; const char *name; } btns[] = {
++			{ drv->btn_start,  "btn-start"  },
++			{ drv->btn_select, "btn-select" },
++			{ drv->btn_mode,   "btn-mode"   },
++			{ drv->btn_back,   "btn-back"   },
++		};
++		size_t i;
++		int irq;
++
++		for (i = 0; i < ARRAY_SIZE(btns); i++) {
++			if (!btns[i].gpio)
++				continue;
++			irq = gpiod_to_irq(btns[i].gpio);
++			if (irq < 0)
++				return irq;
++			error = devm_request_threaded_irq(&serdev->dev, irq, NULL,
++							  mcu_gpio_btn_handler,
++							  IRQF_TRIGGER_RISING |
++							  IRQF_TRIGGER_FALLING |
++							  IRQF_ONESHOT,
++							  btns[i].name, drv);
++			if (error)
++				return error;
++		}
++	}
 +
 +	serdev_device_set_client_ops(serdev, &mcu_joy_serdev_ops);
 +	error = devm_serdev_device_open(&serdev->dev, serdev);
 +	if (error)
 +		return dev_err_probe(&serdev->dev, error, "UART open failed\n");
 +
-+	error = mcu_hw_init(drv);
++	error = mcu_hw_init_retry(drv);
 +	if (error)
 +		return dev_err_probe(&serdev->dev, error, "MCU init failed\n");
 +
@@ -535,11 +615,43 @@ new file mode 100644
 +	mcu_hw_shutdown(drv);
 +}
 +
++static void mcu_joy_report_neutral(struct mcu_joy_drv *drv)
++{
++	struct input_dev *dev = drv->input;
++	static const unsigned int keys[] = {
++		BTN_A, BTN_B, BTN_X, BTN_Y, BTN_TL, BTN_TR,
++		BTN_THUMBL, BTN_THUMBR, BTN_SELECT, BTN_START,
++		BTN_MODE, BTN_BACK,
++	};
++	size_t i;
++
++	if (!dev)
++		return;
++
++	for (i = 0; i < ARRAY_SIZE(keys); i++)
++		input_report_key(dev, keys[i], 0);
++
++	input_report_abs(dev, ABS_X, 0);
++	input_report_abs(dev, ABS_Y, 0);
++	input_report_abs(dev, ABS_RX, 0);
++	input_report_abs(dev, ABS_RY, 0);
++	input_report_abs(dev, ABS_Z, 0);
++	input_report_abs(dev, ABS_RZ, 0);
++	input_report_abs(dev, ABS_HAT0X, 0);
++	input_report_abs(dev, ABS_HAT0Y, 0);
++	input_sync(dev);
++}
++
 +static int mcu_joy_suspend(struct device *dev)
 +{
 +	struct mcu_joy_drv *drv = dev_get_drvdata(dev);
 +
++	cancel_work_sync(&drv->init_work);
++
 +	mcu_hw_shutdown(drv);
++
++	mcu_joy_report_neutral(drv);
++	drv->last_btn_state = 0;
 +	return 0;
 +}
 +
@@ -547,7 +659,10 @@ new file mode 100644
 +{
 +	struct mcu_joy_drv *drv = dev_get_drvdata(dev);
 +
-+	return mcu_hw_init(drv);
++	mcu_report_gpio_buttons(drv);
++
++	queue_work(drv->init_wq, &drv->init_work);
++	return 0;
 +}
 +
 +static DEFINE_SIMPLE_DEV_PM_OPS(mcu_joy_pm_ops, mcu_joy_suspend, mcu_joy_resume);

--- a/projects/ROCKNIX/devices/SM6115/patches/linux/0080-serial-qcom-geni-mask-irq-during-system-suspend.patch
+++ b/projects/ROCKNIX/devices/SM6115/patches/linux/0080-serial-qcom-geni-mask-irq-during-system-suspend.patch
@@ -1,0 +1,27 @@
+Subject: [PATCH] serial: qcom-geni: mask UART IRQ during system suspend
+
+---
+ drivers/tty/serial/qcom_geni_serial.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/tty/serial/qcom_geni_serial.c b/drivers/tty/serial/qcom_geni_serial.c
+--- a/drivers/tty/serial/qcom_geni_serial.c
++++ b/drivers/tty/serial/qcom_geni_serial.c
+@@ -1963,6 +1963,8 @@ static int qcom_geni_serial_suspend(struct device *dev)
+ 		geni_icc_set_tag(&port->se, QCOM_ICC_TAG_ACTIVE_ONLY);
+ 		geni_icc_set_bw(&port->se);
+ 	}
++
++	disable_irq(uport->irq);
+ 	return uart_suspend_port(private_data->drv, uport);
+ }
+
+@@ -1974,6 +1976,8 @@ static int qcom_geni_serial_resume(struct device *dev)
+ 	struct qcom_geni_private_data *private_data = uport->private_data;
+
+ 	ret = uart_resume_port(private_data->drv, uport);
++
++	enable_irq(uport->irq);
+ 	if (uart_console(uport)) {
+ 		geni_icc_set_tag(&port->se, QCOM_ICC_TAG_ALWAYS);
+ 		geni_icc_set_bw(&port->se);


### PR DESCRIPTION

## Summary

* **What is the goal of this PR?** Prep gamepad for mem suspend PR

removes phatom suspend drop invalid packets

fuzz to sticks

retry mcu init

debounce check added

improves suspend/resume time


## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
