### PR TITLE
SM8250: Fix brightness adjustment causing screen to jump on the RP5

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0016-rp5-smooth-brightness-adjustment.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0016-rp5-smooth-brightness-adjustment.patch
@@ -1,0 +1,40 @@
+diff --git a/drivers/gpu/drm/msm/dsi/dsi_host.c b/drivers/gpu/drm/msm/dsi/dsi_host.c
+index e0de545d4..5238279a8 100644
+--- a/drivers/gpu/drm/msm/dsi/dsi_host.c
++++ b/drivers/gpu/drm/msm/dsi/dsi_host.c
+@@ -2114,8 +2114,18 @@ int msm_dsi_host_xfer_prepare(struct mipi_dsi_host *host,
+ 	 * mdp clock need to be enabled to receive dsi interrupt
+ 	 */
+ 	pm_runtime_get_sync(&msm_host->pdev->dev);
+-	cfg_hnd->ops->link_clk_set_rate(msm_host);
+-	cfg_hnd->ops->link_clk_enable(msm_host);
++
++	/*
++	 * Skip link clock enable/set_rate when the display is already active.
++	 * The link clocks are owned by host_power_on()/host_power_off() for
++	 * the duration of the display session. Re-cycling them here while the
++	 * MDP frame pipeline is running cuts the byte/pixel clock supply to
++	 * the DSI serializer mid-frame, causing all-lane HS FIFO underflows.
++	 */
++	if (!(msm_host->power_on && msm_host->enabled)) {
++		cfg_hnd->ops->link_clk_set_rate(msm_host);
++		cfg_hnd->ops->link_clk_enable(msm_host);
++	}
+ 
+ 	/* TODO: vote for bus bandwidth */
+ 
+@@ -2146,7 +2156,13 @@ void msm_dsi_host_xfer_restore(struct mipi_dsi_host *host,
+ 
+ 	/* TODO: unvote for bus bandwidth */
+ 
+-	cfg_hnd->ops->link_clk_disable(msm_host);
++	/*
++	 * Only disable link clocks if the display was not already active when
++	 * xfer_prepare() ran. Matches the conditional enable above.
++	 */
++	if (!(msm_host->power_on && msm_host->enabled))
++		cfg_hnd->ops->link_clk_disable(msm_host);
++
+ 	pm_runtime_put(&msm_host->pdev->dev);
+ }
+ 


### PR DESCRIPTION
Thanks for @loki666 for finding the patch and @PostmarketOS for the fix:

https://gitlab.postmarketos.org/-/snippets/26

Tested on RP5.