### PR TITLE
drastic: add lcd1x-nds-color shader (DS Phat display replication)

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
+++ b/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
@@ -305,14 +305,10 @@ static const char *FRAG_SHARP_SHIMMERLESS =
     "    gl_FragColor = SWIZ(texture2D(u_texture, mod_texel / u_texture_size));\n"
     "}\n";
 
-// lcd1x-nds-color: attempts to replicate the look and feel of a real DS Phat display.
-// Combines nearest-neighbour sampling (avoids blurring at the RG DS's non-integer 2.5x
-// NDS scale), a DS Phat colour correction matrix, a 2D LCD pixel grid, and a subtle
-// RGB subpixel column tint matching the DS Phat's RGB stripe layout.
-//
-// Colour correction matrix and gamma values adapted from jdgleaver/drastic_ds_shaders
-// (public domain). LCD grid structure inspired by LCD3X (already in this file).
-// RGB subpixel tint is an AI-assisted addition (Claude Code / Anthropic).
+// lcd1x-nds-color: nearest-neighbour base with DS Phat colour correction, 2D LCD pixel
+// grid (3-pixel period, 80% gap), and subtle RGB subpixel column tint.
+// Colour correction matrix adapted from jdgleaver/drastic_ds_shaders, itself derived
+// from hunterk/Pokefan531's nds-color.glsl (public domain).
 static const char *FRAG_LCD1X_NDS_COLOR =
     "precision mediump float;\n"
     "varying vec2 v_texcoord;\n"

--- a/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
+++ b/projects/ROCKNIX/packages/emulators/standalone/drastic-sa/sources/libdrastouch.c
@@ -69,6 +69,7 @@ static void (*p_glDisable)(GLenum) = NULL;
 #define SHADER_QUILEZ 3
 #define SHADER_SCANLINES 4
 #define SHADER_LCD3X 5
+#define SHADER_LCD1X_NDS_COLOR 6
 
 static int shader_mode = SHADER_NONE;
 static int gl_renderer_desktop = 0; // 1 when SDL uses "opengl" renderer (not "opengles2")
@@ -304,6 +305,41 @@ static const char *FRAG_SHARP_SHIMMERLESS =
     "    gl_FragColor = SWIZ(texture2D(u_texture, mod_texel / u_texture_size));\n"
     "}\n";
 
+// lcd1x-nds-color: attempts to replicate the look and feel of a real DS Phat display.
+// Combines nearest-neighbour sampling (avoids blurring at the RG DS's non-integer 2.5x
+// NDS scale), a DS Phat colour correction matrix, a 2D LCD pixel grid, and a subtle
+// RGB subpixel column tint matching the DS Phat's RGB stripe layout.
+//
+// Colour correction matrix and gamma values adapted from jdgleaver/drastic_ds_shaders
+// (public domain). LCD grid structure inspired by LCD3X (already in this file).
+// RGB subpixel tint is an AI-assisted addition (Claude Code / Anthropic).
+static const char *FRAG_LCD1X_NDS_COLOR =
+    "precision mediump float;\n"
+    "varying vec2 v_texcoord;\n"
+    "uniform sampler2D u_texture;\n"
+    "uniform vec2 u_texture_size;\n"
+    "void main() {\n"
+    "    vec2 uv = (floor(v_texcoord * u_texture_size) + 0.5) / u_texture_size;\n"
+    "    vec3 colour = pow(SWIZ(texture2D(u_texture, uv)).rgb, vec3(1.91));\n"
+    "    colour = clamp(colour * 0.89, 0.0, 1.0);\n"
+    "    colour = pow(\n"
+    "        mat3( 0.87,  0.10,  0.10,\n"
+    "              0.255, 0.645, 0.17,\n"
+    "             -0.125, 0.255, 0.73) * colour,\n"
+    "        vec3(1.0 / 1.91));\n"
+    "    float px = mod(floor(gl_FragCoord.x), 3.0);\n"
+    "    float py = mod(floor(gl_FragCoord.y), 3.0);\n"
+    "    float gap = mix(0.80, 1.0, step(1.0, px)) * mix(0.80, 1.0, step(1.0, py));\n"
+    "    colour *= gap;\n"
+    "    vec3 col_r = vec3(1.0,  0.90, 0.90);\n"
+    "    vec3 col_g = vec3(0.90, 1.0,  0.90);\n"
+    "    vec3 col_b = vec3(0.90, 0.90, 1.0 );\n"
+    "    vec3 subpx = mix(col_r, col_g, step(1.0, px));\n"
+    "    subpx = mix(subpx, col_b, step(2.0, px));\n"
+    "    colour *= subpx;\n"
+    "    gl_FragColor = vec4(colour, 1.0);\n"
+    "}\n";
+
 // Inigo Quilez smooth Hermite interpolation (smootherstep)
 static const char *FRAG_QUILEZ =
     "precision mediump float;\n"
