### PR TITLE
workflows: build qt6 - use bash shell

### DIFF
--- a/.github/workflows/build-aarch64-qt6.yml
+++ b/.github/workflows/build-aarch64-qt6.yml
@@ -18,6 +18,9 @@ jobs:
     if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' 
       || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115' }}
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
     env:
       EMULATION_DEVICE: no
       ENABLE_32BIT: no


### PR DESCRIPTION
## Summary

workflows: build qt6 - use bash shell

## Testing

Tested in job: https://github.com/porschemad911/rocknix-distribution/actions/runs/28801376701/job/85485793649

## Additional Context

To fix: https://discord.com/channels/948029830325235753/1522541787380584489

This regex requires bash shell: https://github.com/ROCKNIX/distribution/blob/42ac616588fd8a8eec610de525de230193efa1a8/projects/ROCKNIX/packages/graphics/qt6/package.mk#L15

---

### AI Usage

**Did you use AI tools to help write this code?** NO
