### PR TITLE
SM8750: AYN Odin 3 - expose the two back paddles as gpio-keys

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0047-arm64-dts-qcom-Add-AYN-Odin3.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0047-arm64-dts-qcom-Add-AYN-Odin3.patch
@@ -4,10 +4,17 @@ Date: Wed, 15 Apr 2026 17:59:10 +0800
 Subject: [PATCH 54/54] arm64: dts: qcom: Add AYN Odin3
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
+[Anze: expose the two back paddles (M1 left / M2 right) as gpio-keys.
+They are plain active-low SoC TLMM GPIOs 3 / 7 (not on the gamepad MCU
+UART, not ADC), reverse-engineered from AYN's Android keydetect.ko
+(gpio_request 515/519 = TLMM base 512 + offsets 3/7). They emit
+BTN_Z / BTN_C - the codes AYN's own firmware uses and which the
+existing InputPlumber map (ayn_mcu.yaml) already routes to
+Left/RightPaddle1.]
 ---
  arch/arm64/boot/dts/qcom/Makefile             |   1 +
- .../arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts | 313 ++++++++++++++++++
- 2 files changed, 314 insertions(+)
+ .../arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts | 352 ++++++++++++++++++
+ 2 files changed, 353 insertions(+)
  create mode 100644 arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts
 
 diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
@@ -27,7 +34,7 @@ new file mode 100644
 index 000000000000..8d92b2c95158
 --- /dev/null
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts
-@@ -0,0 +1,313 @@
+@@ -0,0 +1,352 @@
 +// SPDX-License-Identifier: BSD-3-Clause
 +/*
 + * Copyright (c) 2026 Teguh Sobirin.
@@ -339,6 +346,45 @@ index 000000000000..8d92b2c95158
 +		function = "gpio";
 +		bias-pull-down;
 +		drive-strength = <2>;
++	};
++
++	paddle_keys_default: paddle-keys-default-state {
++		pins = "gpio3", "gpio7";
++		function = "gpio";
++		bias-pull-up;
++		drive-strength = <2>;
++	};
++};
++
++/*
++ * AYN Odin 3 has two extra back paddles (M1, M2) below the shoulder
++ * triggers. They are plain active-low SoC TLMM GPIOs (M1 = GPIO_3,
++ * M2 = GPIO_7), not on the gamepad MCU UART and not ADC (despite AYN's
++ * Android "adckey"/keydetect.ko naming). Expose them as a gpio-keys
++ * device emitting BTN_Z (M1, left) / BTN_C (M2, right); ROCKNIX's
++ * InputPlumber map (ayn_mcu.yaml) already routes BTN_Z -> LeftPaddle1 and
++ * BTN_C -> RightPaddle1. RE'd from the AYN Android keydetect driver
++ * (gpio_request 515/519 = TLMM base 512 + offsets 3/7).
++ */
++/ {
++	gpio-keys-paddles {
++		compatible = "gpio-keys";
++		pinctrl-names = "default";
++		pinctrl-0 = <&paddle_keys_default>;
++
++		key-paddle-m1 {
++			label = "Back Paddle M1";
++			linux,code = <BTN_Z>;
++			gpios = <&tlmm 3 GPIO_ACTIVE_LOW>;
++			debounce-interval = <15>;
++		};
++
++		key-paddle-m2 {
++			label = "Back Paddle M2";
++			linux,code = <BTN_C>;
++			gpios = <&tlmm 7 GPIO_ACTIVE_LOW>;
++			debounce-interval = <15>;
++		};
 +	};
 +};
 -- 


### PR DESCRIPTION
## Summary

* **Goal:** Make the AYN Odin 3's two back paddles (M1, M2) work. On stock ROCKNIX they emit nothing because there is no driver for them. This adds a `gpio-keys` node to the Odin 3 dts so they report buttons.
* They are not on the gamepad MCU UART (`rsinput`) and not ADC despite AYN's Android `adckey`/`keydetect.ko` naming — they are plain active-low SoC TLMM GPIOs: **M1 (left) = GPIO 3 → `BTN_Z`**, **M2 (right) = GPIO 7 → `BTN_C`** (TLMM base 512 + offsets 3/7, RE'd from AYN's `keydetect.ko`).
* `BTN_Z`/`BTN_C` are what AYN's firmware uses and what the existing `ayn_mcu.yaml` already maps to Left/RightPaddle1, so no InputPlumber change is needed.

## Testing

* Built and flashed on an AYN Odin 3.
* Both paddles produce clean press/release (`evtest`) with no chatter; left → `BTN_Z`, right → `BTN_C`. Pins verified UNCLAIMED before use.

## Additional Context

* Single additive patch, Odin 3 only — no other device affected.
* Pins referenced by TLMM offset (`<&tlmm 3>`, `<&tlmm 7>`), input + pull-up, 15ms debounce.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY — reverse-engineering and patch authoring assisted by AI; hardware findings verified on-device.