### PR TITLE
scripts/get_env: fix to not overwrite PATH from current system

### DIFF
--- a/scripts/get_env
+++ b/scripts/get_env
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-for var in $(compgen -e); do echo "$var=${!var}"; done
+for var in $(compgen -e); do 
+  [[ "$var" == PATH  ]] && continue
+  echo "$var=${!var}"
+done


### PR DESCRIPTION
This solves building in docker on nixos, for example.

Thanks to @LukeDSchenk

## Summary

* **What is the goal of this PR?** enable building in docker on nixos

## Testing

* **How was this tested?** on nixos
* **Test results:**
* 
## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
