### PR TITLE
sm8250: Stop RP5 full speed fan at shutdown

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/linux/dts/qcom/sm8250-retroidpocket-common.dtsi
+++ b/projects/ROCKNIX/devices/SM8250/linux/dts/qcom/sm8250-retroidpocket-common.dtsi
@@ -214,6 +214,9 @@
 		gpio = <&tlmm 7 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 
+		pinctrl-names = "default";
+		pinctrl-0 = <&fan_pwr_en_state>;
+
 		regulator-state-mem {
 			regulator-off-in-suspend;
 		};
@@ -1095,7 +1098,7 @@
 	fan_pwm_active: fan-pwm-active-state {
 		pins = "gpio6";
 		function = "func1";
-        bias-disable;
+        bias-pull-down;
         power-source = <0>;
         output-low;
         qcom,drive-strength = <3>;
@@ -1326,6 +1329,13 @@
 		drive-strength = <16>;
 		output-low;
 		bias-pull-up;
+	};
+
+	fan_pwr_en_state: fan-pwr-en-state {
+		pins = "gpio7";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-down;
 	};
 
 	mcu_boot_default: mcu-boot-default-state {

--- a/projects/ROCKNIX/packages/hardware/quirks/package.mk
+++ b/projects/ROCKNIX/packages/hardware/quirks/package.mk
@@ -22,6 +22,7 @@ makeinstall_target() {
 
 post_install() {
   enable_service led-poweroff.service
+  enable_service fan-poweroff.service
   if [ "${DEVICE}" = "RK3566" ]
   then
     enable_service volume-fixup.service

--- a/projects/ROCKNIX/packages/hardware/quirks/system.d/fan-poweroff.service
+++ b/projects/ROCKNIX/packages/hardware/quirks/system.d/fan-poweroff.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cut fan power before shutting down.
+DefaultDependencies=no
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'for p in /sys/class/hwmon/hwmon*/pwm1; do [ -e "$p" ] && echo 0 > "$p"; done'
+TimeoutStartSec=0
+
+[Install]
+WantedBy=shutdown.target


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** QoL, refinement just ensures fan doesn't ramp at fullspeed on shutdown

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
