### PR TITLE
gamescope: Vulkan Compositor without VK_EXT_robustness2

### DIFF
--- a/projects/ROCKNIX/packages/apps/gamescope/package.mk
+++ b/projects/ROCKNIX/packages/apps/gamescope/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="gamescope"
-PKG_VERSION="428688779e481681ddf6e2ea346987889527a0b7"
+PKG_VERSION="61c74c18af1aaa4a2593f73b409a0c22b9314db4"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="BSD-2-Clause"
 PKG_SITE="https://github.com/ValveSoftware/gamescope"

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0007-rendervulkan-composite-without-robustness2-mali.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0007-rendervulkan-composite-without-robustness2-mali.patch
@@ -1,0 +1,75 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: composite without VK_EXT_robustness2 on Mali
+
+gamescope unconditionally enables VK_EXT_robustness2 only to use its nullDescriptor feature, binding VK_NULL_HANDLE combined-image-sampler / storage-image descriptors to the composite slots it does not use (the unused ycbcr chroma target, unused layer/ycbcr sampler slots and absent colour-management LUTs). Mali drivers (libMali, PanVK) do not implement robustness2, so the device either cannot be created or faults in vkUpdateDescriptorSets on the first null descriptor, crashing the compositor whenever a client layer is presented. Stop requesting robustness2 and bind a valid blank texture view (plus the luma view for the unused chroma target) to those slots instead. The shader only samples bound layers, so the blanks are inert; this makes the compute composite work on Mali with no dependency on nullDescriptor.
+
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 0be72f6..95635bc 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -576,7 +576,6 @@ bool CVulkanDevice::createDevice()
+ 
+ 	enabledExtensions.push_back( VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME );
+ 
+-	enabledExtensions.push_back( VK_EXT_ROBUSTNESS_2_EXTENSION_NAME );
+ #if 0
+ 	enabledExtensions.push_back( VK_KHR_MAINTENANCE_5_EXTENSION_NAME );
+ #endif
+@@ -666,11 +665,6 @@ bool CVulkanDevice::createDevice()
+ 		.samplerYcbcrConversion = VK_TRUE,
+ 	};
+ 
+-	VkPhysicalDeviceRobustness2FeaturesEXT robustness2Features = {
+-		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT,
+-		.pNext = std::exchange(features2.pNext, &robustness2Features),
+-		.nullDescriptor = VK_TRUE,
+-	};
+ 
+ 	VkResult res = vk.CreateDevice(physDev(), &deviceCreateInfo, nullptr, &m_device);
+ 	if ( res == VK_ERROR_NOT_PERMITTED_KHR && gamescope::Process::HasCapSysNice() )
+@@ -1744,11 +1738,21 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
+ 	scratchDescriptor.offset = m_renderBufferOffset;
+ 	scratchDescriptor.range = VK_WHOLE_SIZE;
+ 
++	// Mali GPU drivers (libMali, PanVK) do not implement VK_EXT_robustness2, so a
++	// null combined-image-sampler faults them. Bind a valid blank view to every
++	// otherwise-unused composite slot instead (inert: only bound layers are
++	// sampled), so no null descriptor is ever created.
++	VkImageView blankView = VK_NULL_HANDLE;
++	if ( CVulkanTexture *blank = vulkan_get_hacky_blank_texture().get() )
++		blankView = blank->linearView();
++
+ 	for (uint32_t i = 0; i < VKR_SAMPLER_SLOTS; i++)
+ 	{
+ 		imageDescriptors[i].sampler = m_device->sampler(m_samplerState[i]);
+ 		imageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+ 		ycbcrImageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
++		imageDescriptors[i].imageView = blankView;
++		ycbcrImageDescriptors[i].imageView = blankView;
+ 		if (m_boundTextures[i] == nullptr)
+ 			continue;
+ 
+@@ -1773,17 +1777,21 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
+ 		shaperLutDescriptor[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+ 		// TODO(Josh): I hate the fact that srgbView = view *as* raw srgb and treat as linear.
+ 		// I need to change this, it's so utterly stupid and confusing.
+-		shaperLutDescriptor[i].imageView = m_shaperLut[i] ? m_shaperLut[i]->srgbView() : VK_NULL_HANDLE;
++		shaperLutDescriptor[i].imageView = m_shaperLut[i] ? m_shaperLut[i]->srgbView() : blankView;
+ 
+ 		lut3DDescriptor[i].sampler = m_device->sampler(nearestState);
+ 		lut3DDescriptor[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+-		lut3DDescriptor[i].imageView = m_lut3D[i] ? m_lut3D[i]->srgbView() : VK_NULL_HANDLE;
++		lut3DDescriptor[i].imageView = m_lut3D[i] ? m_lut3D[i]->srgbView() : blankView;
+ 	}
+ 
+ 	if (!m_target->isYcbcr())
+ 	{
+ 		targetDescriptors[0].imageView = m_target->srgbView();
+ 		targetDescriptors[0].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
++		// binding 2 (chroma storage image) is unused for non-ycbcr targets; bind the
++		// luma view so it is never a null descriptor.
++		targetDescriptors[1].imageView = m_target->srgbView();
++		targetDescriptors[1].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+ 	}
+ 	else
+ 	{

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0008-rendervulkan-DRMBackend-libmali-cma-scanout-RK3576.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0008-rendervulkan-DRMBackend-libmali-cma-scanout-RK3576.patch
@@ -1,0 +1,267 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan, DRMBackend: libMali CMA scanout on RK3576
+
+The proprietary ARM libMali Vulkan blob lacks VK_EXT_physical_device_drm and cannot export dma-bufs. Accept the device and find a DRM node via libdrm; drop the DRM master libMaliVulkan grabs on card0 before the KMS backend opens it; allocate the output images from the CMA dma-heap as LINEAR and import them for compositing and scanout (flippable/exported images crash on libMali); and open a read-only advertisement fd so wlroots binds wl_drm / zwp_linux_dmabuf_v1. Automatic via absence of VK_EXT_physical_device_drm; Mesa/PanVK keep the exported path.
+
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index 108333e..2ec0f5a 100644
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -6,6 +6,7 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <unistd.h>
++#include <dirent.h>
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <poll.h>
+@@ -1266,6 +1267,30 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
+ 		drm_log.infof("warning: picking an arbitrary DRM device");
+ 	}
+ 
++	if ( drm->device_name )
++	{
++		struct stat targetSt = {};
++		if ( stat( drm->device_name, &targetSt ) == 0 )
++		{
++			if ( DIR *pFdDir = opendir( "/proc/self/fd" ) )
++			{
++				struct dirent *pEnt;
++				while ( ( pEnt = readdir( pFdDir ) ) != nullptr )
++				{
++					int nFd = atoi( pEnt->d_name );
++					if ( nFd <= 2 )
++						continue;
++					struct stat fdSt = {};
++					if ( fstat( nFd, &fdSt ) != 0 || !S_ISCHR( fdSt.st_mode ) )
++						continue;
++					if ( fdSt.st_rdev != targetSt.st_rdev )
++						continue;
++					drmDropMaster( nFd );
++				}
++				closedir( pFdDir );
++			}
++		}
++	}
+ 	drm->fd = wlsession_open_kms( drm->device_name );
+ 	if ( drm->fd < 0 )
+ 	{
+@@ -3500,7 +3525,7 @@ namespace gamescope
+         }
+ 		virtual bool ValidPhysicalDevice( VkPhysicalDevice pVkPhysicalDevice ) const override
+ 		{
+-			return vulkan_has_drm_props();
++			return true;
+ 		}
+ 
+ 		virtual int Present( const FrameInfo_t *pFrameInfo, bool bAsync )
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index a7bb6b1..581054d 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -11,6 +11,8 @@
+ #include <bitset>
+ #include <thread>
+ #include <dlfcn.h>
++#include <sys/ioctl.h>
++#include <linux/dma-heap.h>
+ #include "vulkan_include.h"
+ #include "Utils/Algorithm.h"
+ 
+@@ -460,11 +462,62 @@ bool CVulkanDevice::createDevice()
+ 
+ 	vk_log.infof( "physical device %s DRM format modifiers", m_bSupportsModifiers ? "supports" : "does not support" );
+ 
+-	if ( !hasDrmProps ) {
+-		// This could happen when e.g. running the lavapipe driver
+-		// (without an actual physical device)
++	if ( !hasDrmProps )
++	{
+ 		vk_log.warnf( "physical device doesn't support VK_EXT_physical_device_drm" );
+-	} else {
++#if HAVE_DRM
++		drmDevicePtr devices[16] = {};
++		int nDevs = drmGetDevices2( 0, devices, 16 );
++		if ( nDevs <= 0 )
++		{
++			vk_log.errorf( "libmali fallback: drmGetDevices2() returned %d", nDevs );
++			return false;
++		}
++		for ( int pass = 0; pass < 2 && m_drmRendererFd < 0; pass++ )
++		{
++			int wantedNodeBit = ( pass == 0 ) ? DRM_NODE_RENDER : DRM_NODE_PRIMARY;
++			for ( int i = 0; i < nDevs && m_drmRendererFd < 0; i++ )
++			{
++				drmDevicePtr dev = devices[i];
++				if ( !( dev->available_nodes & ( 1 << wantedNodeBit ) ) )
++					continue;
++				const char *nodeName = dev->nodes[wantedNodeBit];
++				if ( wantedNodeBit == DRM_NODE_PRIMARY )
++				{
++					struct stat st = {};
++					if ( stat( nodeName, &st ) == 0 )
++					{
++						m_bHasDrmPrimaryDevId = true;
++						m_drmPrimaryDevId = st.st_rdev;
++					}
++					if ( m_drmAdvertiseFd < 0 )
++					{
++						int advFd = open( nodeName, O_RDONLY | O_CLOEXEC );
++						if ( advFd >= 0 )
++						{
++							m_drmAdvertiseFd = advFd;
++						}
++					}
++					continue;
++				}
++				int fd = open( nodeName, O_RDWR | O_CLOEXEC );
++				if ( fd < 0 )
++				{
++					continue;
++				}
++				m_drmRendererFd = fd;
++			}
++		}
++		drmFreeDevices( devices, nDevs );
++		if ( m_drmRendererFd < 0 && !m_bHasDrmPrimaryDevId )
++		{
++			vk_log.errorf( "libmali fallback: no DRM render or primary node available" );
++			return false;
++		}
++#endif
++	}
++	else
++	{
+ #if HAVE_DRM
+ 		VkPhysicalDeviceDrmPropertiesEXT drmProps = {
+ 			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT,
+@@ -2038,6 +2091,8 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
+ 	m_drmFormat = drmFormat;
+ 	VkResult res = VK_ERROR_INITIALIZATION_FAILED;
+ 
++	if ( flags.bFlippable && pDMA == nullptr && !vulkan_has_drm_props() )
++		flags.bFlippable = false;
+ 	VkImageTiling tiling = (flags.bMappable || flags.bLinear) ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL;
+ 	VkImageUsageFlags usage = 0;
+ 	VkMemoryPropertyFlags properties;
+@@ -3110,6 +3165,8 @@ gamescope::OwningRc<CVulkanTexture> vulkan_create_flat_texture( uint32_t width,
+ 	flags.bFlippable = true;
+ 	flags.bSampled = true;
+ 	flags.bTransferDst = true;
++	if ( !vulkan_has_drm_props() )
++		flags.bFlippable = false;
+ 
+ 	gamescope::OwningRc<CVulkanTexture> texture = new CVulkanTexture();
+ 	bool bRes = texture->BInit( width, height, 1u, VulkanFormatToDRM( VK_FORMAT_B8G8R8A8_UNORM ), flags );
+@@ -3287,6 +3344,58 @@ bool vulkan_remake_swapchain( void )
+ 	return bRet;
+ }
+ 
++namespace rxnix_cma {
++    static int g_DmaHeapFd = -1;
++    static int dmaheap_alloc( size_t bytes ) {
++        if ( g_DmaHeapFd < 0 ) {
++            g_DmaHeapFd = open( "/dev/dma_heap/default_cma_region", O_RDWR | O_CLOEXEC );
++            if ( g_DmaHeapFd < 0 ) { vk_log.errorf_errno( "rxnix_cma: open dma_heap default_cma_region" ); return -1; }
++        }
++        struct dma_heap_allocation_data a = {};
++        a.len = bytes;
++        a.fd_flags = O_RDWR | O_CLOEXEC;
++        if ( ioctl( g_DmaHeapFd, DMA_HEAP_IOCTL_ALLOC, &a ) < 0 ) {
++            vk_log.errorf_errno( "rxnix_cma: DMA_HEAP_IOCTL_ALLOC %zu", bytes );
++            return -1;
++        }
++        return (int)a.fd;
++    }
++    static bool make_output_image( gamescope::OwningRc<CVulkanTexture> &outTex,
++                                   uint32_t width, uint32_t height, uint32_t drmFormat ) {
++        uint32_t stride_bytes = ( ( width * 4u ) + 255u ) & ~255u; // aligned pitch (import + VOP2 scanout)
++        size_t size = (size_t)stride_bytes * height;
++        int fd = dmaheap_alloc( size );
++        if ( fd < 0 ) return false;
++        struct wlr_dmabuf_attributes attrs = {};
++        attrs.width = (int)width;
++        attrs.height = (int)height;
++        attrs.format = drmFormat;
++        attrs.modifier = DRM_FORMAT_MOD_LINEAR;
++        attrs.n_planes = 1;
++        attrs.fd[0] = fd;
++        attrs.stride[0] = stride_bytes;
++        attrs.offset[0] = 0;
++        gamescope::OwningRc<gamescope::IBackendFb> pBackendFb = GetBackend()->ImportDmabufToBackend( &attrs );
++        if ( !pBackendFb ) {
++            vk_log.errorf( "rxnix_cma: ImportDmabufToBackend failed (%ux%u stride=%u fmt=0x%x)", width, height, stride_bytes, drmFormat );
++            close( fd );
++            return false;
++        }
++        CVulkanTexture::createFlags flags;
++        flags.bSampled = true;
++        flags.bStorage = true;
++        flags.bOutputImage = true;
++        flags.bTransferSrc = true;
++        gamescope::OwningRc<CVulkanTexture> pTex = new CVulkanTexture();
++        if ( !pTex->BInit( width, height, 1u, drmFormat, flags, &attrs, 0, 0, nullptr, std::move( pBackendFb ) ) ) {
++            vk_log.errorf( "rxnix_cma: BInit failed on CMA dma-buf (%ux%u stride=%u fmt=0x%x)", width, height, stride_bytes, drmFormat );
++            close( fd );
++            return false;
++        }
++        outTex = std::move( pTex );
++        return true;
++    }
++} // namespace rxnix_cma
+ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ {
+ 	CVulkanTexture::createFlags outputImageflags;
+@@ -3308,6 +3417,20 @@ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ 
+ 	uint32_t uDRMFormat = pOutput->uOutputFormat;
+ 
++	if ( !vulkan_has_drm_props() )
++	{
++		uint32_t fmt = ( uDRMFormat != DRM_FORMAT_INVALID ) ? uDRMFormat : DRM_FORMAT_ABGR8888;
++		for ( int i = 0; i < 3; i++ )
++		{
++			if ( !rxnix_cma::make_output_image( pOutput->outputImages[i], outputWidth, outputHeight, fmt ) )
++			{
++				vk_log.errorf( "rxnix_cma: output image %d alloc failed", i );
++				return false;
++			}
++		}
++		pOutput->temporaryHackyBlankImage = vulkan_create_debug_blank_texture( outputWidth, outputHeight );
++		return true;
++	}
+ 	pOutput->outputImages[0] = new CVulkanTexture();
+ 	bool bSuccess = pOutput->outputImages[0]->BInit( g_nOutputWidth, g_nOutputHeight, 1u, uDRMFormat, outputImageflags );
+ 	if ( bSuccess != true )
+@@ -4312,7 +4435,10 @@ static const struct wlr_drm_format_set *renderer_get_texture_formats( struct wlr
+ 
+ static int renderer_get_drm_fd( struct wlr_renderer *wlr_renderer )
+ {
+-	return g_device.drmRenderFd();
++	int fd = g_device.drmRenderFd();
++	if ( fd < 0 )
++		fd = g_device.drmAdvertiseFd();
++	return fd;
+ }
+ 
+ static struct wlr_texture *renderer_texture_from_buffer( struct wlr_renderer *wlr_renderer, struct wlr_buffer *buf )
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index b0ee208..0035641 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -802,6 +802,7 @@ public:
+ 	inline VkBuffer uploadBuffer() {return m_uploadBuffer;}
+ 	inline VkPipelineLayout pipelineLayout() {return m_pipelineLayout;}
+ 	inline int drmRenderFd() {return m_drmRendererFd;}
++	inline int drmAdvertiseFd() {return m_drmAdvertiseFd;}
+ 	inline bool supportsModifiers() {return m_bSupportsModifiers;}
+ 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
+ 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
+@@ -865,6 +866,7 @@ protected:
+ 	uint32_t m_generalQueueFamily = -1;
+ 
+ 	int m_drmRendererFd = -1;
++	int m_drmAdvertiseFd = -1;
+ 	dev_t m_drmPrimaryDevId = 0;
+ 
+ 	bool m_bSupportsFp16 = false;

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0009-wlserver-mali-buffer-sharing-for-libmali-EGL.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0009-wlserver-mali-buffer-sharing-for-libmali-EGL.patch
@@ -1,0 +1,145 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] wlserver: mali_buffer_sharing protocol for libMali EGL clients
+
+libMali EGL requires the mali_buffer_sharing global for eglInitialize to succeed; without it GLES clients (glmark2-es2-wayland) fail with EGL_NOT_INITIALIZED. Implement the server side in wlserver, backed by the existing wlr dmabuf buffer factory. Registered automatically when the Vulkan driver lacks VK_EXT_physical_device_drm (libMali); Mesa/PanVK unaffected.
+
+diff --git a/src/wlserver.cpp b/src/wlserver.cpp
+index 34cd5ae..f143c6a 100644
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -33,6 +33,7 @@
+ #include <wlr/render/wlr_renderer.h>
+ #include <wlr/types/wlr_compositor.h>
+ #include <wlr/types/wlr_keyboard.h>
++#include <wlr/types/wlr_linux_dmabuf_v1.h>
+ #include <wlr/types/wlr_keyboard_group.h>
+ #include <wlr/types/wlr_pointer.h>
+ #include <wlr/types/wlr_seat.h>
+@@ -2053,6 +2054,73 @@ bool wlserver_init( void ) {
+ 	// Someday, he will be purged.
+ 	wlr_drm_create(wlserver.display, wlserver.wlr.renderer);
+ 
++	extern bool vulkan_has_drm_props();
++	if ( !vulkan_has_drm_props() )
++	{
++		static const struct wl_interface *mali_create_buffer_types[] = {
++			&wl_buffer_interface, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
++		};
++		static const struct wl_message mali_buffer_sharing_requests[] = {
++			{ "create_buffer", "niiiuuuh", mali_create_buffer_types },
++		};
++		static const struct wl_interface mali_buffer_sharing_interface = {
++			"mali_buffer_sharing", 5, 1, mali_buffer_sharing_requests, 0, NULL,
++		};
++		struct mali_buffer_sharing_state {
++			struct wl_global *global;
++		};
++		static const struct wl_interface *s_iface = &mali_buffer_sharing_interface;
++		static auto mali_create_buffer_handler = [](
++				struct wl_client *client, struct wl_resource *resource,
++				uint32_t buffer_id,
++				int32_t width, int32_t height, int32_t stride,
++				uint32_t format, uint32_t modifier_hi, uint32_t modifier_lo,
++				int32_t fd) {
++			uint64_t modifier = ((uint64_t)modifier_hi << 32) | modifier_lo;
++			bool isAFBC = (modifier != 0);
++			wl_log.infof("mali_buffer_sharing: create_buffer %dx%d stride=%d fmt=0x%x mod=0x%x_%x fd=%d%s",
++				width, height, stride, format, modifier_hi, modifier_lo, fd,
++				isAFBC ? " [AFBC]" : " [LINEAR]");
++			struct wlr_dmabuf_attributes attribs = {};
++			attribs.width = width;
++			attribs.height = height;
++			attribs.format = format;
++			attribs.modifier = modifier;
++			attribs.n_planes = 1;
++			attribs.offset[0] = 0;
++			attribs.stride[0] = stride;
++			attribs.fd[0] = fd;
++			for (int i = 1; i < WLR_DMABUF_MAX_PLANES; i++)
++				attribs.fd[i] = -1;
++			struct wl_resource *buf = wlr_dmabuf_v1_buffer_create_immed(
++				client, buffer_id, &attribs);
++			if (!buf) {
++				wl_resource_post_error(resource, 0,
++					"mali_buffer_sharing: create_buffer failed");
++			}
++		};
++		typedef void (*mali_create_buffer_fn)(
++			struct wl_client *, struct wl_resource *,
++			uint32_t, int32_t, int32_t, int32_t,
++			uint32_t, uint32_t, uint32_t, int32_t);
++		struct mali_buffer_sharing_impl {
++			mali_create_buffer_fn create_buffer;
++		};
++		static const struct mali_buffer_sharing_impl mali_impl = {
++			.create_buffer = mali_create_buffer_handler,
++		};
++		static auto mali_bind = [](struct wl_client *client, void *data,
++				uint32_t version, uint32_t id) {
++			struct wl_resource *resource = wl_resource_create(client,
++				s_iface, version, id);
++			if (!resource) {
++				wl_client_post_no_memory(client);
++				return;
++			}
++			wl_resource_set_implementation(resource, &mali_impl, data, NULL);
++		};
++		wl_global_create(wlserver.display, s_iface, 5, NULL, mali_bind);
++	}
+ 	if ( GetBackend()->SupportsExplicitSync() )
+ 	{
+ 		create_explicit_sync();
+diff --git a/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h b/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h
+index cf967f9..53605fa 100644
+--- a/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h
++++ b/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h
+@@ -134,4 +134,7 @@ struct wlr_linux_dmabuf_feedback_v1_init_options {
+ bool wlr_linux_dmabuf_feedback_v1_init_with_options(struct wlr_linux_dmabuf_feedback_v1 *feedback,
+ 	const struct wlr_linux_dmabuf_feedback_v1_init_options *options);
+ 
++struct wl_resource *wlr_dmabuf_v1_buffer_create_immed(
++		struct wl_client *client, uint32_t buffer_id,
++		struct wlr_dmabuf_attributes *attribs);
+ #endif
+diff --git a/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c b/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c
+index bfd9763..85bc46a 100644
+--- a/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c
++++ b/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c
+@@ -1171,3 +1171,37 @@ error:
+ 	wlr_linux_dmabuf_feedback_v1_finish(feedback);
+ 	return false;
+ }
++struct wl_resource *wlr_dmabuf_v1_buffer_create_immed(
++		struct wl_client *client, uint32_t buffer_id,
++		struct wlr_dmabuf_attributes *attribs) {
++	if (attribs->width < 1 || attribs->height < 1) {
++		wlr_log(WLR_ERROR, "wlr_dmabuf_v1_buffer_create_immed: invalid dimensions %dx%d",
++			attribs->width, attribs->height);
++		wlr_dmabuf_attributes_finish(attribs);
++		return NULL;
++	}
++	if (attribs->n_planes < 1 || attribs->fd[0] < 0) {
++		wlr_log(WLR_ERROR, "wlr_dmabuf_v1_buffer_create_immed: no valid plane fd");
++		wlr_dmabuf_attributes_finish(attribs);
++		return NULL;
++	}
++	struct wlr_dmabuf_v1_buffer *buffer = calloc(1, sizeof(*buffer));
++	if (!buffer) {
++		wlr_dmabuf_attributes_finish(attribs);
++		return NULL;
++	}
++	wlr_buffer_init(&buffer->base, &buffer_impl, attribs->width, attribs->height);
++	buffer->resource = wl_resource_create(client, &wl_buffer_interface,
++		1, buffer_id);
++	if (!buffer->resource) {
++		wlr_dmabuf_attributes_finish(attribs);
++		free(buffer);
++		return NULL;
++	}
++	wl_resource_set_implementation(buffer->resource,
++		&wl_buffer_impl, buffer, buffer_handle_resource_destroy);
++	buffer->attributes = *attribs;
++	buffer->release.notify = buffer_handle_release;
++	wl_signal_add(&buffer->base.events.release, &buffer->release);
++	return buffer->resource;
++}

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0010-DRMBackend-rotate-composite-in-shader-rotated-panel.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0010-DRMBackend-rotate-composite-in-shader-rotated-panel.patch
@@ -1,0 +1,28 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] DRMBackend: rotate composite in-shader for rotated internal panels
+
+Embedded display planes (e.g. rockchip VOP) generally cannot hardware-rotate, so a physically-rotated internal panel (mounted 90/270) fails plane scanout with EINVAL - liftoff finds no plane that accepts the requested rotation, and nothing is presented. gamescope already carries a composite rotation shader (gated behind --use-rotation-shader); enable it automatically once the internal panel is detected as rotated, so the compositor bakes the rotation into its output and the scanout layer needs only rotation=identity. Applies to any GPU driver on such a panel.
+
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index a041491..8e950d3 100644
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -1763,6 +1763,18 @@ static void update_drm_effective_orientations( struct drm_t *drm, const drmModeM
+ 			pInternalMode = find_mode( pDRMInternalConnector->GetModeConnector(), 0, 0, 0 );
+ 
+ 		pDRMInternalConnector->UpdateEffectiveOrientation( pInternalMode );
++
++		// Embedded display planes (e.g. rockchip VOP) generally cannot
++		// hardware-rotate, so a physically-rotated internal panel fails plane
++		// scanout. Rotate in the composite shader instead (plane rotation stays
++		// identity) when the panel is mounted at 90/270 degrees.
++		GamescopePanelOrientation eInternalOrientation = pDRMInternalConnector->GetCurrentOrientation();
++		if ( eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_90 ||
++		     eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_270 )
++		{
++			g_bRotationShaderRequested = true;
++			g_bRotationShaderEnabled = true;
++		}
+ 	}
+ 
+ 	gamescope::IBackendConnector *pExternalConnector = GetBackend()->GetConnector( gamescope::GAMESCOPE_SCREEN_TYPE_EXTERNAL );

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0011-rendervulkan-join-pipeline-thread-on-shutdown.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0011-rendervulkan-join-pipeline-thread-on-shutdown.patch
@@ -1,0 +1,84 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan,steamcompmgr: join pipeline-compile thread on shutdown
+
+compileAllPipelines() runs on a detached background thread. On shutdown gamescope tears down the Vulkan device (steamcompmgr_exit) while that thread is still calling vkCreateComputePipelines, faulting inside the driver (seen on libMali) - a SIGSEGV during exit. Make the thread joinable, have its loop bail as soon as g_bRun is cleared by the signal handler, and join it at the start of steamcompmgr_exit before any device teardown. Shutdown is then clean (at most one in-flight pipeline compile is awaited).
+
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 0851089..e283db5 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -319,8 +319,7 @@ bool CVulkanDevice::BInit(VkInstance instance, VkSurfaceKHR surface)
+ 
+ 	m_bInitialized = true;
+ 
+-	std::thread piplelineThread([this](){compileAllPipelines();});
+-	piplelineThread.detach();
++	m_pipelineThread = std::thread([this](){compileAllPipelines();});
+ 
+ 	g_reshadeManager.init(this);
+ 
+@@ -1266,6 +1265,8 @@ void CVulkanDevice::compileAllPipelines()
+ 							continue;
+ 						if (blur_layers > layerCount)
+ 							continue;
++						if (!g_bRun)
++							return;
+ 
+ 						VkPipeline newPipeline = compilePipeline(layerCount, ycbcrMask, info.shaderType, blur_layers, info.compositeDebug, info.colorspaceMask, info.outputEOTF, info.itmEnable, rotation);
+ 						{
+@@ -1282,6 +1283,12 @@ void CVulkanDevice::compileAllPipelines()
+ 	}
+ }
+ 
++void CVulkanDevice::waitPipelines()
++{
++	if ( m_pipelineThread.joinable() )
++		m_pipelineThread.join();
++}
++
+ extern bool g_bSteamIsActiveWindow;
+ 
+ VkPipeline CVulkanDevice::pipeline(ShaderType type, uint32_t layerCount, uint32_t ycbcrMask, uint32_t blur_layers, uint32_t colorspace_mask, uint32_t output_eotf, bool itm_enable, uint32_t rotation)
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index ca1dcfa..ed34ddd 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -10,6 +10,7 @@
+ #include <array>
+ #include <bitset>
+ #include <mutex>
++#include <thread>
+ #include <optional>
+ 
+ #include "main.hpp"
+@@ -810,6 +811,7 @@ public:
+ 	inline int drmRenderFd() {return m_drmRendererFd;}
+ 	inline int drmAdvertiseFd() {return m_drmAdvertiseFd;}
+ 	inline bool supportsModifiers() {return m_bSupportsModifiers;}
++	void waitPipelines();
+ 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
+ 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
+ 	inline bool supportsFp16() {return m_bSupportsFp16;}
+@@ -887,6 +889,7 @@ protected:
+ 	std::array<VkShaderModule, SHADER_TYPE_COUNT> m_shaderModules;
+ 	std::unordered_map<PipelineInfo_t, VkPipeline> m_pipelineMap;
+ 	std::mutex m_pipelineMutex;
++	std::thread m_pipelineThread;
+ 
+ 	static constexpr uint32_t k_uMaxConcurrentSubmits = 8;
+ 
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index 72d9909..ab4c47c 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -6698,6 +6698,10 @@ error(Display *dpy, XErrorEvent *ev)
+ static void
+ steamcompmgr_exit(void)
+ {
++	// Stop the async pipeline-precompile thread before tearing down the Vulkan
++	// device, or it faults mid-compile inside the driver.
++	g_device.waitPipelines();
++
+ 	g_ImageWaiter.Shutdown();
+ 
+ 	// Clean up any commits.

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0012-DRMBackend-rendervulkan-foreign-device-scanout.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0012-DRMBackend-rendervulkan-foreign-device-scanout.patch
@@ -1,0 +1,107 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] DRMBackend,rendervulkan: scan out on the KMS display node with CMA output images
+
+gamescope derives its KMS/scanout device from the Vulkan render device's DRM
+node (vulkan_primary_dev_id) and allocates its output images on that render
+device. On a split render/display SoC that breaks two ways at once. On RK3576
+with panfrost the GPU is /dev/dri/card1 (render-only, no KMS) while the display
+is the rockchip VOP2 on /dev/dri/card0:
+
+  1. gamescope opens card1 for KMS, logs "is not a KMS device",
+     GetPreferredOutputFormat() returns nothing and vulkan_make_output aborts
+     ("failed to find Vulkan format suitable for KMS").
+  2. Even once scanning out on card0, the output images live in panfrost's GEM
+     space and cannot be turned into VOP2 framebuffers, so nothing is presented
+     (black screen; drmModeRmFB EBADF spam on teardown).
+
+Fix both: after picking the device, if it is not KMS-capable, enumerate DRM
+devices and switch scanout to the first KMS-capable primary node (the VOP2), and
+raise g_bGamescopeForeignScanout. When that flag is set, allocate the output
+images from the CMA dma-heap as LINEAR and import them for scanout (the same
+device-agnostic path already used for libMali via rxnix_cma) so the VOP2 can
+scan them out. No effect on unified render/display GPUs (device is already KMS,
+flag stays false) or on libMali (already takes the CMA path via absence of
+VK_EXT_physical_device_drm).
+
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index 2a3b4c5..6d7e8f9 100644
+--- a/src/Backends/DRMBackend.cpp
++++ /home/felixjones/rocknix/build.ROCKNIX-RK3576.aarch64/build/gamescope-61c74c18af1aaa4a2593f73b409a0c22b9314db4/src/Backends/DRMBackend.cpp	2026-07-05 15:18:57.387424763 +0200
+@@ -584,6 +584,7 @@
+ 
+ bool g_bSupportsAsyncFlips = false;
+ bool g_bSupportsSyncObjs = false;
++bool g_bGamescopeForeignScanout = false;
+ 
+ extern gamescope::GamescopeModeGeneration g_eGamescopeModeGeneration;
+ extern GamescopePanelOrientation g_DesiredInternalOrientation;
+@@ -1293,6 +1294,50 @@
+ 		drm_log.infof("warning: picking an arbitrary DRM device");
+ 	}
+ 
++
++	// The Vulkan render device is not necessarily the KMS/display device. On split
++	// render/display SoCs (e.g. panfrost render GPU + rockchip VOP2 display) the node
++	// selected above is render-only and not a KMS device; find the KMS-capable
++	// display node and scan out through that instead.
++	{
++		bool bDeviceIsKMS = false;
++		if ( drm->device_name )
++		{
++			int nCheckFd = open( drm->device_name, O_RDWR | O_CLOEXEC );
++			if ( nCheckFd >= 0 )
++			{
++				bDeviceIsKMS = drmIsKMS( nCheckFd );
++				close( nCheckFd );
++			}
++		}
++		if ( !bDeviceIsKMS )
++		{
++			drmDevicePtr devices[16] = {};
++			int nDevs = drmGetDevices2( 0, devices, 16 );
++			for ( int i = 0; i < nDevs; i++ )
++			{
++				if ( !( devices[i]->available_nodes & ( 1 << DRM_NODE_PRIMARY ) ) )
++					continue;
++				const char *pszNode = devices[i]->nodes[DRM_NODE_PRIMARY];
++				int nFd = open( pszNode, O_RDWR | O_CLOEXEC );
++				if ( nFd < 0 )
++					continue;
++				bool bKMS = drmIsKMS( nFd );
++				close( nFd );
++				if ( bKMS )
++				{
++					free( drm->device_name );
++					drm->device_name = strdup( pszNode );
++					drm_log.infof( "using KMS display node '%s' (render device is not a KMS device)", drm->device_name );
++					g_bGamescopeForeignScanout = true;
++					break;
++				}
++			}
++			if ( nDevs > 0 )
++				drmFreeDevices( devices, nDevs );
++		}
++	}
++
+ 	if ( drm->device_name )
+ 	{
+ 		struct stat targetSt = {};
+--- a/src/rendervulkan.cpp
++++ /home/felixjones/rocknix/build.ROCKNIX-RK3576.aarch64/build/gamescope-61c74c18af1aaa4a2593f73b409a0c22b9314db4/src/rendervulkan.cpp	2026-07-05 15:18:57.387663026 +0200
+@@ -3416,6 +3416,7 @@
+         return true;
+     }
+ } // namespace rxnix_cma
++extern bool g_bGamescopeForeignScanout;
+ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ {
+ 	CVulkanTexture::createFlags outputImageflags;
+@@ -3454,7 +3455,7 @@
+ 		}
+ 	}
+ 
+-	if ( !vulkan_has_drm_props() )
++	if ( !vulkan_has_drm_props() || g_bGamescopeForeignScanout )
+ 	{
+ 		uint32_t fmt = ( uDRMFormat != DRM_FORMAT_INVALID ) ? uDRMFormat : DRM_FORMAT_ABGR8888;
+ 		for ( int i = 0; i < 3; i++ )

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0013-rendervulkan-composite-ubo-explicit-range-panvk.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0013-rendervulkan-composite-ubo-explicit-range-panvk.patch
@@ -1,0 +1,57 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: bind the composite UBO with an explicit range (PanVK)
+
+The compute composite path binds its per-dispatch constants (scale, offset,
+opacity, CTM, colour-management) as the binding-0 uniform buffer, using
+VkDescriptorBufferInfo.range = VK_WHOLE_SIZE.
+
+On PanVK (Mesa panfrost Vulkan, e.g. Mali-G52 / RK3576) VK_WHOLE_SIZE is
+miscomputed for a uniform-buffer descriptor: the effective hardware UBO size
+ends up as 0, so every uniform read in the composite compute shader returns
+zero. The shader therefore sees scale=0, offset=0, opacity=0, CTM=0 and renders
+a solid black screen, even though the upload buffer at the bound offset holds
+the correct values. The compositor runs and page-flips normally (no crash, no
+KMS/IOMMU fault) so the panel is simply black; verified on RK3576 by mapping the
+CMA scanout dma-buf on the CPU (all-zero before this fix, ~29% non-zero after).
+
+Fix: remember the size of the last uploaded constants block and bind the UBO
+with an explicit range == that size instead of VK_WHOLE_SIZE. Falls back to
+VK_WHOLE_SIZE only for dispatches that did not upload any constants. Harmless on
+drivers that compute VK_WHOLE_SIZE correctly (libMali, desktop) since the
+explicit range is exactly the data the shader reads.
+
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -1000,6 +1000,7 @@
+ 	std::vector<VulkanTimelinePoint_t> m_ExternalSignals;
+ 
+ 	uint32_t m_renderBufferOffset = 0;
++	uint32_t m_renderBufferSize = 0;
+ };
+ 
+ uint32_t VulkanFormatToDRM( VkFormat vkFormat, std::optional<bool> obHasAlphaOverride = std::nullopt );
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -1698,6 +1698,7 @@
+ 
+ 	auto [ptr, offset] = m_device->uploadBufferData(sizeof(data));
+ 	m_renderBufferOffset = offset;
++	m_renderBufferSize = sizeof(data);
+ 	memcpy(ptr, &data, sizeof(data));
+ }
+ 
+@@ -1799,7 +1800,13 @@
+ 
+ 	scratchDescriptor.buffer = m_device->m_uploadBuffer;
+ 	scratchDescriptor.offset = m_renderBufferOffset;
+-	scratchDescriptor.range = VK_WHOLE_SIZE;
++	// PanVK (Mali) miscomputes VK_WHOLE_SIZE for a uniform-buffer descriptor: the
++	// effective hardware UBO size becomes 0, so every composite uniform (scale,
++	// offset, opacity, CTM, colour-management) reads back as zero and the compute
++	// composite renders solid black. Bind an explicit range equal to the uploaded
++	// constants size so the shader reads the real values; fall back to
++	// VK_WHOLE_SIZE only for dispatches that uploaded no constants.
++	scratchDescriptor.range = m_renderBufferSize ? (VkDeviceSize)m_renderBufferSize : VK_WHOLE_SIZE;
+ 
+ 	// Mali GPU drivers (libMali, PanVK) do not implement VK_EXT_robustness2, so a
+ 	// null combined-image-sampler faults them. Bind a valid blank view to every


### PR DESCRIPTION
## Summary

These patches allow Gamescope to run on the Mali-G52

Gamescope relies on `VK_EXT_robustness2`, which is not exposed by either Panvk nor libmali, however it's also only used for null descriptor binding so in practice it doesn't take much effort to remove that required extension.

This also uses Vulkan shader rotation as the rockchip VOP doesn't have hardware rotation without RGA (which is coming via other PRs). There is a performance penalty with Vulkan shader rotation, but it's supposed to be the most compatible. As such, expect bad performance with Gamescope until librga comes into the picture.

Feel free to ask questions - this was quite the journey.

## Testing

This was tested and built exclusively around `glmark2-es2-wayland`, `vkgears`, and `vkcube`. I recommend installing those if you want to test this yourself.

To actually test this, release the EmulationStation/Sway session from the DRM so gamescope can own it:
```sh
systemctl stop essway.service sway.service
```
For panvk the following environment variables need to be set:
```sh
export PAN_I_WANT_A_BROKEN_VULKAN_DRIVER=1 MESA_VK_VERSION_OVERRIDE=1.3
```
libmali masks `libGL.so.1` with `/dev/null` (days of debugging...) so that needs to be unmasked so gamescope can use it.

Here's a convenience script for running `glmark2-es-wayland`:
```sh
#!/bin/sh
export XDG_RUNTIME_DIR=/var/run/0-runtime-dir
mkdir -p "$XDG_RUNTIME_DIR"; chmod 700 "$XDG_RUNTIME_DIR"
export PAN_I_WANT_A_BROKEN_VULKAN_DRIVER=1 MESA_VK_VERSION_OVERRIDE=1.3
exec unshare -m --propagation private -- /bin/sh -c '
  for lib in /usr/lib/libGL.so.1 /usr/lib32/libGL.so.1; do
    real=$(readlink -f "$lib" 2>/dev/null)
    [ -n "$real" ] && umount "$real" 2>/dev/null
  done
  exec gamescope --expose-wayland -W 1920 -H 1080 -r 60 -- glmark2-es2-wayland
'
```
And yes `--expose-wayland` is required.

## Additional Context

Again, performance isn't ideal, using hardware RGA for direct scanout is the real goal here

---

### AI Usage

The detailed patch descriptions and comments are machine generated; I have reviewed them for correctness.