### PR TITLE
SM8750: add the gpio-keys-paddles source to the Odin 3 composite

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/filesystem/usr/share/inputplumber/devices/01-ayn-controller.yaml
+++ b/projects/ROCKNIX/devices/SM8750/filesystem/usr/share/inputplumber/devices/01-ayn-controller.yaml
@@ -29,6 +29,16 @@ source_devices:
       phys_path: rsinput-gamepad/input0
       handler: event*
     capability_map_id: ayn_mcu
+  # AYN Odin 3 back paddles (M1/M2): a separate gpio-keys device from the
+  # Odin 3 dts emitting BTN_Z (M1, left) / BTN_C (M2, right). Matched by
+  # name because its phys_path is shared with the other gpio-keys node.
+  # The ayn_mcu map turns them into Left/RightPaddle2, which the ds5-edge
+  # target emits as the Edge's real back-lever buttons.
+  - group: gamepad
+    evdev:
+      name: gpio-keys-paddles
+      handler: event*
+    capability_map_id: ayn_mcu
 
 # Optional configuration for the composite device
 options:


### PR DESCRIPTION
Follow-up to #2992, as discussed — the fix in e98cce3 landed on the PR branch minutes after the merge, so it never made it in.

Adds `gpio-keys-paddles` as a second gamepad source (matched by name — its phys_path is shared with the other gpio-keys node), mapped through `ayn_mcu` like the MCU pad. Completes the stock chain: gpio-keys (BTN_Z/C) → source → ayn_mcu (Left/RightPaddle2) → ds5-edge target → hid-playstation decode (#2991) → evdev/SDL paddles.

Same source config as running on my Odin 3: both paddles emit clean press/release as BTN_TRIGGER_HAPPY3/4 on the emulated Edge pad.

### AI Usage
**Did you use AI tools to help write this code?** PARTIALLY — authored with AI assistance; verified on-device.