### PR TITLE
sm8650: update sdhc_2 regulators

### DIFF
--- a/projects/ROCKNIX/devices/SM8650/linux/dts/qcom/sm8650-ayaneo-common.dtsi
+++ b/projects/ROCKNIX/devices/SM8650/linux/dts/qcom/sm8650-ayaneo-common.dtsi
@@ -483,7 +483,7 @@
 		vreg_l8b_1p8: ldo8 {
 			regulator-name = "vreg_l8b_1p8";
 			regulator-min-microvolt = <1800000>;
-			regulator-max-microvolt = <2960000>;
+			regulator-max-microvolt = <3008000>;
 			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
 			regulator-allow-set-load;
 			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
@@ -492,8 +492,8 @@
 
 		vreg_l9b_2p9: ldo9 {
 			regulator-name = "vreg_l9b_2p9";
-			regulator-min-microvolt = <2950000>;
-			regulator-max-microvolt = <2960000>;
+			regulator-min-microvolt = <2960000>;
+			regulator-max-microvolt = <3008000>;
 			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
 			regulator-allow-set-load;
 			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM


### PR DESCRIPTION
### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
