### PR TITLE
sm8250: autoload for MPM gamepad

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0060_Mangmi-Pocket-Max-SPI-joypad.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0060_Mangmi-Pocket-Max-SPI-joypad.patch
@@ -37,7 +37,7 @@ new file mode 100644
 index 000000000000..82570eff2fbe
 --- /dev/null
 +++ b/drivers/input/joystick/mangmi-pocket-max.c
-@@ -0,0 +1,636 @@
+@@ -0,0 +1,644 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * MANGMI Pocket Max Joypad Driver SPI
@@ -660,6 +660,13 @@ index 000000000000..82570eff2fbe
 +};
 +MODULE_DEVICE_TABLE(of, pmax_of_match);
 +
++static const struct spi_device_id pmax_spi_id[] = {
++	{ "pocket-max-joypad" },
++	{ "mcu_joystick" },
++	{ }
++};
++MODULE_DEVICE_TABLE(spi, pmax_spi_id);
++
 +static struct spi_driver pmax_driver = {
 +	.driver = {
 +		.name = DRIVER_NAME,
@@ -668,6 +675,7 @@ index 000000000000..82570eff2fbe
 +	},
 +	.probe = pmax_probe,
 +	.remove = pmax_remove,
++	.id_table = pmax_spi_id,
 +};
 +module_spi_driver(pmax_driver);
 +


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** For spi devices udev reports with spi so now udev will autoload.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
