### PR TITLE
librga: switch to JeffyCN linux-rga-multi RGA source

### DIFF
--- a/projects/ROCKNIX/packages/graphics/librga/package.mk
+++ b/projects/ROCKNIX/packages/graphics/librga/package.mk
@@ -2,11 +2,13 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="librga"
-PKG_VERSION="ccfec13d6c48e3f0c7f24810b3dac162c40cdda8"
+PKG_VERSION="57a1067a246c71fa6c9a355d1668884fda155dd5"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="Apache-2.0"
 PKG_DEPENDS_TARGET="toolchain libdrm"
-PKG_SITE="https://github.com/varphone/rockchip-linux-rga"
+PKG_SITE="https://github.com/JeffyCN/mirrors"
 PKG_URL="${PKG_SITE}.git"
+PKG_GIT_CLONE_BRANCH="linux-rga-multi"
+PKG_GIT_CLONE_SINGLE="yes"
 PKG_LONGDESC="RGA is an independent 2D hardware acceleration userspace driver"
 PKG_TOOLCHAIN="meson"


### PR DESCRIPTION
## Summary

This bumps `librga` from `1.3.1` to `1.10.5`

## Testing

Tested exclusively on RG Vita Pro

## Additional Context

Noticed that we're using a pretty old version of librga whilst I was experimenting with hardware scaling & rotation, so I bumped it for my experiments

---

### AI Usage

NO