### PR TITLE
sm8250: PM resolve panel race

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/linux/dts/qcom/sm8250-mangmi-pocket-max.dts
+++ b/projects/ROCKNIX/devices/SM8250/linux/dts/qcom/sm8250-mangmi-pocket-max.dts
@@ -165,6 +165,19 @@
 		regulator-boot-on;
 	};
 
+	vreg_disp_avdd: display-avdd-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "display_panel_avdd";
+		regulator-min-microvolt = <5500000>;
+		regulator-max-microvolt = <5500000>;
+		gpio = <&tlmm 61 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		regulator-enable-ramp-delay = <233>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&disp_avdd_active>;
+	};
+
 	vreg_vibrator_en: vibrator-en-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vibrator_en";
@@ -685,6 +698,7 @@
 		vddio-supply = <&vreg_l14a_1p8>;
 		vdd-supply = <&vreg_l11c_3p3>;
 		disp-supply = <&vreg_panel_en>;
+		blvdd-supply = <&vreg_disp_avdd>;
 
 		reset-gpios = <&tlmm 74 GPIO_ACTIVE_LOW>;
 
@@ -1144,6 +1158,13 @@
 		drive-strength = <16>;
 		output-low;
 		bias-pull-up;
+	};
+
+	disp_avdd_active: disp-avdd-active-state {
+		pins = "gpio61";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
 	};
 
 	dsi_rst_active: dsi-rst-active-state {

--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0057_Chipone-ICNA35XX-panel.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0057_Chipone-ICNA35XX-panel.patch
@@ -7,8 +7,8 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
  drivers/gpu/drm/panel/Kconfig                 |  12 +
  drivers/gpu/drm/panel/Makefile                |   1 +
- .../gpu/drm/panel/panel-chipone-icna35xx.c    | 783 ++++++++++++++++++
- 3 files changed, 796 insertions(+)
+ .../gpu/drm/panel/panel-chipone-icna35xx.c    | 845 ++++++++++++++++++
+ 3 files changed, 858 insertions(+)
  create mode 100644 drivers/gpu/drm/panel/panel-chipone-icna35xx.c
 
 diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
@@ -48,10 +48,9 @@ index 4b64459f88b5..339a5cb9f31b 100644
  obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple.o
 diff --git a/drivers/gpu/drm/panel/panel-chipone-icna35xx.c b/drivers/gpu/drm/panel/panel-chipone-icna35xx.c
 new file mode 100644
-index 000000000000..9021933b0714
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-chipone-icna35xx.c
-@@ -0,0 +1,783 @@
+@@ -0,0 +1,845 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Chipone ICNA35XX Driver IC panels driver
@@ -97,6 +96,7 @@ index 000000000000..9021933b0714
 +	unsigned long mode_flags;
 +	enum mipi_dsi_pixel_format format;
 +	unsigned int max_brightness;
++	unsigned int min_brightness;
 +
 +	const struct regulator_bulk_data *supplies;
 +	unsigned int num_supplies;
@@ -104,6 +104,9 @@ index 000000000000..9021933b0714
 +	const struct drm_display_mode *modes;
 +	unsigned int num_modes;
 +	int (*init_sequence)(struct panel_info *pinfo);
++
++	unsigned int display_off_ms;
++	unsigned int enter_sleep_ms;
 +
 +	struct drm_dsc_config dsc;
 +};
@@ -502,6 +505,61 @@ index 000000000000..9021933b0714
 +	}
 +};
 +
