### PR TITLE
SM8250: add support for HDMI audio, and limit HDMI output resolution

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/linux/dts/qcom/sm8250-retroidpocket-common.dtsi
+++ b/projects/ROCKNIX/devices/SM8250/linux/dts/qcom/sm8250-retroidpocket-common.dtsi
@@ -836,6 +836,7 @@
 
 &mdss_dp {
 	status = "okay";
+	#sound-dai-cells = <0>;
 };
 
 &mdss_dp_out {
@@ -1128,6 +1129,10 @@
 	dai@2 {
 		reg = <2>;
 	};
+
+	dai@3 {
+		reg = <3>;
+	};
 };
 
 &qupv3_id_0 {
@@ -1210,6 +1215,13 @@
 		};
 	};
 
+	mm4-dai-link {
+		link-name = "MultiMedia4";
+		cpu {
+			sound-dai = <&q6asmdai  MSM_FRONTEND_DAI_MULTIMEDIA4>;
+		};
+	};
+
 	wcd-playback-dai-link {
 		link-name = "WCD Playback";
 		cpu {
@@ -1245,6 +1257,19 @@
 
 		codec {
 			sound-dai = <&wcd938x 1>, <&swr2 0>, <&txmacro 0>;
+		};
+		platform {
+			sound-dai = <&q6routing>;
+		};
+	};
+
+	displayport-dai-link {
+		link-name = "DisplayPort Playback";
+		cpu {
+			sound-dai = <&q6afedai DISPLAY_PORT_RX>;
+		};
+		codec {
+			sound-dai = <&mdss_dp>;
 		};
 		platform {
 			sound-dai = <&q6routing>;

--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0017-drm-display-add-hw_params-callback-to-hdmi-audio-ops.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0017-drm-display-add-hw_params-callback-to-hdmi-audio-ops.patch
@@ -1,0 +1,11 @@
+diff --git a/drivers/gpu/drm/display/drm_hdmi_audio_helper.c b/drivers/gpu/drm/display/drm_hdmi_audio_helper.c
+--- a/drivers/gpu/drm/display/drm_hdmi_audio_helper.c
++++ b/drivers/gpu/drm/display/drm_hdmi_audio_helper.c
+@@ -130,6 +130,7 @@ EXPORT_SYMBOL(drm_connector_hdmi_audio_plugged_notify);
+
+ static const struct hdmi_codec_ops drm_connector_hdmi_audio_ops = {
+ 	.audio_startup = drm_connector_hdmi_audio_startup,
++	.hw_params = drm_connector_hdmi_audio_prepare,
+ 	.prepare = drm_connector_hdmi_audio_prepare,
+ 	.audio_shutdown = drm_connector_hdmi_audio_shutdown,
+ 	.mute_stream = drm_connector_hdmi_audio_mute_stream,

--- a/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8250/0004_Add-HDMI-DisplayPort-audio-device.patch
+++ b/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8250/0004_Add-HDMI-DisplayPort-audio-device.patch
@@ -1,0 +1,45 @@
+--- /dev/null
++++ b/ucm2/Qualcomm/sm8250/HDMI-RP.conf
+@@ -0,0 +1,28 @@
++# HDMI / DisplayPort output for Retroid Pocket SM8250.
++# Separate verb so an unconnected/unrouted DP PCM never poisons the HiFi card.
++
++SectionVerb {
++	EnableSequence [
++		cset "name='DISPLAY_PORT_RX Audio Mixer MultiMedia4' 1"
++	]
++
++	DisableSequence [
++		cset "name='DISPLAY_PORT_RX Audio Mixer MultiMedia4' 0"
++	]
++
++	Value {
++		TQ "HiFi"
++	}
++}
++
++SectionDevice."HDMI" {
++	Comment "HDMI / DisplayPort Audio (USB-C)"
++
++	Value {
++		PlaybackPCM "hw:${CardId},3"
++		PlaybackPriority 100
++		PlaybackChannels 2
++		PlaybackRate 48000
++		JackControl "DP0 Jack"
++	}
++}
+--- a/ucm2/Qualcomm/sm8250/RetroidPocket.conf
++++ b/ucm2/Qualcomm/sm8250/RetroidPocket.conf
+@@ -5,6 +5,11 @@
+ 	Comment "HiFi quality Music."
+ }
+ 
++SectionUseCase."HDMI" {
++	File "/Qualcomm/sm8250/HDMI-RP.conf"
++	Comment "HDMI / DisplayPort Output."
++}
++
+ BootSequence [
+ 	cset "name='WSA_RX0 Digital Volume' 120"
+ 	cset "name='WSA_RX1 Digital Volume' 120"

--- a/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/output_monitor
+++ b/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/output_monitor
@@ -30,6 +30,37 @@ _get_all_internals() {
     wlr-randr 2>/dev/null | awk '/^(DSI|eDP|LVDS)-/ { print $1 }'
 }
 
+_wp_audio_card() {
+    wpctl status 2>/dev/null | awk -F'[.[:space:]]+' '
+        /\[alsa\]/ { for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) { print $i; exit } }'
+}
+
+_wp_profile_index() {
+    pw-cli enum-params "$1" EnumProfile 2>/dev/null | awk -v want="$2" '
+        /Param:Profile:index/ { getline; idx = $2 }
+        /Param:Profile:name/  { getline; gsub(/"/, "", $2); if ($2 == want) { print idx; exit } }'
+}
+
+_switch_audio() {
+    local card target i
+    card=$(_wp_audio_card); [ -n "$card" ] || return 0
+    if [ "$1" = "external" ]; then
+        target=$(_wp_profile_index "$card" "HDMI")
+        if [ -z "$target" ]; then
+            systemctl restart wireplumber 2>/dev/null || true
+            for i in $(seq 1 20); do
+                sleep 0.5
+                card=$(_wp_audio_card)
+                [ -n "$card" ] && target=$(_wp_profile_index "$card" "HDMI")
+                [ -n "$target" ] && break
+            done
+        fi
+    else
+        target=$(_wp_profile_index "$card" "HiFi")
+    fi
+    [ -n "$card" ] && [ -n "$target" ] && wpctl set-profile "$card" "$target" 2>/dev/null || true
+}
+
 _apply() {
     local state="internal"
     [ -n "$(_get_active_externals)" ] && state="external"
@@ -44,16 +75,20 @@ _apply() {
             wlr-randr --output "$out" --off 2>/dev/null
         done < <(_get_all_internals)
         if [ -n "$ext_out" ]; then
+            wlr-randr --output "$ext_out" --mode 1920x1080@60 2>/dev/null \
+                || wlr-randr --output "$ext_out" --mode 1920x1080 2>/dev/null || true
             swaymsg "[app_id=\"emulationstation\"] move output ${ext_out}" 2>/dev/null || true
         fi
         # Stop USB gadget: its data lanes conflict with DP Alt Mode on RK3576
         systemctl is-active --quiet usbgadget && systemctl stop usbgadget
+        _switch_audio external
     else
         # Only re-enable internal panels on actual disconnect, not first-boot
         if [ "$prev" != "init" ]; then
             while IFS= read -r out; do
                 wlr-randr --output "$out" --preferred --on 2>/dev/null
             done < <(_get_all_internals)
+            _switch_audio internal
         fi
     fi
 


### PR DESCRIPTION
this commit adds the plumbing for HDMI audio output on the SM8250, but also introduces two side effects for all chipsets: setting the output resolution on HDMI to 1080p@60hz, and restarting wireplumber when connecting and disconnecting HDMI

## Summary

This pull request implements support for HDMI audio on the SM8250 device(s).

## Testing

Tested on Retroid Pocket Flip 2, not tested on other SM8250 hardware (or other chipsets). Also note I had to revert the previous commit to build successfully.


## Additional Context

Introduces changes to output-monitor which have implications for other chipsets:
When HDMI with audio support is plugged/unplugged, the wireplumber service is restarted, introducing a delay in audio switching (presumably, on devices where HDMI audio is already supported). It also sets the requested resolution to 1080p60hz - this might not be desired on other chipsets, but was required to achieve usable HDMI out on my device.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES 
