### PR TITLE
linux-drivers: add rga3 Rockchip multi-RGA driver

### DIFF
--- a/packages/linux-drivers/rga3/package.mk
+++ b/packages/linux-drivers/rga3/package.mk
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="rga3"
+# Pristine mirror of drivers/video/rockchip/rga3 (Rockchip BSP kernel); the
+# mainline port + RK3576 enablement are applied from patches/.
+PKG_VERSION="23e78a0b080603376409d7c8e6af925162b5b617"
+PKG_SITE="https://github.com/rockchip-linux/kernel"
+PKG_URL="https://github.com/felixjones/linux-rga3-mirror.git"
+PKG_LICENSE="GPL-2.0"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_LONGDESC="Rockchip multi-RGA (RGA2/RGA2E/RGA3) 2D accelerator driver. RK3576 uses a mainline kernel with no in-tree multi-RGA driver (only the older V4L2 rockchip-rga), so build the BSP driver out-of-tree to provide the /dev/rga miscdevice that librga consumers use."
+PKG_TOOLCHAIN="manual"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  kernel_make -C $(kernel_path) M="${PKG_BUILD}" modules
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+  cp ${PKG_BUILD}/rga3.ko ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+  # No MODULE_DEVICE_TABLE, so udev can't autoload it from a DT modalias.
+  mkdir -p ${INSTALL}/usr/lib/modules-load.d
+  echo "rga3" > ${INSTALL}/usr/lib/modules-load.d/rga3.conf
+}

--- a/packages/linux-drivers/rga3/patches/0001-rga3-build-as-an-out-of-tree-module.patch
+++ b/packages/linux-drivers/rga3/patches/0001-rga3-build-as-an-out-of-tree-module.patch
@@ -1,0 +1,28 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] rga3: build as an out-of-tree module
+
+The BSP ships an in-tree Kbuild (obj-$(CONFIG_ROCKCHIP_MULTI_RGA)). ROCKNIX
+builds this driver out-of-tree against a mainline kernel that has no such
+Kconfig symbol, so use a plain obj-m Makefile and a module-relative include
+path.
+
+diff --git a/Makefile b/Makefile
+index 11f401d..a929e0c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+-
+-ccflags-y += -I$(srctree)/$(src)/include
+-
+-rga3-y	:= rga_drv.o rga_common.o rga3_reg_info.o rga_iommu.o rga_dma_buf.o rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o
+-rga3-$(CONFIG_ROCKCHIP_RGA_ASYNC) += rga_fence.o
+-rga3-$(CONFIG_ROCKCHIP_RGA_DEBUGGER) += rga_debugger.o
+-
+-obj-$(CONFIG_ROCKCHIP_MULTI_RGA)	+= rga3.o
++# ROCKNIX: out-of-tree build of the Rockchip multi-RGA (rga3) driver.
++ccflags-y += -I$(src)/include
++obj-m += rga3.o
++rga3-y := rga_drv.o rga_common.o rga3_reg_info.o rga_iommu.o rga_dma_buf.o \
++          rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o

