### PR TITLE
SM8550: fix CPU affinity — restrict SLOW to A510 little cores only

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8550/040-affinity
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8550/040-affinity
@@ -3,6 +3,6 @@
 # Copyright (C) 2024 ROCKNIX (https://github.com/ROCKNIX)
 
 cat <<EOF >/storage/.config/profile.d/040-affinity
-SLOW_CORES="taskset -c 0-3"
-FAST_CORES="taskset -c 4-7"
+SLOW_CORES="taskset -c 0-2"
+FAST_CORES="taskset -c 3-7"
 EOF


### PR DESCRIPTION
SM8550 has 3x A510 (cpu0-2), 2x A710 (cpu3-4), 2x A715 (cpu5-6), 1x X3 (cpu7). The old 4+4 split placed cpu3 (A710 mid-core) in the SLOW group alongside the A510 little cores.

Correct split: SLOW=cpu0-2 (A510 only), FAST=cpu3-7 (A710/A715/X3 for gaming).

## Summary

* **What is the goal of this PR?** Fix CPU core affinity for SM8550 to prevent A710 mid-cores from being wasted on background tasks.

## Testing

* **How was this tested?** Built and tested on AYANEO Pocket S (SM8550).
* **Test results:** FEX/Steam gaming performance improved with A710 correctly assigned to FAST group.

## Additional Context

Same issue affects SM8250, SM8650, and SM8750 — these will be addressed in follow-up PRs after this pattern is reviewed.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY