### PR TITLE
AYN Odin 2 (SM8550): enable UHS-I SDR50/SDR104 on microSD, remove 37.5Mhz clamp for faster SD read/write

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-common.dtsi
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-common.dtsi
@@ -1456,12 +1456,12 @@
 	pinctrl-1 = <&sdc2_sleep &sdc2_card_det_n>;
 	vmmc-supply = <&vreg_l9b_2p9>;
 	vqmmc-supply = <&vreg_l8b_1p8>;
-	max-sd-hs-hz = <37500000>;
 	no-sdio;
 	no-mmc;
+	sd-uhs-sdr50;
+	sd-uhs-sdr104;
 
 	qcom,dll-config = <0x0007442c>;
-	sdhci-caps-mask = <0x3 0x0>;
 
 	status = "okay";
 };


### PR DESCRIPTION
## What

`&sdhc_2` (external microSD, mmc@8804000) in qcs8550-ayn-common.dtsi is clamped to
SD High Speed at 37.5 MHz via `max-sd-hs-hz = <37500000>` and `sdhci-caps-mask = <0x3 0x0>`,
with no UHS modes declared — capping reads at ~18 MB/s. This removes the clamp/mask and
declares sd-uhs-sdr50 / sd-uhs-sdr104.

## Tested on Odin 2 hardware

**Before:** `/sys/kernel/debug/mmc0/ios` → clock 37500000 Hz, timing sd high-speed,
signal voltage 3.30 V; `dd` read = **17.6 MB/s**

**After:** `ios` → clock 202000000 Hz, timing sd uhs SDR104, signal voltage 1.80 V;
`dmesg` → "mmc0: new UHS-I speed SDR104 SDXC card"; `dd` (2 GB, iflag=direct) = **81.0 MB/s**;
no mmc CRC/timeout/retune/I/O errors after sustained reads.

~4.6x sequential read improvement, stable under load. Real workloads (emulation, Steam)
noticeably smoother. Card: SanDisk Extreme 512GB (A2/V30/U3).

## Why it's safe

`vqmmc-supply = <&vreg_l8b_1p8>` (1.8 V signaling) is present, driver is upstream
`qcom,sdhci-msm-v5`, and there is no `no-1-8-v` — the hardware is UHS-I capable and the
modes were simply masked. The 37.5 MHz clamp appears to be a conservative default rather
than a signal-integrity requirement, confirmed by error-free SDR104 operation under
sustained reads. `qcom,dll-config` left unchanged; it tunes correctly at SDR104 in testing.

## Scope

Tested on Odin 2. The identical clamp exists in qcs8550-ayaneo-pocket-common.dtsi
(AYANEO Pocket) and likely other SM8550 board files; left untouched here pending
independent validation on that hardware.