### PR TITLE
bugfix: set pcsx2-sa build version for hardcore retro achievements

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/pcsx2-sa/patches/0000-set-version.patch
+++ b/projects/ROCKNIX/packages/emulators/standalone/pcsx2-sa/patches/0000-set-version.patch
@@ -1,0 +1,49 @@
+diff -rupbN pcsx2.orig/cmake/Pcsx2Utils.cmake pcsx2/cmake/Pcsx2Utils.cmake
+--- pcsx2.orig/cmake/Pcsx2Utils.cmake	2026-06-24 20:55:17.110675390 +0000
++++ pcsx2/cmake/Pcsx2Utils.cmake	2026-06-24 20:56:30.063705979 +0000
+@@ -98,40 +98,16 @@ function(get_git_version_info)
+ endfunction()
+ 
+ function(write_svnrev_h)
+-	if ("${PCSX2_GIT_TAG}" MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+ 		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h
+-			"#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n"
++		"#define GIT_TAG \"v2.6.3\"\n"
+ 			"#define GIT_TAGGED_COMMIT 1\n"
+-			"#define GIT_TAG_HI  ${CMAKE_MATCH_1}\n"
+-			"#define GIT_TAG_MID ${CMAKE_MATCH_2}\n"
+-			"#define GIT_TAG_LO  ${CMAKE_MATCH_3}\n"
+-			"#define GIT_REV \"${PCSX2_GIT_TAG}\"\n"
++		"#define GIT_TAG_HI 2\n"
++		"#define GIT_TAG_MID 6\n"
++		"#define GIT_TAG_LO 3\n"
++		"#define GIT_REV \"v2.6.3\"\n"
+ 			"#define GIT_HASH \"${PCSX2_GIT_HASH}\"\n"
+ 			"#define GIT_DATE \"${PCSX2_GIT_DATE}\"\n"
+ 		)
+-	elseif ("${PCSX2_GIT_REV}" MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+-		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h
+-			"#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n"
+-			"#define GIT_TAGGED_COMMIT 0\n"
+-			"#define GIT_TAG_HI  ${CMAKE_MATCH_1}\n"
+-			"#define GIT_TAG_MID ${CMAKE_MATCH_2}\n"
+-			"#define GIT_TAG_LO  ${CMAKE_MATCH_3}\n"
+-			"#define GIT_REV \"${PCSX2_GIT_REV}\"\n"
+-			"#define GIT_HASH \"${PCSX2_GIT_HASH}\"\n"
+-			"#define GIT_DATE \"${PCSX2_GIT_DATE}\"\n"
+-		)
+-	else()
+-		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h
+-			"#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n"
+-			"#define GIT_TAGGED_COMMIT 0\n"
+-			"#define GIT_TAG_HI 0\n"
+-			"#define GIT_TAG_MID 0\n"
+-			"#define GIT_TAG_LO 0\n"
+-			"#define GIT_REV \"${PCSX2_GIT_REV}\"\n"
+-			"#define GIT_HASH \"${PCSX2_GIT_HASH}\"\n"
+-			"#define GIT_DATE \"${PCSX2_GIT_DATE}\"\n"
+-		)
+-	endif()
+ endfunction()
+ 
+ function(check_no_parenthesis_in_path)


### PR DESCRIPTION
This correctly sets the build version, instead of just git hash