### PR TITLE
thor:  Split lid switch from gpio-keys

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
@@ -25,6 +25,10 @@
 			linux,code = <KEY_F24>;
 			linux,can-disable;
 		};
+	};
+
+	gpio-keys-lid {
+		compatible = "gpio-keys";
 
 		hall-lid-sensor {
 			label = "Hall Lid Sensor";


### PR DESCRIPTION
## Summary

Split lid switch from gpio-keys. Otherwise inputplumber takes it, and logind `HandleLidSwitch` stops working

## Testing

* **How was this tested?**: tested on ayn thor
* **Test results:** builds and works as expected

## Additional Context

honestly don't know what i am doing. there wasn't a pinctrl for tlmm pin 41 before, so i assume a pinctrl definition is not needed for this hall sensor?

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
