### PR TITLE
Update ROCKNIX to support GCC 15.x/16

### DIFF
--- a/projects/ROCKNIX/packages/audio/fluidsynth/package.mk
+++ b/projects/ROCKNIX/packages/audio/fluidsynth/package.mk
@@ -11,3 +11,7 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=1 \
                        -Denable-pulseaudio=1 \
                        -Denable-systemd=1 \
                        -Denable-readline=0"
+
+pre_configure_target() {
+  export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${TOOLCHAIN}/${TARGET_NAME}/lib"
+}

--- a/projects/ROCKNIX/packages/devel/ncurses/package.mk
+++ b/projects/ROCKNIX/packages/devel/ncurses/package.mk
@@ -62,12 +62,19 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --enable-sigwinch \
                            --cache-file=config.cache"
 
-PKG_CONFIGURE_OPTS_HOST="--enable-termcap \
+PKG_CONFIGURE_OPTS_HOST="--without-cxx-binding \
+                         --enable-termcap \
                          --with-termlib \
                          --with-shared \
                          --enable-pc-files \
                          --without-tests \
                          --without-manpages"
+
+pre_configure_host() {
+  unset TERMINFO
+  unset TERMINFO_DIR
+}
+
 
 pre_configure_target() {
   cat >config.cache <<EOF
@@ -77,6 +84,7 @@ EOF
 
   CFLAGS="${CFLAGS} -std=gnu17"
 }
+
 
 post_makeinstall_target() {
   local f

--- a/projects/ROCKNIX/packages/graphics/spirv-tools/patches/spirv-tools-0001-op-words-warn.patch
+++ b/projects/ROCKNIX/packages/graphics/spirv-tools/patches/spirv-tools-0001-op-words-warn.patch
@@ -1,0 +1,14 @@
+diff --git a/source/opt/decoration_manager.cpp b/source/opt/decoration_manager.cpp
+index 3e95dbc..92657fb 100644
+--- a/source/opt/decoration_manager.cpp
++++ b/source/opt/decoration_manager.cpp
+@@ -543,7 +543,8 @@ void DecorationManager::CloneDecorations(uint32_t from, uint32_t to) {
+         const uint32_t num_operands = inst->NumOperands();
+         for (uint32_t i = 1; i < num_operands; i += 2) {
+           Operand op = inst->GetOperand(i);
+-          if (op.words[0] == from) {  // add new pair of operands: (to, literal)
++          if (!op.words.empty() &&
++              op.words[0] == from) {
+             inst->AddOperand(
+                 Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID, {to}));
+             op = inst->GetOperand(i + 1);

--- a/projects/ROCKNIX/packages/tools/grub/patches/grub-const-char.patch
+++ b/projects/ROCKNIX/packages/tools/grub/patches/grub-const-char.patch
@@ -1,0 +1,79 @@
+diff --git a/grub-core/osdep/linux/ofpath.c b/grub-core/osdep/linux/ofpath.c
+index a6153d3..79e442b 100644
+--- a/grub-core/osdep/linux/ofpath.c
++++ b/grub-core/osdep/linux/ofpath.c
+@@ -488,13 +488,13 @@ check_hba_identifiers (const char *sysfs_path, int *vendor, int *device_id)
+ static void
+ check_sas (const char *sysfs_path, int *tgt, unsigned long int *sas_address)
+ {
+-  char *ed = strstr (sysfs_path, "end_device");
+-  char *p, *q, *path;
++  const char *sysfs_ed = strstr (sysfs_path, "end_device");
++  char *ed, *p, *q, *path;
+   char phy[21];
+   int fd;
+   size_t path_size;
+ 
+-  if (!ed)
++  if (!sysfs_ed)
+     return;
+ 
+   /* SAS devices are identified using disk@$PHY_ID */
+diff --git a/util/probe.c b/util/probe.c
+index 81d91cf..a9158d6 100644
+--- a/util/probe.c
++++ b/util/probe.c
+@@ -70,7 +70,7 @@ char *
+ grub_util_guess_bios_drive (const char *orig_path)
+ {
+   char *canon;
+-  char *ptr;
++  const char *ptr;
+   canon = grub_canonicalize_file_name (orig_path);
+   if (!canon)
+     return NULL;
+@@ -99,7 +99,7 @@ char *
+ grub_util_guess_efi_drive (const char *orig_path)
+ {
+   char *canon;
+-  char *ptr;
++  const char *ptr;
+   canon = grub_canonicalize_file_name (orig_path);
+   if (!canon)
+     return NULL;
+@@ -128,7 +128,7 @@ char *
+ grub_util_guess_baremetal_drive (const char *orig_path)
+ {
+   char *canon;
+-  char *ptr;
++  const char *ptr;
+   canon = grub_canonicalize_file_name (orig_path);
+   if (!canon)
+     return NULL;
+diff --git a/util/resolve.c b/util/resolve.c
+index b6e2631..5310a55 100644
+--- a/util/resolve.c
++++ b/util/resolve.c
+@@ -138,8 +138,8 @@ read_dep_list (FILE *fp)
+ static char *
+ get_module_name (const char *str)
+ {
+-  char *base;
+-  char *ext;
++  const char *base;
++  const char *ext;
+ 
+   base = strrchr (str, '/');
+   if (! base)
+@@ -164,9 +164,9 @@ get_module_name (const char *str)
+ static char *
+ get_module_path (const char *prefix, const char *str)
+ {
+-  char *dir;
++  const char *dir;
+   char *base;
+-  char *ext;
++  const char *ext;
+   char *ret;
+ 
+   ext = strrchr (str, '.');


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 

Several tools are updated and patched to permit building on the latest GCC compilers (later 15.x, 16).

* a4d5cc2a18 Cmake: Disable GHS in bootstrap

  GreenHells is removed from the bootstrap stage of CMake.  It should be available in the final build (although unlikely to be needed).

* 0cfc6b2aaf ncurses: Disable C++ and TERMINFO

  TERMINFO should not be read from the build environment, which can cause issues with less mainstream terminal emulators (e.g. Kitty).  This PR unsets TERMINFO related content within the build.

* f0869c024f m4: Update to 1.4.21
  bfb1ec791d gettext: Update to 1.0
  13de8ec0dc elfutils: Update to 0.195
  e17532c226 security updates: nspr 4.39, nss 3.125
  a302703863 binutils 2.46 update

  Newer GCCs enforce C23 more strictly, which did not match use of _Generic() in gnulib in several projects.  This was quickly updated in most projects, but requires an update of the ROCKNIX packages.

  In gettext, additional legacy issues requiring patches are no longer needed, and the patches were removed.

* a39434fdad SPIRV-tools: patch an uninitialized variable

  Contained an uninitialized variable, which was failing `-Werror` builds.  This adds an initialization test as a patch.

* 073bac8204 Fluidsynth: Add rpaths

  I encountered a dylib linking issue here.  Perhaps the container worked around this with environment variables, but I was able to fix it by adding the toolchain to the RPATH.

* fbec52f86b grub: Patch to handle str* API changes

  Several functions which accept `const str *` now require the return result to be `const str *`.  This is now enforced more strictly in GCC.  This patch modifies the definitions of the respective outputs.

## Testing

SM8250 build was tested, build was verified and was able to successfully boot kernel and launch EmulationStation on Retroid Pocket 5.


### AI Usage


**Did you use AI tools to help write this code?**

GPT 5.5 chatbot debugging support but no code generation.