### PR TITLE
azahar-sa: fix on Mali platforms

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/azahar-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/azahar-sa/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="azahar-sa"
-PKG_VERSION="308a9b14eaea1e484fa83f9e9eb6c68ca2bfc064" # tag 2125.1.2
+PKG_VERSION="b42d0916ba9799297ae0e27c07d56801da1b5de5" # tag 2125.1.3
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/azahar-emu/azahar"
 PKG_URL="${PKG_SITE}.git"
@@ -27,18 +27,19 @@ if [ "${VULKAN_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${VULKAN}"
 fi
 
-TARGET_CXXFLAGS+=-fpch-preprocess
-
 PKG_CMAKE_OPTS_TARGET+="-DENABLE_OPENGL=ON \
-                        -DENABLE_QT_TRANSLATION=OFF \
                         -DENABLE_QT=ON \
+                        -DENABLE_QT_TRANSLATION=OFF \
                         -DENABLE_ROOM=OFF \
-                        -DENABLE_SDL2_FRONTEND=OFF \
                         -DENABLE_SDL2=ON \
                         -DENABLE_TESTS=OFF \
                         -DENABLE_VULKAN=ON \
-                        -DUSE_DISCORD_PRESENCE=OFF \
-                        -DUSE_SYSTEM_SDL2=ON"
+                        -DUSE_DISCORD_PRESENCE=OFF"
+
+pre_configure_target() {
+  export CXXFLAGS+=-fpch-preprocess
+  export CFLAGS="${CFLAGS} -Wno-error=incompatible-pointer-types"
+}
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin

--- a/projects/ROCKNIX/packages/graphics/qt6/package.mk
+++ b/projects/ROCKNIX/packages/graphics/qt6/package.mk
@@ -11,6 +11,12 @@ PKG_DEPENDS_TARGET="toolchain qt6:host openssl libjpeg-turbo libpng pcre2 sqlite
 PKG_DEPENDS_HOST="gcc:host llvm:host mesa:host"
 PKG_LONGDESC="A cross-platform application and UI framework"
 
+# Mali devices require pinning to v6.8.3 or azahar-sa will segfault
+if [[ "${DEVICE}" =~ RK3566|RK3576|RK3588|S922X ]]; then
+  PKG_VERSION_MAJOR="6.8"
+  PKG_VERSION="${PKG_VERSION_MAJOR}.3"
+fi
+
 # Apply project-specific patches
 PKG_PATCH_DIRS="${PROJECT}"
 

--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -44,7 +44,7 @@ case "${DEVICE}" in
   RK3566|RK3576)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 desmume-lr gpsp-lr pcsx_rearmed-lr"
     PKG_DEPENDS_TARGET+=" common-shaders glsl-shaders"
-    PKG_EMUS+=" aethersx2-sa azahar-sa dolphin-sa drastic-sa mednafen melonds-sa vita3k-sa pcsx2-sa"
+    PKG_EMUS+=" aethersx2-sa azahar-sa dolphin-sa drastic-sa mednafen melonds-sa vita3k-sa"
     LIBRETRO_CORES+=" dolphin-lr"
     ;;
   RK3588|SM6115)
@@ -1136,7 +1136,7 @@ makeinstall_target() {
       add_emu_core ps2 aethersx2 aethersx2-sa true
 
       case ${DEVICE} in
-        SM8250|SM8550|SM8650|SM8750|RK3566|RK3576)
+        SM8250|SM8550|SM8650|SM8750)
           add_emu_core ps2 pcsx2 pcsx2-sa false
           install_script "Start PCSX2.sh"
         ;;


### PR DESCRIPTION
## Summary

Fix `azahar-sa` on Mali platforms

## Testing

Tested on my Odin 2 (SM8550) and Odroid Go Ultra (S922X)

## Additional Context

`pcsx2-sa` requires `qt6@6.10.1`, but `azahar-sa` will segfault with this version with Mali devices. Have to version `qt6` package per platform and remove `pcsx2-sa` from RK3566 / RK3576 (`azahar-sa` is preferred vs `pcsx2-sa` on those platforms).

---

### AI Usage

**Did you use AI tools to help write this code?** NO
