### PR TITLE
doom: fix default emulator

### DIFF
--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -1656,7 +1656,7 @@ makeinstall_target() {
 
   ### Doom
   add_emu_core doom gzdoom gzdoom-sa true
-  add_emu_core doom retroarch prboom true
+  add_emu_core doom retroarch prboom false
   add_es_system doom
 
   ### Media Player


### PR DESCRIPTION
## Summary

doom: fix default emulator

## Testing

Tested on my OGU

## Additional Context

Shouldn't have 2 emulators with `default=true`

---

### AI Usage

**Did you use AI tools to help write this code?** NO
