### PR TITLE
sm8550: fix input regressions

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-controller.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-controller.yaml
@@ -57,6 +57,7 @@ source_devices:
 
   - group: gamepad
     evdev:
+      name: gpio-keys
       phys_path: gpio-keys/input0
       handler: event*
     capability_map_id: ayn_mcu


### PR DESCRIPTION
## Summary

* This PR reverts changes from
#2824 
#2909 
which caused issues with lid switch / duplicate controller detection.
* Additionally, it changes the AYN button to KEY_HOME so it can be recognized in RetroArch.

## Testing

* Tested on Thor(SM8550).
* Verified that the LID sensor (fake suspend) behaves correctly and that duplicate controller detection is resolved.

## Additional Context

* BTN_BACK button remains unrecognized in RetroArch, as there are no available slots in the DualSense mapping.


---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
