### PR TITLE
lowerdeck: bump package

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
@@ -268,11 +268,12 @@ case ${EMULATOR} in
       echo 'network_cmd_enable = "true"' >> "${RETROARCH_APPEND_CONFIG}"
       echo 'network_cmd_port = "55355"'  >> "${RETROARCH_APPEND_CONFIG}"
       echo 'savestate_thumbnail_enable = "true"' >> "${RETROARCH_APPEND_CONFIG}"
+      echo 'cheevos_custom_host = "http://127.0.0.1:4874"' >> "${RETROARCH_APPEND_CONFIG}"
 
       if ! pgrep -f 'python3 .*/lowerdeck/ra_proxy\.py' >/dev/null 2>&1; then
         ( python3 /usr/share/lowerdeck/ra_proxy.py >/dev/null 2>&1 ) &
         for _ in 1 2 3 4 5 6 7 8 9 10; do
-          netstat -ln 2>/dev/null | grep -q ':8080 ' && break
+          netstat -ln 2>/dev/null | grep -q ':4874 ' && break
           sleep 0.1
         done
       fi

--- a/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
+++ b/projects/ROCKNIX/packages/ui/lowerdeck/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="lowerdeck"
-PKG_VERSION="f5b48c138db3dba65e15b1efc9b3464d96f8842e"
+PKG_VERSION="ab735114ab318a84e4d28c9c5f1b154e450a579a"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/bulzipke/lowerdeck"


### PR DESCRIPTION
## Summary

- Update `ra_proxy` default port to 4874
- Fix bug where `cheevos_custom_host` was missing
- Display hardcore achievements in rainbow colors

## Testing

- Verified on Thor (SM8550)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