@@ -389,6 +425,7 @@ static void init_shader_program(void) {
         case SHADER_QUILEZ:            frag = FRAG_QUILEZ;            break;
         case SHADER_SCANLINES:         frag = FRAG_SCANLINES;         break;
         case SHADER_LCD3X:             frag = FRAG_LCD3X;             break;
+        case SHADER_LCD1X_NDS_COLOR:   frag = FRAG_LCD1X_NDS_COLOR;   break;
         default:                       frag = FRAG_SHARP_BILINEAR;    break;
     }
     shader_program = make_gl_program(VERT_SRC, frag);
@@ -835,6 +872,8 @@ static void init(void) {
             shader_mode = SHADER_LCD3X;
         else if (strcmp(shader_str, "sharp-shimmerless") == 0)
             shader_mode = SHADER_SHARP_SHIMMERLESS;
+        else if (strcmp(shader_str, "lcd1x-nds-color") == 0)
+            shader_mode = SHADER_LCD1X_NDS_COLOR;
     }
 
     const char* threshold_str = getenv("DSHOOK_MIC_THRESH");

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -1816,6 +1816,7 @@
             <choice name="quilez" value="quilez" />
             <choice name="scanlines" value="scanlines" />
             <choice name="lcd3x" value="lcd3x" />
+            <choice name="lcd1x+nds-color" value="lcd1x-nds-color" />
           </feature>
         </features>
       </core>


### PR DESCRIPTION
## Summary

* Adds a new `lcd1x-nds-color` shader to the DraStic hook library (`libdrastouch.so`) that attempts to replicate the look and feel of a real DS Phat display. DraStic is the only viable NDS emulator on RK3566 hardware (melonDS performs poorly), making its shader system the only option for RG DS users — yet none of the existing shaders target NDS screen authenticity.
* Adds the corresponding `<choice>` entry to `es_features.cfg` so the shader is selectable from the EmulationStation per-system shader menu without manual config editing.
* The existing ROCKNIX DraStic shaders (bilinear, sharp-bilinear, scanlines, lcd3x, quilez) are generic — none attempt to replicate the specific look of an NDS screen. This shader fills that gap.
* Takes inspiration from [jdgleaver/drastic_ds_shaders `lcd1x+nds_color`](https://github.com/jdgleaver/drastic_ds_shaders), but those `.dsd`/`.dfx` files are Android-only and cannot be used on ROCKNIX. The shader was therefore reimplemented as GLSL embedded in `libdrastouch.c`, with colour correction coefficients adapted from the original (itself derived from hunterk/Pokefan531's `nds-color.glsl`, public domain) and two additional layers: a 2D LCD pixel grid and a subtle RGB subpixel column tint simulating the DS Phat's RGB stripe layout.

The shader stacks four layers:
1. **Nearest-neighbour sampling** — avoids blurring at the RG DS's non-integer 2.5× NDS scale (256×192 → 640×480)
2. **DS Phat colour correction** — gamma 1.91, luma 0.89, 3×3 matrix adapted from [jdgleaver/drastic_ds_shaders](https://github.com/jdgleaver/drastic_ds_shaders)
3. **2D LCD pixel grid** — 80% gap brightness, 3-pixel period chosen to align cleanly with the RG DS's 2.5× NDS scale
4. **RGB subpixel column tint** — subtle 0.90 off-channel tint per column, simulating the DS Phat's RGB stripe layout

## Testing

* Built with `aarch64-linux-gnu-gcc` and deployed via bind-mount on an **Anbernic RG DS (RK3566)** running ROCKNIX `nightly-20260628`
* Heavily tested in-game on **Castlevania: Dawn of Sorrow**, **Mario Kart DS**, and **Advance Wars: Dual Strike** — covering 2D-heavy, mixed 2D/3D, and flat sprite-based titles
* Shader selectable from ES menu via the new `es_features.cfg` entry; selection persists correctly in `system.cfg`
* All existing shaders introduced in #2910 are unaffected

## Additional Context

* The 3-pixel grid period aligns cleanly with the RG DS's 2.5× NDS scale — avoids the ragged appearance that scanline-style effects produce at non-integer scaling
* The colour correction values bring the output closer to the subdued, slightly desaturated look of the original DS Phat LCD — games feel more authentic to how they looked on real hardware rather than vivid and oversaturated.


## AI Usage

YES — the initial shader implementation, C integration, and most of this PR description was written with Claude Code (Anthropic) as an AI coding assistant. I then took over for real-device testing and hands-on fine-tuning of the shader output until the result matched what I was looking for.

