### PR TITLE
gamescope: fix rotation shader cache key

### DIFF
--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0005-feature-add-rotation-shader-for-rotating-output.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0005-feature-add-rotation-shader-for-rotating-output.patch
@@ -218,7 +218,7 @@ index 65411dcf..81f46c9e 100644
 -	SHADER(EASU, 1, 1, 1);
 -	SHADER(NIS, 1, 1, 1);
 -	SHADER(RGB_TO_NV12, 1, 1, 1);
-+#define SHADER(type, layer_count, max_ycbcr, blur_layers, need_rotations) pipelineInfos[SHADER_TYPE_##type] = {SHADER_TYPE_##type, layer_count, max_ycbcr, blur_layers, need_rotations ? 3 : 0}
++#define SHADER(type, layer_count, max_ycbcr, blur_layers, need_rotations) pipelineInfos[SHADER_TYPE_##type] = {SHADER_TYPE_##type, layer_count, max_ycbcr, blur_layers, 0, 0, 0, false, (need_rotations) && g_bRotationShaderRequested ? 3u : 0u}
 +	SHADER(BLIT, k_nMaxLayers, k_nMaxYcbcrMask_ToPreCompile, 1, true);
 +	SHADER(BLUR, k_nMaxLayers, k_nMaxYcbcrMask_ToPreCompile, k_nMaxBlurLayers, true);
 +	SHADER(BLUR_COND, k_nMaxLayers, k_nMaxYcbcrMask_ToPreCompile, k_nMaxBlurLayers, true);
@@ -253,7 +253,7 @@ index 65411dcf..81f46c9e 100644
 +						VkPipeline newPipeline = compilePipeline(layerCount, ycbcrMask, info.shaderType, blur_layers, info.compositeDebug, info.colorspaceMask, info.outputEOTF, info.itmEnable, rotation);
 +						{
 +							std::lock_guard<std::mutex> lock(m_pipelineMutex);
-+							PipelineInfo_t key = {info.shaderType, layerCount, ycbcrMask, blur_layers, info.compositeDebug};
++							PipelineInfo_t key = {info.shaderType, layerCount, ycbcrMask, blur_layers, info.compositeDebug, info.colorspaceMask, info.outputEOTF, info.itmEnable, rotation};
 +							auto result = m_pipelineMap.emplace(std::make_pair(key, newPipeline));
 +							if (!result.second)
 +								vk.DestroyPipeline(device(), newPipeline, nullptr);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
* Set rotation in the right field an also gate on if shader is rotatable and if rotatio is set
* Use all 9 field for cache lookup key to avoid piplines from getting destroyed
* Previously cache misses were likely downgrading performance

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
