### PR TITLE
sm8650: restore Pocket Fit touchscreen

### DIFF
--- a/projects/ROCKNIX/devices/SM8650/options
+++ b/projects/ROCKNIX/devices/SM8650/options
@@ -45,8 +45,7 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    #ADDITIONAL_DRIVERS="chipone_tddi"
-    ADDITIONAL_DRIVERS=""
+    ADDITIONAL_DRIVERS="chipone_tddi"
 
   # Additional Firmware to use ( )
   # Space separated list is supported,

--- a/projects/ROCKNIX/packages/linux-drivers/chipone_tddi/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/chipone_tddi/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="chipone_tddi"
-PKG_VERSION="ad4e075903c0c02728d22c3e87cc9f9e9a53be43"
+PKG_VERSION="af27029fa2b27c4a77d16809298ed5d03c9da5a6"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/kevinkreiser/chipone_tddi"
+PKG_SITE="https://github.com/ROCKNIX/chipone_tddi"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="chipone_tddi: ChipOne ICNL9922C TDDI touchscreen driver (KONKR Pocket FIT)"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