--- a/packages/linux-drivers/rga3/patches/0002-rga3-port-to-the-mainline-kernel-API.patch
+++ b/packages/linux-drivers/rga3/patches/0002-rga3-port-to-the-mainline-kernel-API.patch
@@ -1,0 +1,152 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] rga3: port to the mainline kernel API
+
+Adapt the Rockchip BSP (develop-6.1) driver to build against the mainline
+kernel ROCKNIX uses:
+
+ * dma-buf: mainline has no CONFIG_DMABUF_CACHE / <linux/dma-buf-cache.h>;
+   include <linux/dma-buf.h>.
+ * hrtimer: hrtimer_init() + assigning .function was replaced by
+   hrtimer_setup(timer, fn, ...).
+ * MODULE_IMPORT_NS() now takes a string literal.
+ * rga_get_user_pages_from_vma() manually walked the page tables with
+   pte_offset_map_lock() to pin raw VM_PFNMAP pointers; those helpers are no
+   longer exported to modules. This out-of-tree build only uses the dma-buf /
+   get_user_pages import paths, so stub the manual-walk fallback.
+
+diff --git a/include/rga_drv.h b/include/rga_drv.h
+index 1e9cbd5..aab9fe9 100644
+--- a/include/rga_drv.h
++++ b/include/rga_drv.h
+@@ -53,7 +53,7 @@
+ #include <linux/pagemap.h>
+ 
+ #ifdef CONFIG_DMABUF_CACHE
+-#include <linux/dma-buf-cache.h>
++#include <linux/dma-buf.h> /* ROCKNIX: was dma-buf-cache.h (BSP-only) */
+ #else
+ #include <linux/dma-buf.h>
+ #endif
+diff --git a/rga_drv.c b/rga_drv.c
+index 8a270a7..0e55302 100644
+--- a/rga_drv.c
++++ b/rga_drv.c
+@@ -370,9 +370,8 @@ static enum hrtimer_restart hrtimer_handler(struct hrtimer *timer)
+ static void rga_init_timer(void)
+ {
+ 	kt = ktime_set(0, RGA_TIMER_INTERVAL_NS);
+-	hrtimer_init(&timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+-
+-	timer.function = hrtimer_handler;
++	/* ROCKNIX: mainline replaced hrtimer_init()+.function with hrtimer_setup() */
++	hrtimer_setup(&timer, hrtimer_handler, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+ 
+ 	hrtimer_start(&timer, kt, HRTIMER_MODE_REL);
+ }
+@@ -1721,6 +1720,6 @@ MODULE_AUTHOR("putin.li@rock-chips.com");
+ MODULE_DESCRIPTION("Driver for rga device");
+ MODULE_LICENSE("GPL");
+ #ifdef MODULE_IMPORT_NS
+-MODULE_IMPORT_NS(DMA_BUF);
+-MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
++MODULE_IMPORT_NS("DMA_BUF");
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
+ #endif
+diff --git a/rga_mm.c b/rga_mm.c
+index c497ec3..8ad4b8f 100644
+--- a/rga_mm.c
++++ b/rga_mm.c
+@@ -33,82 +33,17 @@ static void rga_current_mm_read_unlock(struct mm_struct *mm)
+ }
+ 
+ static int rga_get_user_pages_from_vma(struct page **pages, unsigned long Memory,
+-				       uint32_t pageCount, struct mm_struct *current_mm)
++       uint32_t pageCount, struct mm_struct *current_mm)
+ {
+-	int ret = 0;
+-	int i;
+-	struct vm_area_struct *vma;
+-	spinlock_t *ptl;
+-	pte_t *pte;
+-	pgd_t *pgd;
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+-	p4d_t *p4d;
+-#endif
+-	pud_t *pud;
+-	pmd_t *pmd;
+-	unsigned long pfn;
+-
+-	for (i = 0; i < pageCount; i++) {
+-		vma = find_vma(current_mm, (Memory + i) << PAGE_SHIFT);
+-		if (!vma) {
+-			rga_err("page[%d] failed to get vma\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-
+-		pgd = pgd_offset(current_mm, (Memory + i) << PAGE_SHIFT);
+-		if (pgd_none(*pgd) || unlikely(pgd_bad(*pgd))) {
+-			rga_err("page[%d] failed to get pgd\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+-		/*
+-		 * In the four-level page table,
+-		 * it will do nothing and return pgd.
+-		 */
+-		p4d = p4d_offset(pgd, (Memory + i) << PAGE_SHIFT);
+-		if (p4d_none(*p4d) || unlikely(p4d_bad(*p4d))) {
+-			rga_err("page[%d] failed to get p4d\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-
+-		pud = pud_offset(p4d, (Memory + i) << PAGE_SHIFT);
+-#else
+-		pud = pud_offset(pgd, (Memory + i) << PAGE_SHIFT);
+-#endif
+-
+-		if (pud_none(*pud) || unlikely(pud_bad(*pud))) {
+-			rga_err("page[%d] failed to get pud\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-		pmd = pmd_offset(pud, (Memory + i) << PAGE_SHIFT);
+-		if (pmd_none(*pmd) || unlikely(pmd_bad(*pmd))) {
+-			rga_err("page[%d] failed to get pmd\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-		pte = pte_offset_map_lock(current_mm, pmd,
+-					  (Memory + i) << PAGE_SHIFT, &ptl);
+-		if (pte_none(*pte)) {
+-			rga_err("page[%d] failed to get pte\n", i);
+-			pte_unmap_unlock(pte, ptl);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-
+-		pfn = pte_pfn(*pte);
+-		pages[i] = pfn_to_page(pfn);
+-		pte_unmap_unlock(pte, ptl);
+-	}
+-
+-	if (ret == RGA_OUT_OF_RESOURCES && i > 0)
+-		rga_err("Only get buffer %d byte from vma, but current image required %d byte",
+-			(int)(i * PAGE_SIZE), (int)(pageCount * PAGE_SIZE));
+-
+-	return ret;
++/*
++ * ROCKNIX: the original BSP fallback manually walked the page tables via
++ * pte_offset_map_lock() to pin raw VM_PFNMAP user pointers that
++ * get_user_pages() cannot. On mainline the pte map helpers are not
++ * exported to modules, and this out-of-tree build only uses the dma-buf /
++ * get_user_pages paths, so the manual-walk fallback is disabled.
++ */
++(void)pages; (void)Memory; (void)pageCount; (void)current_mm;
++return RGA_OUT_OF_RESOURCES;
+ }
+ 
+ static int rga_get_user_pages(struct page **pages, unsigned long Memory,

--- a/packages/linux-drivers/rga3/patches/0003-rga3-run-the-RK3576-RGA2-Pro-in-IOMMU-mode.patch
+++ b/packages/linux-drivers/rga3/patches/0003-rga3-run-the-RK3576-RGA2-Pro-in-IOMMU-mode.patch
@@ -1,0 +1,23 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] rga3: run the RK3576 RGA2-Pro in IOMMU mode
+
+The RK3576 RGA (hw_version 3.e.19357) maps to rga2p_iommu_data. Each RGA2-Pro
+core has an embedded 40-bit rockchip iommu-v2 MMU (described in the RK3576
+dtsi), so select RGA_IOMMU: this lets the engine operate on non-contiguous
+dma-buf (GPU) memory directly instead of only physically-contiguous CMA.
+
+diff --git a/rga_hw_config.c b/rga_hw_config.c
+index 581693e..1b3c753 100644
+--- a/rga_hw_config.c
++++ b/rga_hw_config.c
+@@ -724,6 +724,9 @@ const struct rga_hw_data rga2p_iommu_data = {
+ 			RGA_MODE_CSC_BT709,
+ 	.csc_y2r_mode = RGA_MODE_CSC_BT601L | RGA_MODE_CSC_BT601F |
+ 			RGA_MODE_CSC_BT709,
++	/* ROCKNIX: RK3576 RGA (ver 3.e.19357 -> rga2p_iommu_data). The RGA2-Pro
++	 * embeds a 40-bit rockchip iommu-v2 MMU (DT: rga2_core{0,1}_mmu). RGA_IOMMU lets
++	 * it rotate non-contiguous dma-buf (GPU) memory directly, not just CMA. */
+ 	.mmu = RGA_IOMMU,
+ 
+ 	.cmd_reg_size = 32, //0x100:0x17c

--- a/packages/linux-drivers/rga3/patches/0004-rga3-enable-async-fence-mode.patch
+++ b/packages/linux-drivers/rga3/patches/0004-rga3-enable-async-fence-mode.patch
@@ -1,0 +1,26 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Mon, 6 Jul 2026 23:18:40 +0200
+Subject: [PATCH] rga3: enable asynchronous fence mode
+
+The out-of-tree Makefile dropped the config-gated async objects, so the driver
+was built without rga_fence.o and rejects RGA_BLIT_ASYNC ("The current driver
+does not support asynchronous mode, please enable CONFIG_ROCKCHIP_RGA_ASYNC").
+
+Build rga_fence.o and define CONFIG_ROCKCHIP_RGA_ASYNC so the driver returns a
+release fence for non-blocking blits, letting a client overlap the blit with
+other work instead of blocking on completion. RK3588 already enables this
+option.
+
+diff --git a/Makefile b/Makefile
+index a929e0c..575f35c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ # ROCKNIX: out-of-tree build of the Rockchip multi-RGA (rga3) driver.
+-ccflags-y += -I$(src)/include
++ccflags-y += -I$(src)/include -DCONFIG_ROCKCHIP_RGA_ASYNC=1
+ obj-m += rga3.o
+ rga3-y := rga_drv.o rga_common.o rga3_reg_info.o rga_iommu.o rga_dma_buf.o \
+-          rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o
++          rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o rga_fence.o

--- a/projects/ROCKNIX/devices/RK3576/options
+++ b/projects/ROCKNIX/devices/RK3576/options
@@ -62,7 +62,8 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="mali-bifrost"
+  # rga3: Rockchip multi-RGA 2D accelerator.
+    ADDITIONAL_DRIVERS="mali-bifrost rga3"
 
   # Additional Firmware to use ( )
   # Space separated list is supported,

--- a/projects/ROCKNIX/devices/RK3576/patches/linux/0019-arm64-dts-rockchip-rk3576-add-rga2-iommu-nodes.patch
+++ b/projects/ROCKNIX/devices/RK3576/patches/linux/0019-arm64-dts-rockchip-rk3576-add-rga2-iommu-nodes.patch
@@ -1,0 +1,95 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] arm64: dts: rockchip: rk3576: add RGA2 nodes with IOMMU for
+ hardware rotation
+
+The RK3576 has two RGA2-Pro cores (reported hw_version 3.e.19357) at
+0x27920000 and 0x27930000. Mainline does not describe them. Add the two
+rga@ nodes so the rockchip multi-RGA driver (packages/linux-drivers/rga3)
+can bind and expose /dev/rga for hardware-accelerated rotate/scale/blit
+(used to rotate the gamescope output for the 90deg-mounted panel in
+hardware, instead of on the GPU compute composite).
+
+Each RGA2-Pro core has an embedded 40-bit rockchip iommu-v2 MMU at
+core_base + 0xf00, with a register block identical to the standalone
+rk3568/rk3576 iommu. Describe each as a rockchip,rk3576-iommu node and
+wire it to its core via the iommus property, so the rga3 driver runs in
+RGA_IOMMU mode and can rotate non-contiguous (GPU/dma-buf) memory -- not
+just physically-contiguous CMA. The mainline rockchip-iommu driver
+already provides the v2 (40-bit) ops via the rockchip,rk3568-iommu match
+(used by vop_mmu/vdec_mmu on this SoC).
+
+Notes:
+ * The core reg is shrunk from 0x1000 to 0xf00 so the mmu node owns the
+   MMU register page (0xf00-0xfff) without overlapping the core mapping.
+ * The MMU shares the core's GIC SPI (328/329); both rga3 and rk_iommu
+   request it with IRQF_SHARED, so the shared line is fine.
+ * Pairs with the rga3 driver change setting rga2p_iommu_data.mmu =
+   RGA_IOMMU (packages/linux-drivers/rga3, patch 0003).
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+index 58f2215..9b493c6 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+@@ -1279,6 +1279,61 @@
+ 			status = "disabled";
+ 		};
+ 
++			/* ROCKNIX: RGA2E 2D accelerator (two cores) for hardware rotation.
++			 * Each RGA2-Pro core has an embedded 40-bit rockchip iommu-v2 MMU at
++			 * core_base + 0xf00 (register block identical to the standalone
++			 * rk3568/rk3576 iommu). The core reg is shrunk to 0xf00 so the mmu
++			 * node owns the MMU page. The MMU shares the core GIC SPI (both the
++			 * rga3 and rk_iommu drivers request it IRQF_SHARED). Requires the rga3
++			 * driver hw_data rga2p_iommu_data.mmu = RGA_IOMMU. */
++			rga2_core0: rga@27920000 {
++				compatible = "rockchip,rga2";
++				reg = <0x0 0x27920000 0x0 0xf00>;
++				interrupts = <GIC_SPI 328 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_core0_irq";
++				clocks = <&cru ACLK_RGA2E_0>, <&cru HCLK_RGA2E_0>, <&cru CLK_CORE_RGA2E_0>;
++				clock-names = "aclk_rga", "hclk_rga", "clk_rga";
++				power-domains = <&power RK3576_PD_VPU>;
++				iommus = <&rga2_core0_mmu>;
++				status = "okay";
++			};
++
++			rga2_core0_mmu: iommu@27920f00 {
++				compatible = "rockchip,rk3576-iommu", "rockchip,rk3568-iommu";
++				reg = <0x0 0x27920f00 0x0 0x100>;
++				interrupts = <GIC_SPI 328 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_0_mmu";
++				clocks = <&cru ACLK_RGA2E_0>, <&cru HCLK_RGA2E_0>;
++				clock-names = "aclk", "iface";
++				power-domains = <&power RK3576_PD_VPU>;
++				#iommu-cells = <0>;
++				status = "okay";
++			};
++
++			rga2_core1: rga@27930000 {
++				compatible = "rockchip,rga2";
++				reg = <0x0 0x27930000 0x0 0xf00>;
++				interrupts = <GIC_SPI 329 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_core1_irq";
++				clocks = <&cru ACLK_RGA2E_1>, <&cru HCLK_RGA2E_1>, <&cru CLK_CORE_RGA2E_1>;
++				clock-names = "aclk_rga", "hclk_rga", "clk_rga";
++				power-domains = <&power RK3576_PD_VPU>;
++				iommus = <&rga2_core1_mmu>;
++				status = "okay";
++			};
++
++			rga2_core1_mmu: iommu@27930f00 {
++				compatible = "rockchip,rk3576-iommu", "rockchip,rk3568-iommu";
++				reg = <0x0 0x27930f00 0x0 0x100>;
++				interrupts = <GIC_SPI 329 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_1_mmu";
++				clocks = <&cru ACLK_RGA2E_1>, <&cru HCLK_RGA2E_1>;
++				clock-names = "aclk", "iface";
++				power-domains = <&power RK3576_PD_VPU>;
++				#iommu-cells = <0>;
++				status = "okay";
++			};
++
+ 		vdec: video-codec@27b00000 {
+ 			compatible = "rockchip,rk3576-vdec";
+ 			reg = <0x0 0x27b00100 0x0 0x500>,

--- a/projects/ROCKNIX/packages/graphics/librga/package.mk
+++ b/projects/ROCKNIX/packages/graphics/librga/package.mk
@@ -2,11 +2,13 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="librga"
-PKG_VERSION="ccfec13d6c48e3f0c7f24810b3dac162c40cdda8"
+PKG_VERSION="57a1067a246c71fa6c9a355d1668884fda155dd5"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="Apache-2.0"
 PKG_DEPENDS_TARGET="toolchain libdrm"
-PKG_SITE="https://github.com/varphone/rockchip-linux-rga"
+PKG_SITE="https://github.com/JeffyCN/mirrors"
 PKG_URL="${PKG_SITE}.git"
+PKG_GIT_CLONE_BRANCH="linux-rga-multi"
+PKG_GIT_CLONE_SINGLE="yes"
 PKG_LONGDESC="RGA is an independent 2D hardware acceleration userspace driver"
 PKG_TOOLCHAIN="meson"


### PR DESCRIPTION
## Summary

Based on https://github.com/ROCKNIX/distribution/pull/2969

Ports rga3 driver from https://github.com/rockchip-linux/kernel to the latest kernel (hosted from a mirror https://github.com/felixjones/linux-rga3-mirror).

Developer guide for the rga3: https://github.com/sz-jack-01/linux-rga/blob/rkr3.5/docs/Rockchip_Developer_Guide_RGA_EN.md

This is another change from my gamescope experiments, rga3 has neat hardware rotation available, and AFBC 32x8 rotation with the RK3576 (where I'm getting gamescope working).

## Testing

I had patched this driver for my gamescope experiments, it's been tested over the past few weeks.

## Additional Context

Again, uses a mirror host here https://github.com/felixjones/linux-rga3-mirror for the rga3 driver

---

### AI Usage

NO
