### PR TITLE
scripts/get_git: clean cached submodule dir on retry

### DIFF
--- a/scripts/get_git
+++ b/scripts/get_git
@@ -78,6 +78,9 @@ _update_submodules() {
       echo "Syncing submodule: $submodule"
       git submodule sync -- "${submodule}"
 
+      echo "Removing cached submodule git dir: $submodule"
+      rm -rf ".git/modules/${submodule}" "${submodule}"
+
       echo "Reinitializing submodule: $submodule"
       git submodule update --init --recursive ${GIT_SUBMODULE_PARAMS} -- "${submodule}"
       _rv=$?


### PR DESCRIPTION
## Summary

Cloning a submodule whose pinned commit is not the tip of its default branch leaves a shallow git dir with `--shallow-submodules` that ends up breaking fetches of that commit (git fails with 'upload-pack: not our ref').

Removing the cached .git/modules entry and the directory before reinit performs a clean full clone that resolves the pinned commit

## Testing

I encountered this 'upload-pack: not our ref' when experimenting with gamescope, which pins wlroots to a commit on a non-default branch - I was deleting the cached .git/modules/ directory over and over and I figured if it's in this Failed branch it's safe to delete `.git/modules/${submodule}`

## Additional Context

It could be that I suck at git and got into this broken state myself, but it was consistent when I was messing around with gamescope

---

### AI Usage

NO