### PR TITLE
thor: fix volume up by splitting AYN key into separate gpio-keys node

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-thor-controller.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-thor-controller.yaml
@@ -6,7 +6,7 @@ version: 1
 kind: CompositeDevice
 
 # Name of the composite device mapping
-name: AYN Layout
+name: AYN Thor Layout
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.
@@ -16,27 +16,7 @@ matches:
       sys_path: /sys/firmware/devicetree/base
       attributes:
         - name: model
-          value: AYN Odin 2
-  - udev:
-      sys_path: /sys/firmware/devicetree/base
-      attributes:
-        - name: model
-          value: AYN Odin 2 Mini
-  - udev:
-      sys_path: /sys/firmware/devicetree/base
-      attributes:
-        - name: model
-          value: AYN Odin 2 Portal
-  - udev:
-      sys_path: /sys/firmware/devicetree/base
-      attributes:
-        - name: model
-          value: Retroid Pocket 6
-  - udev:
-      sys_path: /sys/firmware/devicetree/base
-      attributes:
-        - name: model
-          value: Retroid Pocket 6 TOP-DPAD
+          value: AYN Thor
 
 # Only allow a single source device per composite device of this type.
 single_source: false
@@ -52,8 +32,8 @@ source_devices:
 
   - group: gamepad
     evdev:
-      name: gpio-keys
-      phys_path: gpio-keys/input0
+      name: gpio-keys-ayn
+      phys_path: gpio-keys-ayn/input0
       handler: event*
     capability_map_id: ayn_mcu
 

--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-thor.dts
@@ -13,10 +13,11 @@
 	qcom,msm-id = <603 0x20000>;
 	qcom,board-id = <0x1001f 0>;
 
-	gpio-keys {
+	gpio-keys-ayn {
 		compatible = "gpio-keys";
 
-		pinctrl-0 = <&volume_up_n &key_ayn_n>;
+		pinctrl-0 = <&key_ayn_n>;
+		pinctrl-names = "default";
 
 		key-ayn {
 			label = "AYN Key";


### PR DESCRIPTION
## Summary

* Fixed volume up key not working on AYN thor

## Testing

* Tested on Thor(SM8550).

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
