### PR TITLE
thor: enable bottom touchscreen when secondary window appears

### DIFF
--- a/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
+++ b/projects/ROCKNIX/packages/wayland/compositor/sway/autostart/111-sway-init
@@ -159,6 +159,7 @@ fi
 if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
   echo "output ${second_con} power off" >> $SWAY_HOME/config
   echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] output '"${second_con}"' power on' >> $SWAY_HOME/config
+  echo 'for_window [title=".*(Secondary|\[w2\]|Sub|Bottom|Screen 2|GamePad).*"] exec swaymsg input "0:0:bottom_touchscreen" events enabled' >> $SWAY_HOME/config
   echo 'for_window [app_id="emulationstation"] reload' >> $SWAY_HOME/config
   echo 'for_window [app_id="emulationstation"] exec "sleep 1 && swaymsg seat seat1 cursor press button1 && swaymsg seat seat1 cursor release button1"' >> $SWAY_HOME/config
   echo "exec_always swaymsg '[app_id=\"emulationstation\"]' focus output ${con}, output ${second_con} power off" >> $SWAY_HOME/config


### PR DESCRIPTION
## Summary

* enables bottom touchscreen input for standalone emulators (e.g. azahar) that bypass vertical-check.

## Testing

* Tested on Thor(SM8550).
* resolved https://github.com/ROCKNIX/distribution/pull/2936#issuecomment-4826223286

## Additional Context

* As I only have a Thor, changes were limited to that device.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