++static const struct drm_display_mode mangmi_pocket_max_modes[] = {
++	{
++		/* 60 Hz */
++		.clock = (1080 + 156 + 1 + 23) * (1920 + 20 + 1 + 15) * 60 /
++			 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 156,
++		.hsync_end = 1080 + 156 + 1,
++		.htotal = 1080 + 156 + 1 + 23,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 20,
++		.vsync_end = 1920 + 20 + 1,
++		.vtotal = 1920 + 20 + 1 + 15,
++	},
++	{
++		/* 90 Hz */
++		.clock = (1080 + 156 + 1 + 23) * (1920 + 20 + 1 + 15) * 90 /
++			 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 156,
++		.hsync_end = 1080 + 156 + 1,
++		.htotal = 1080 + 156 + 1 + 23,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 20,
++		.vsync_end = 1920 + 20 + 1,
++		.vtotal = 1920 + 20 + 1 + 15,
++	},
++	{
++		/* 120 Hz */
++		.clock = (1080 + 156 + 1 + 23) * (1920 + 20 + 1 + 15) * 120 /
++			 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 156,
++		.hsync_end = 1080 + 156 + 1,
++		.htotal = 1080 + 156 + 1 + 23,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 20,
++		.vsync_end = 1920 + 20 + 1,
++		.vtotal = 1920 + 20 + 1 + 15,
++	},
++	{
++		/* 144 Hz */
++		.clock = (1080 + 156 + 1 + 23) * (1920 + 20 + 1 + 15) * 144 /
++			 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 156,
++		.hsync_end = 1080 + 156 + 1,
++		.htotal = 1080 + 156 + 1 + 23,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 20,
++		.vsync_end = 1920 + 20 + 1,
++		.vtotal = 1920 + 20 + 1 + 15,
++	},
++};
++
 +static struct panel_desc icna3512_desc = {
 +	.modes = icna3512_modes,
 +	.num_modes = ARRAY_SIZE(icna3512_modes),
@@ -515,6 +573,8 @@ index 000000000000..9021933b0714
 +	.supplies = icna35xx_supplies,
 +	.num_supplies = ARRAY_SIZE(icna35xx_supplies),
 +	.init_sequence = icna3512_init_sequence,
++	.display_off_ms = 50,
++	.enter_sleep_ms = 120,
 +	.dsc = {
 +		.dsc_version_major = 0x1,
 +		.dsc_version_minor = 0x1,
@@ -540,6 +600,8 @@ index 000000000000..9021933b0714
 +	.supplies = icna35xx_supplies,
 +	.num_supplies = ARRAY_SIZE(icna35xx_supplies),
 +	.init_sequence = icna3520_init_sequence,
++	.display_off_ms = 50,
++	.enter_sleep_ms = 120,
 +	.dsc = {
 +		.dsc_version_major = 0x1,
 +		.dsc_version_minor = 0x1,
@@ -553,8 +615,8 @@ index 000000000000..9021933b0714
 +};
 +
 +static struct panel_desc mangmi_pocket_max_desc = {
-+	.modes = icna3512_modes,
-+	.num_modes = ARRAY_SIZE(icna3512_modes),
++	.modes = mangmi_pocket_max_modes,
++	.num_modes = ARRAY_SIZE(mangmi_pocket_max_modes),
 +	.width_mm = 87,
 +	.height_mm = 155,
 +	.bpc = 8,
@@ -562,9 +624,12 @@ index 000000000000..9021933b0714
 +	.format = MIPI_DSI_FMT_RGB888,
 +	.mode_flags = MIPI_DSI_CLOCK_NON_CONTINUOUS | MIPI_DSI_MODE_LPM,
 +	.max_brightness = 3515,
++	.min_brightness = 1,
 +	.supplies = icna35xx_supplies,
 +	.num_supplies = ARRAY_SIZE(icna35xx_supplies),
 +	.init_sequence = mangmi_pocket_max_init_sequence,
++	.display_off_ms = 120,
++	.enter_sleep_ms = 10,
 +	.dsc = {
 +		.dsc_version_major = 0x1,
 +		.dsc_version_minor = 0x1,
@@ -602,6 +667,7 @@ index 000000000000..9021933b0714
 +
 +	ret = pinfo->desc->init_sequence(pinfo);
 +	if (ret < 0) {
++		gpiod_set_value_cansleep(pinfo->reset_gpio, 1);
 +		regulator_bulk_disable(pinfo->desc->num_supplies,
 +				       pinfo->supplies);
 +		dev_err(panel->dev, "failed to initialize panel: %d\n", ret);
@@ -619,9 +685,9 @@ index 000000000000..9021933b0714
 +	pinfo->dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
 +
 +	mipi_dsi_dcs_set_display_off_multi(&dsi_ctx);
-+	mipi_dsi_msleep(&dsi_ctx, 50);
++	mipi_dsi_msleep(&dsi_ctx, pinfo->desc->display_off_ms);
 +	mipi_dsi_dcs_enter_sleep_mode_multi(&dsi_ctx);
-+	mipi_dsi_msleep(&dsi_ctx, 120);
++	mipi_dsi_msleep(&dsi_ctx, pinfo->desc->enter_sleep_ms);
 +
 +	return dsi_ctx.accum_err;
 +}
@@ -700,35 +766,30 @@ index 000000000000..9021933b0714
 +static int icna35xx_bl_update_status(struct backlight_device *bl)
 +{
 +	struct mipi_dsi_device *dsi = bl_get_data(bl);
++	struct panel_info *pinfo = mipi_dsi_get_drvdata(dsi);
++	unsigned int min = pinfo->desc->min_brightness;
++	unsigned int max = pinfo->desc->max_brightness;
 +	u16 brightness = backlight_get_brightness(bl);
 +	int ret;
++
++	if (!pinfo->panel.enabled)
++		return 0;
++
++	if (min && brightness)
++		brightness = min + (max - min) * brightness / max;
 +
 +	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
 +
 +	ret = mipi_dsi_dcs_set_display_brightness_large(dsi, brightness);
-+	if (ret < 0)
-+		return ret;
 +
 +	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
 +
-+	return 0;
++	return ret;
 +}
 +
 +static int icna35xx_bl_get_brightness(struct backlight_device *bl)
 +{
-+	struct mipi_dsi_device *dsi = bl_get_data(bl);
-+	u16 brightness;
-+	int ret;
-+
-+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
-+
-+	ret = mipi_dsi_dcs_get_display_brightness_large(dsi, &brightness);
-+	if (ret < 0)
-+		return ret;
-+
-+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
-+
-+	return brightness;
++	return backlight_get_brightness(bl);
 +}
 +
 +static const struct backlight_ops icna35xx_bl_ops = {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Inspiration from tiopex patch for sm8550 also match suspend and resume time to venor panel. Also pin porch and change DSI clock should save some power also matches vendor. 

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
