### PR TITLE
supersnes9x: change the proper branch for libretro

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/supersnes9x-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/supersnes9x-lr/package.mk
@@ -20,7 +20,7 @@
 ################################################################################
 
 PKG_NAME="supersnes9x-lr"
-PKG_VERSION="d39f1a24efb3351cab9118b87412f8ffc8e4555e"
+PKG_VERSION="d7561a84555a6edcdcb2dc098824b89dab1d8c38"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/shanytc/snes9x"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
@@ -39,5 +39,5 @@ make_target() {
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
-  cp libretro/snes9x_libretro.so ${INSTALL}/usr/lib/libretro/supersnes9x_libretro.so
+  cp libretro/supersnes9x_libretro.so ${INSTALL}/usr/lib/libretro/
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )
Change the proper branch of libretro core for supersnes9x. It isn't master branch, but sgb_libretro. Since it changes the built file name, I change it too.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
