### PR TITLE
rk3576: Fix black screen on first boot

### DIFF
--- a/projects/ROCKNIX/devices/RK3576/linux/dts/rockchip/rk3576-anbernic-rg-vita-pro.dts
+++ b/projects/ROCKNIX/devices/RK3576/linux/dts/rockchip/rk3576-anbernic-rg-vita-pro.dts
@@ -761,6 +761,7 @@
 
 			vdd_gpu_s0: dcdc-reg5 {
 				regulator-boot-on;
+				regulator-always-on;
 				regulator-enable-ramp-delay = <400>;
 				regulator-min-microvolt = <550000>;
 				regulator-max-microvolt = <900000>;


### PR DESCRIPTION
## Summary

I noticed recently that whenever I flashed a new image the first boot (after all the setup boots) would halt on a black screen, requiring a press of the reset button.

After a whole bunch of logging, it looks like on that first boot the GPU powers down after a failed graphics driver startup, and when the second attempt to starts it's like "huh no GPU anymore" and black screens

I set `regulator-always-on;` in the dts just to test the theory, and that fixed the problem.

I fully admit, I don't know the consequences of `regulator-always-on;`, I assume we generally want to use the GPU for 100% of the device's operation so my _assumption_ is that we want `regulator-always-on;` and it makes little sense to not have it always on, but again this is a case of "this seems to fix the problem"

## Testing

Tested with and without the patch multiple fresh image-installs, and it's a 100% repro and 100% fix rate

## Additional Context

This issue does seem to be a regression on the `next` branch, for some reason it's only recently started happening

**I have not performed a bisect to figure out the regressing commit**

### AI Usage

NO