### PR TITLE
qt6: fix PKG_VERSION / PKG_URL logic

### DIFF
--- a/projects/ROCKNIX/packages/graphics/qt6/package.mk
+++ b/projects/ROCKNIX/packages/graphics/qt6/package.mk
@@ -2,20 +2,26 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="qt6"
-PKG_VERSION_MAJOR="6.10"
-PKG_VERSION="${PKG_VERSION_MAJOR}.1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://download.qt.io"
-PKG_URL="${PKG_SITE}/archive/qt/${PKG_VERSION_MAJOR}/${PKG_VERSION}/single/qt-everywhere-src-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain qt6:host openssl libjpeg-turbo libpng pcre2 sqlite zlib freetype SDL2 gstreamer gst-plugins-base gst-plugins-good gst-libav"
 PKG_DEPENDS_HOST="gcc:host llvm:host mesa:host"
 PKG_LONGDESC="A cross-platform application and UI framework"
 
 # Mali devices require pinning to v6.8.3 or azahar-sa will segfault
-if [[ "${DEVICE}" =~ RK3566|RK3576|RK3588|S922X ]]; then
-  PKG_VERSION_MAJOR="6.8"
-  PKG_VERSION="${PKG_VERSION_MAJOR}.3"
-fi
+case ${DEVICE} in
+  RK35*|S922X)
+    PKG_VERSION_MAJOR="6.8"
+    PKG_VERSION="${PKG_VERSION_MAJOR}.3"
+  ;;
+  *)
+    PKG_VERSION_MAJOR="6.10"
+    PKG_VERSION="${PKG_VERSION_MAJOR}.1"
+  ;;
+esac
+
+# Package URL depends on version derived above
+PKG_URL="${PKG_SITE}/archive/qt/${PKG_VERSION_MAJOR}/${PKG_VERSION}/single/qt-everywhere-src-${PKG_VERSION}.tar.xz"
 
 # Apply project-specific patches
 PKG_PATCH_DIRS="${PROJECT}"


### PR DESCRIPTION
## Summary

qt6: fix PKG_VERSION / PKG_URL logic

## Testing

Tested S922X / SM8550 build

## Additional Context

Use `case` rather than regex so we don't need `bash` shell on GH runner

---

### AI Usage

**Did you use AI tools to help write this code?** NO
