### PR TITLE
emulationstation: merge latest ES changes

### DIFF
--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="fdfbf4bb9c1140d3b7fd90918cb6f0f94551389d"
+PKG_VERSION="26ded87813e47f24a116923bdd1fc783ec796f04"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
Inludes the following 2 changes;

*Hides display mode option when only one display mode is available. 

*Hides dual screen options on single screen devices. 