### PR TITLE
thor: disable bottom touchscreen in ES to prevent focus stealing

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
@@ -51,8 +51,9 @@ esac
 if [ "${IS_VERTICAL}" = "true" ]; then
     if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
         # Needs two separate swaymsg calls. Screen cannot move and have windows moved to it in the same line.
-        swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 pos 340 1080'
+        swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 power on pos 340 1080'
         swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 1240 2160, move to output DSI-2, move absolute position 340 0'
+        swaymsg 'input "0:0:bottom_touchscreen" events enabled'
     elif [ "${QUIRK_DEVICE}" = "AYN Thor Lite" ]; then
         # Same notes from above apply here.
         swaymsg '[title="RetroArch.*"] output DSI-1 pos 0 0, output DSI-2 power on pos 340 1080'
@@ -114,6 +115,9 @@ elif [ "${DEVICE_HAS_DUAL_SCREEN}" = "true" ] && [ "${EXTERNAL_DISPLAY_CONNECTED
                 OUTPUT="DSI-2"
                 swaymsg output ${OUTPUT} transform 270
                 ;;
+            "AYN Thor")
+                OUTPUT="DSI-1"
+                swaymsg input "0:0:bottom_touchscreen" events enabled ;;
             "AYN Thor Lite")
                 OUTPUT="DSI-2" ;;
             *)

--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -157,10 +157,13 @@ fi
 
 # AYN Thor touchscreen setup
 if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
+  echo "output ${second_con} power off" >> $SWAY_HOME/config
+  echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' power on' >> $SWAY_HOME/config
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
-  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}" >> $SWAY_HOME/config
+  echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} power off" >> $SWAY_HOME/config
   echo 'exec_always swaymsg input "0:0:top_touchscreen" map_to_output DSI-2' >> $SWAY_HOME/config
   echo 'exec_always swaymsg input "0:0:bottom_touchscreen" map_to_output DSI-1' >> $SWAY_HOME/config
+  echo 'exec_always swaymsg input "0:0:bottom_touchscreen" events disabled' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:top_touchscreen\"" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"0:0:bottom_touchscreen\"" >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' seat seat1 attach \"4660:22136:InputPlumber_Keyboard\"" >> $SWAY_HOME/config


### PR DESCRIPTION
## Summary

* Fixed an issue where the bottom touchscreen steals focus from es on return.

## Testing

* Tested on Thor(SM8550).

## Additional Context

* As I only have a Thor, changes were limited to that device.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
