### PR TITLE
gamescope: RGA hardware acceleration

### DIFF
--- a/packages/linux-drivers/rga3/package.mk
+++ b/packages/linux-drivers/rga3/package.mk
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="rga3"
+# Pristine mirror of drivers/video/rockchip/rga3 (Rockchip BSP kernel); the
+# mainline port + RK3576 enablement are applied from patches/.
+PKG_VERSION="23e78a0b080603376409d7c8e6af925162b5b617"
+PKG_SITE="https://github.com/rockchip-linux/kernel"
+PKG_URL="https://github.com/felixjones/linux-rga3-mirror.git"
+PKG_LICENSE="GPL-2.0"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_LONGDESC="Rockchip multi-RGA (RGA2/RGA2E/RGA3) 2D accelerator driver. RK3576 uses a mainline kernel with no in-tree multi-RGA driver (only the older V4L2 rockchip-rga), so build the BSP driver out-of-tree to provide the /dev/rga miscdevice that librga consumers use."
+PKG_TOOLCHAIN="manual"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  kernel_make -C $(kernel_path) M="${PKG_BUILD}" modules
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+  cp ${PKG_BUILD}/rga3.ko ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+  # No MODULE_DEVICE_TABLE, so udev can't autoload it from a DT modalias.
+  mkdir -p ${INSTALL}/usr/lib/modules-load.d
+  echo "rga3" > ${INSTALL}/usr/lib/modules-load.d/rga3.conf
+}

--- a/packages/linux-drivers/rga3/patches/0001-rga3-build-as-an-out-of-tree-module.patch
+++ b/packages/linux-drivers/rga3/patches/0001-rga3-build-as-an-out-of-tree-module.patch
@@ -1,0 +1,28 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] rga3: build as an out-of-tree module
+
+The BSP ships an in-tree Kbuild (obj-$(CONFIG_ROCKCHIP_MULTI_RGA)). ROCKNIX
+builds this driver out-of-tree against a mainline kernel that has no such
+Kconfig symbol, so use a plain obj-m Makefile and a module-relative include
+path.
+
+diff --git a/Makefile b/Makefile
+index 11f401d..a929e0c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+-
+-ccflags-y += -I$(srctree)/$(src)/include
+-
+-rga3-y	:= rga_drv.o rga_common.o rga3_reg_info.o rga_iommu.o rga_dma_buf.o rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o
+-rga3-$(CONFIG_ROCKCHIP_RGA_ASYNC) += rga_fence.o
+-rga3-$(CONFIG_ROCKCHIP_RGA_DEBUGGER) += rga_debugger.o
+-
+-obj-$(CONFIG_ROCKCHIP_MULTI_RGA)	+= rga3.o
++# ROCKNIX: out-of-tree build of the Rockchip multi-RGA (rga3) driver.
++ccflags-y += -I$(src)/include
++obj-m += rga3.o
++rga3-y := rga_drv.o rga_common.o rga3_reg_info.o rga_iommu.o rga_dma_buf.o \
++          rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o

--- a/packages/linux-drivers/rga3/patches/0002-rga3-port-to-the-mainline-kernel-API.patch
+++ b/packages/linux-drivers/rga3/patches/0002-rga3-port-to-the-mainline-kernel-API.patch
@@ -1,0 +1,152 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] rga3: port to the mainline kernel API
+
+Adapt the Rockchip BSP (develop-6.1) driver to build against the mainline
+kernel ROCKNIX uses:
+
+ * dma-buf: mainline has no CONFIG_DMABUF_CACHE / <linux/dma-buf-cache.h>;
+   include <linux/dma-buf.h>.
+ * hrtimer: hrtimer_init() + assigning .function was replaced by
+   hrtimer_setup(timer, fn, ...).
+ * MODULE_IMPORT_NS() now takes a string literal.
+ * rga_get_user_pages_from_vma() manually walked the page tables with
+   pte_offset_map_lock() to pin raw VM_PFNMAP pointers; those helpers are no
+   longer exported to modules. This out-of-tree build only uses the dma-buf /
+   get_user_pages import paths, so stub the manual-walk fallback.
+
+diff --git a/include/rga_drv.h b/include/rga_drv.h
+index 1e9cbd5..aab9fe9 100644
+--- a/include/rga_drv.h
++++ b/include/rga_drv.h
+@@ -53,7 +53,7 @@
+ #include <linux/pagemap.h>
+ 
+ #ifdef CONFIG_DMABUF_CACHE
+-#include <linux/dma-buf-cache.h>
++#include <linux/dma-buf.h> /* ROCKNIX: was dma-buf-cache.h (BSP-only) */
+ #else
+ #include <linux/dma-buf.h>
+ #endif
+diff --git a/rga_drv.c b/rga_drv.c
+index 8a270a7..0e55302 100644
+--- a/rga_drv.c
++++ b/rga_drv.c
+@@ -370,9 +370,8 @@ static enum hrtimer_restart hrtimer_handler(struct hrtimer *timer)
+ static void rga_init_timer(void)
+ {
+ 	kt = ktime_set(0, RGA_TIMER_INTERVAL_NS);
+-	hrtimer_init(&timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+-
+-	timer.function = hrtimer_handler;
++	/* ROCKNIX: mainline replaced hrtimer_init()+.function with hrtimer_setup() */
++	hrtimer_setup(&timer, hrtimer_handler, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+ 
+ 	hrtimer_start(&timer, kt, HRTIMER_MODE_REL);
+ }
+@@ -1721,6 +1720,6 @@ MODULE_AUTHOR("putin.li@rock-chips.com");
+ MODULE_DESCRIPTION("Driver for rga device");
+ MODULE_LICENSE("GPL");
+ #ifdef MODULE_IMPORT_NS
+-MODULE_IMPORT_NS(DMA_BUF);
+-MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
++MODULE_IMPORT_NS("DMA_BUF");
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
+ #endif
+diff --git a/rga_mm.c b/rga_mm.c
+index c497ec3..8ad4b8f 100644
+--- a/rga_mm.c
++++ b/rga_mm.c
+@@ -33,82 +33,17 @@ static void rga_current_mm_read_unlock(struct mm_struct *mm)
+ }
+ 
+ static int rga_get_user_pages_from_vma(struct page **pages, unsigned long Memory,
+-				       uint32_t pageCount, struct mm_struct *current_mm)
++       uint32_t pageCount, struct mm_struct *current_mm)
+ {
+-	int ret = 0;
+-	int i;
+-	struct vm_area_struct *vma;
+-	spinlock_t *ptl;
+-	pte_t *pte;
+-	pgd_t *pgd;
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+-	p4d_t *p4d;
+-#endif
+-	pud_t *pud;
+-	pmd_t *pmd;
+-	unsigned long pfn;
+-
+-	for (i = 0; i < pageCount; i++) {
+-		vma = find_vma(current_mm, (Memory + i) << PAGE_SHIFT);
+-		if (!vma) {
+-			rga_err("page[%d] failed to get vma\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-
+-		pgd = pgd_offset(current_mm, (Memory + i) << PAGE_SHIFT);
+-		if (pgd_none(*pgd) || unlikely(pgd_bad(*pgd))) {
+-			rga_err("page[%d] failed to get pgd\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+-		/*
+-		 * In the four-level page table,
+-		 * it will do nothing and return pgd.
+-		 */
+-		p4d = p4d_offset(pgd, (Memory + i) << PAGE_SHIFT);
+-		if (p4d_none(*p4d) || unlikely(p4d_bad(*p4d))) {
+-			rga_err("page[%d] failed to get p4d\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-
+-		pud = pud_offset(p4d, (Memory + i) << PAGE_SHIFT);
+-#else
+-		pud = pud_offset(pgd, (Memory + i) << PAGE_SHIFT);
+-#endif
+-
+-		if (pud_none(*pud) || unlikely(pud_bad(*pud))) {
+-			rga_err("page[%d] failed to get pud\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-		pmd = pmd_offset(pud, (Memory + i) << PAGE_SHIFT);
+-		if (pmd_none(*pmd) || unlikely(pmd_bad(*pmd))) {
+-			rga_err("page[%d] failed to get pmd\n", i);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-		pte = pte_offset_map_lock(current_mm, pmd,
+-					  (Memory + i) << PAGE_SHIFT, &ptl);
+-		if (pte_none(*pte)) {
+-			rga_err("page[%d] failed to get pte\n", i);
+-			pte_unmap_unlock(pte, ptl);
+-			ret = RGA_OUT_OF_RESOURCES;
+-			break;
+-		}
+-
+-		pfn = pte_pfn(*pte);
+-		pages[i] = pfn_to_page(pfn);
+-		pte_unmap_unlock(pte, ptl);
+-	}
+-
+-	if (ret == RGA_OUT_OF_RESOURCES && i > 0)
+-		rga_err("Only get buffer %d byte from vma, but current image required %d byte",
+-			(int)(i * PAGE_SIZE), (int)(pageCount * PAGE_SIZE));
+-
+-	return ret;
++/*
++ * ROCKNIX: the original BSP fallback manually walked the page tables via
++ * pte_offset_map_lock() to pin raw VM_PFNMAP user pointers that
++ * get_user_pages() cannot. On mainline the pte map helpers are not
++ * exported to modules, and this out-of-tree build only uses the dma-buf /
++ * get_user_pages paths, so the manual-walk fallback is disabled.
++ */
++(void)pages; (void)Memory; (void)pageCount; (void)current_mm;
++return RGA_OUT_OF_RESOURCES;
+ }
+ 
+ static int rga_get_user_pages(struct page **pages, unsigned long Memory,

--- a/packages/linux-drivers/rga3/patches/0003-rga3-run-the-RK3576-RGA2-Pro-in-IOMMU-mode.patch
+++ b/packages/linux-drivers/rga3/patches/0003-rga3-run-the-RK3576-RGA2-Pro-in-IOMMU-mode.patch
@@ -1,0 +1,23 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] rga3: run the RK3576 RGA2-Pro in IOMMU mode
+
+The RK3576 RGA (hw_version 3.e.19357) maps to rga2p_iommu_data. Each RGA2-Pro
+core has an embedded 40-bit rockchip iommu-v2 MMU (described in the RK3576
+dtsi), so select RGA_IOMMU: this lets the engine operate on non-contiguous
+dma-buf (GPU) memory directly instead of only physically-contiguous CMA.
+
+diff --git a/rga_hw_config.c b/rga_hw_config.c
+index 581693e..1b3c753 100644
+--- a/rga_hw_config.c
++++ b/rga_hw_config.c
+@@ -724,6 +724,9 @@ const struct rga_hw_data rga2p_iommu_data = {
+ 			RGA_MODE_CSC_BT709,
+ 	.csc_y2r_mode = RGA_MODE_CSC_BT601L | RGA_MODE_CSC_BT601F |
+ 			RGA_MODE_CSC_BT709,
++	/* ROCKNIX: RK3576 RGA (ver 3.e.19357 -> rga2p_iommu_data). The RGA2-Pro
++	 * embeds a 40-bit rockchip iommu-v2 MMU (DT: rga2_core{0,1}_mmu). RGA_IOMMU lets
++	 * it rotate non-contiguous dma-buf (GPU) memory directly, not just CMA. */
+ 	.mmu = RGA_IOMMU,
+ 
+ 	.cmd_reg_size = 32, //0x100:0x17c

--- a/packages/linux-drivers/rga3/patches/0004-rga3-enable-async-fence-mode.patch
+++ b/packages/linux-drivers/rga3/patches/0004-rga3-enable-async-fence-mode.patch
@@ -1,0 +1,26 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Mon, 6 Jul 2026 23:18:40 +0200
+Subject: [PATCH] rga3: enable asynchronous fence mode
+
+The out-of-tree Makefile dropped the config-gated async objects, so the driver
+was built without rga_fence.o and rejects RGA_BLIT_ASYNC ("The current driver
+does not support asynchronous mode, please enable CONFIG_ROCKCHIP_RGA_ASYNC").
+
+Build rga_fence.o and define CONFIG_ROCKCHIP_RGA_ASYNC so the driver returns a
+release fence for non-blocking blits, letting a client overlap the blit with
+other work instead of blocking on completion. RK3588 already enables this
+option.
+
+diff --git a/Makefile b/Makefile
+index a929e0c..575f35c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ # ROCKNIX: out-of-tree build of the Rockchip multi-RGA (rga3) driver.
+-ccflags-y += -I$(src)/include
++ccflags-y += -I$(src)/include -DCONFIG_ROCKCHIP_RGA_ASYNC=1
+ obj-m += rga3.o
+ rga3-y := rga_drv.o rga_common.o rga3_reg_info.o rga_iommu.o rga_dma_buf.o \
+-          rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o
++          rga_job.o rga_hw_config.o rga2_reg_info.o rga_policy.o rga_mm.o rga_fence.o

--- a/projects/ROCKNIX/devices/RK3576/options
+++ b/projects/ROCKNIX/devices/RK3576/options
@@ -62,7 +62,8 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="mali-bifrost"
+  # rga3: Rockchip multi-RGA 2D accelerator.
+    ADDITIONAL_DRIVERS="mali-bifrost rga3"
 
   # Additional Firmware to use ( )
   # Space separated list is supported,

--- a/projects/ROCKNIX/devices/RK3576/patches/linux/0019-arm64-dts-rockchip-rk3576-add-rga2-iommu-nodes.patch
+++ b/projects/ROCKNIX/devices/RK3576/patches/linux/0019-arm64-dts-rockchip-rk3576-add-rga2-iommu-nodes.patch
@@ -1,0 +1,95 @@
+From: Felix Jones <felix@felixjones.co.uk>
+Date: Sun, 5 Jul 2026 00:14:55 +0200
+Subject: [PATCH] arm64: dts: rockchip: rk3576: add RGA2 nodes with IOMMU for
+ hardware rotation
+
+The RK3576 has two RGA2-Pro cores (reported hw_version 3.e.19357) at
+0x27920000 and 0x27930000. Mainline does not describe them. Add the two
+rga@ nodes so the rockchip multi-RGA driver (packages/linux-drivers/rga3)
+can bind and expose /dev/rga for hardware-accelerated rotate/scale/blit
+(used to rotate the gamescope output for the 90deg-mounted panel in
+hardware, instead of on the GPU compute composite).
+
+Each RGA2-Pro core has an embedded 40-bit rockchip iommu-v2 MMU at
+core_base + 0xf00, with a register block identical to the standalone
+rk3568/rk3576 iommu. Describe each as a rockchip,rk3576-iommu node and
+wire it to its core via the iommus property, so the rga3 driver runs in
+RGA_IOMMU mode and can rotate non-contiguous (GPU/dma-buf) memory -- not
+just physically-contiguous CMA. The mainline rockchip-iommu driver
+already provides the v2 (40-bit) ops via the rockchip,rk3568-iommu match
+(used by vop_mmu/vdec_mmu on this SoC).
+
+Notes:
+ * The core reg is shrunk from 0x1000 to 0xf00 so the mmu node owns the
+   MMU register page (0xf00-0xfff) without overlapping the core mapping.
+ * The MMU shares the core's GIC SPI (328/329); both rga3 and rk_iommu
+   request it with IRQF_SHARED, so the shared line is fine.
+ * Pairs with the rga3 driver change setting rga2p_iommu_data.mmu =
+   RGA_IOMMU (packages/linux-drivers/rga3, patch 0003).
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+index 58f2215..9b493c6 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+@@ -1279,6 +1279,61 @@
+ 			status = "disabled";
+ 		};
+ 
++			/* ROCKNIX: RGA2E 2D accelerator (two cores) for hardware rotation.
++			 * Each RGA2-Pro core has an embedded 40-bit rockchip iommu-v2 MMU at
++			 * core_base + 0xf00 (register block identical to the standalone
++			 * rk3568/rk3576 iommu). The core reg is shrunk to 0xf00 so the mmu
++			 * node owns the MMU page. The MMU shares the core GIC SPI (both the
++			 * rga3 and rk_iommu drivers request it IRQF_SHARED). Requires the rga3
++			 * driver hw_data rga2p_iommu_data.mmu = RGA_IOMMU. */
++			rga2_core0: rga@27920000 {
++				compatible = "rockchip,rga2";
++				reg = <0x0 0x27920000 0x0 0xf00>;
++				interrupts = <GIC_SPI 328 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_core0_irq";
++				clocks = <&cru ACLK_RGA2E_0>, <&cru HCLK_RGA2E_0>, <&cru CLK_CORE_RGA2E_0>;
++				clock-names = "aclk_rga", "hclk_rga", "clk_rga";
++				power-domains = <&power RK3576_PD_VPU>;
++				iommus = <&rga2_core0_mmu>;
++				status = "okay";
++			};
++
++			rga2_core0_mmu: iommu@27920f00 {
++				compatible = "rockchip,rk3576-iommu", "rockchip,rk3568-iommu";
++				reg = <0x0 0x27920f00 0x0 0x100>;
++				interrupts = <GIC_SPI 328 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_0_mmu";
++				clocks = <&cru ACLK_RGA2E_0>, <&cru HCLK_RGA2E_0>;
++				clock-names = "aclk", "iface";
++				power-domains = <&power RK3576_PD_VPU>;
++				#iommu-cells = <0>;
++				status = "okay";
++			};
++
++			rga2_core1: rga@27930000 {
++				compatible = "rockchip,rga2";
++				reg = <0x0 0x27930000 0x0 0xf00>;
++				interrupts = <GIC_SPI 329 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_core1_irq";
++				clocks = <&cru ACLK_RGA2E_1>, <&cru HCLK_RGA2E_1>, <&cru CLK_CORE_RGA2E_1>;
++				clock-names = "aclk_rga", "hclk_rga", "clk_rga";
++				power-domains = <&power RK3576_PD_VPU>;
++				iommus = <&rga2_core1_mmu>;
++				status = "okay";
++			};
++
++			rga2_core1_mmu: iommu@27930f00 {
++				compatible = "rockchip,rk3576-iommu", "rockchip,rk3568-iommu";
++				reg = <0x0 0x27930f00 0x0 0x100>;
++				interrupts = <GIC_SPI 329 IRQ_TYPE_LEVEL_HIGH>;
++				interrupt-names = "rga2_1_mmu";
++				clocks = <&cru ACLK_RGA2E_1>, <&cru HCLK_RGA2E_1>;
++				clock-names = "aclk", "iface";
++				power-domains = <&power RK3576_PD_VPU>;
++				#iommu-cells = <0>;
++				status = "okay";
++			};
++
+ 		vdec: video-codec@27b00000 {
+ 			compatible = "rockchip,rk3576-vdec";
+ 			reg = <0x0 0x27b00100 0x0 0x500>,

--- a/projects/ROCKNIX/packages/apps/gamescope/package.mk
+++ b/projects/ROCKNIX/packages/apps/gamescope/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="gamescope"
-PKG_VERSION="428688779e481681ddf6e2ea346987889527a0b7"
+PKG_VERSION="61c74c18af1aaa4a2593f73b409a0c22b9314db4"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="BSD-2-Clause"
 PKG_SITE="https://github.com/ValveSoftware/gamescope"

--- a/projects/ROCKNIX/packages/apps/gamescope/package.mk
+++ b/projects/ROCKNIX/packages/apps/gamescope/package.mk
@@ -20,6 +20,17 @@ configure_package() {
   if [ "${VULKAN_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" ${VULKAN}"
   fi
+
+  # Rockchip arm/aarch64 targets ship the RGA2 2D engine; link
+  # librga so gamescope can offload panel rotation + nested->native upscaling to
+  # it (see patches 0014/0015). librga only builds for arm/aarch64, and the RGA
+  # path is additionally gated at runtime on /dev/rga, so this is a no-op on
+  # hardware without an RGA.
+  case "${TARGET_ARCH}" in
+    arm|aarch64)
+      PKG_DEPENDS_TARGET+=" librga"
+      ;;
+  esac
 }
 
 pre_configure_target() {

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0007-rendervulkan-composite-without-robustness2-mali.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0007-rendervulkan-composite-without-robustness2-mali.patch
@@ -1,0 +1,75 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: composite without VK_EXT_robustness2 on Mali
+
+gamescope unconditionally enables VK_EXT_robustness2 only to use its nullDescriptor feature, binding VK_NULL_HANDLE combined-image-sampler / storage-image descriptors to the composite slots it does not use (the unused ycbcr chroma target, unused layer/ycbcr sampler slots and absent colour-management LUTs). Mali drivers (libMali, PanVK) do not implement robustness2, so the device either cannot be created or faults in vkUpdateDescriptorSets on the first null descriptor, crashing the compositor whenever a client layer is presented. Stop requesting robustness2 and bind a valid blank texture view (plus the luma view for the unused chroma target) to those slots instead. The shader only samples bound layers, so the blanks are inert; this makes the compute composite work on Mali with no dependency on nullDescriptor.
+
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 0be72f6..95635bc 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -576,7 +576,6 @@ bool CVulkanDevice::createDevice()
+ 
+ 	enabledExtensions.push_back( VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME );
+ 
+-	enabledExtensions.push_back( VK_EXT_ROBUSTNESS_2_EXTENSION_NAME );
+ #if 0
+ 	enabledExtensions.push_back( VK_KHR_MAINTENANCE_5_EXTENSION_NAME );
+ #endif
+@@ -666,11 +665,6 @@ bool CVulkanDevice::createDevice()
+ 		.samplerYcbcrConversion = VK_TRUE,
+ 	};
+ 
+-	VkPhysicalDeviceRobustness2FeaturesEXT robustness2Features = {
+-		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT,
+-		.pNext = std::exchange(features2.pNext, &robustness2Features),
+-		.nullDescriptor = VK_TRUE,
+-	};
+ 
+ 	VkResult res = vk.CreateDevice(physDev(), &deviceCreateInfo, nullptr, &m_device);
+ 	if ( res == VK_ERROR_NOT_PERMITTED_KHR && gamescope::Process::HasCapSysNice() )
+@@ -1744,11 +1738,21 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
+ 	scratchDescriptor.offset = m_renderBufferOffset;
+ 	scratchDescriptor.range = VK_WHOLE_SIZE;
+ 
++	// Mali GPU drivers (libMali, PanVK) do not implement VK_EXT_robustness2, so a
++	// null combined-image-sampler faults them. Bind a valid blank view to every
++	// otherwise-unused composite slot instead (inert: only bound layers are
++	// sampled), so no null descriptor is ever created.
++	VkImageView blankView = VK_NULL_HANDLE;
++	if ( CVulkanTexture *blank = vulkan_get_hacky_blank_texture().get() )
++		blankView = blank->linearView();
++
+ 	for (uint32_t i = 0; i < VKR_SAMPLER_SLOTS; i++)
+ 	{
+ 		imageDescriptors[i].sampler = m_device->sampler(m_samplerState[i]);
+ 		imageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+ 		ycbcrImageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
++		imageDescriptors[i].imageView = blankView;
++		ycbcrImageDescriptors[i].imageView = blankView;
+ 		if (m_boundTextures[i] == nullptr)
+ 			continue;
+ 
+@@ -1773,17 +1777,21 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
+ 		shaperLutDescriptor[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+ 		// TODO(Josh): I hate the fact that srgbView = view *as* raw srgb and treat as linear.
+ 		// I need to change this, it's so utterly stupid and confusing.
+-		shaperLutDescriptor[i].imageView = m_shaperLut[i] ? m_shaperLut[i]->srgbView() : VK_NULL_HANDLE;
++		shaperLutDescriptor[i].imageView = m_shaperLut[i] ? m_shaperLut[i]->srgbView() : blankView;
+ 
+ 		lut3DDescriptor[i].sampler = m_device->sampler(nearestState);
+ 		lut3DDescriptor[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+-		lut3DDescriptor[i].imageView = m_lut3D[i] ? m_lut3D[i]->srgbView() : VK_NULL_HANDLE;
++		lut3DDescriptor[i].imageView = m_lut3D[i] ? m_lut3D[i]->srgbView() : blankView;
+ 	}
+ 
+ 	if (!m_target->isYcbcr())
+ 	{
+ 		targetDescriptors[0].imageView = m_target->srgbView();
+ 		targetDescriptors[0].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
++		// binding 2 (chroma storage image) is unused for non-ycbcr targets; bind the
++		// luma view so it is never a null descriptor.
++		targetDescriptors[1].imageView = m_target->srgbView();
++		targetDescriptors[1].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+ 	}
+ 	else
+ 	{

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0008-rendervulkan-DRMBackend-libmali-cma-scanout-RK3576.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0008-rendervulkan-DRMBackend-libmali-cma-scanout-RK3576.patch
@@ -1,0 +1,267 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan, DRMBackend: libMali CMA scanout on RK3576
+
+The proprietary ARM libMali Vulkan blob lacks VK_EXT_physical_device_drm and cannot export dma-bufs. Accept the device and find a DRM node via libdrm; drop the DRM master libMaliVulkan grabs on card0 before the KMS backend opens it; allocate the output images from the CMA dma-heap as LINEAR and import them for compositing and scanout (flippable/exported images crash on libMali); and open a read-only advertisement fd so wlroots binds wl_drm / zwp_linux_dmabuf_v1. Automatic via absence of VK_EXT_physical_device_drm; Mesa/PanVK keep the exported path.
+
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index 108333e..2ec0f5a 100644
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -6,6 +6,7 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <unistd.h>
++#include <dirent.h>
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <poll.h>
+@@ -1266,6 +1267,30 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
+ 		drm_log.infof("warning: picking an arbitrary DRM device");
+ 	}
+ 
++	if ( drm->device_name )
++	{
++		struct stat targetSt = {};
++		if ( stat( drm->device_name, &targetSt ) == 0 )
++		{
++			if ( DIR *pFdDir = opendir( "/proc/self/fd" ) )
++			{
++				struct dirent *pEnt;
++				while ( ( pEnt = readdir( pFdDir ) ) != nullptr )
++				{
++					int nFd = atoi( pEnt->d_name );
++					if ( nFd <= 2 )
++						continue;
++					struct stat fdSt = {};
++					if ( fstat( nFd, &fdSt ) != 0 || !S_ISCHR( fdSt.st_mode ) )
++						continue;
++					if ( fdSt.st_rdev != targetSt.st_rdev )
++						continue;
++					drmDropMaster( nFd );
++				}
++				closedir( pFdDir );
++			}
++		}
++	}
+ 	drm->fd = wlsession_open_kms( drm->device_name );
+ 	if ( drm->fd < 0 )
+ 	{
+@@ -3500,7 +3525,7 @@ namespace gamescope
+         }
+ 		virtual bool ValidPhysicalDevice( VkPhysicalDevice pVkPhysicalDevice ) const override
+ 		{
+-			return vulkan_has_drm_props();
++			return true;
+ 		}
+ 
+ 		virtual int Present( const FrameInfo_t *pFrameInfo, bool bAsync )
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index a7bb6b1..581054d 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -11,6 +11,8 @@
+ #include <bitset>
+ #include <thread>
+ #include <dlfcn.h>
++#include <sys/ioctl.h>
++#include <linux/dma-heap.h>
+ #include "vulkan_include.h"
+ #include "Utils/Algorithm.h"
+ 
+@@ -460,11 +462,62 @@ bool CVulkanDevice::createDevice()
+ 
+ 	vk_log.infof( "physical device %s DRM format modifiers", m_bSupportsModifiers ? "supports" : "does not support" );
+ 
+-	if ( !hasDrmProps ) {
+-		// This could happen when e.g. running the lavapipe driver
+-		// (without an actual physical device)
++	if ( !hasDrmProps )
++	{
+ 		vk_log.warnf( "physical device doesn't support VK_EXT_physical_device_drm" );
+-	} else {
++#if HAVE_DRM
++		drmDevicePtr devices[16] = {};
++		int nDevs = drmGetDevices2( 0, devices, 16 );
++		if ( nDevs <= 0 )
++		{
++			vk_log.errorf( "libmali fallback: drmGetDevices2() returned %d", nDevs );
++			return false;
++		}
++		for ( int pass = 0; pass < 2 && m_drmRendererFd < 0; pass++ )
++		{
++			int wantedNodeBit = ( pass == 0 ) ? DRM_NODE_RENDER : DRM_NODE_PRIMARY;
++			for ( int i = 0; i < nDevs && m_drmRendererFd < 0; i++ )
++			{
++				drmDevicePtr dev = devices[i];
++				if ( !( dev->available_nodes & ( 1 << wantedNodeBit ) ) )
++					continue;
++				const char *nodeName = dev->nodes[wantedNodeBit];
++				if ( wantedNodeBit == DRM_NODE_PRIMARY )
++				{
++					struct stat st = {};
++					if ( stat( nodeName, &st ) == 0 )
++					{
++						m_bHasDrmPrimaryDevId = true;
++						m_drmPrimaryDevId = st.st_rdev;
++					}
++					if ( m_drmAdvertiseFd < 0 )
++					{
++						int advFd = open( nodeName, O_RDONLY | O_CLOEXEC );
++						if ( advFd >= 0 )
++						{
++							m_drmAdvertiseFd = advFd;
++						}
++					}
++					continue;
++				}
++				int fd = open( nodeName, O_RDWR | O_CLOEXEC );
++				if ( fd < 0 )
++				{
++					continue;
++				}
++				m_drmRendererFd = fd;
++			}
++		}
++		drmFreeDevices( devices, nDevs );
++		if ( m_drmRendererFd < 0 && !m_bHasDrmPrimaryDevId )
++		{
++			vk_log.errorf( "libmali fallback: no DRM render or primary node available" );
++			return false;
++		}
++#endif
++	}
++	else
++	{
+ #if HAVE_DRM
+ 		VkPhysicalDeviceDrmPropertiesEXT drmProps = {
+ 			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT,
+@@ -2038,6 +2091,8 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
+ 	m_drmFormat = drmFormat;
+ 	VkResult res = VK_ERROR_INITIALIZATION_FAILED;
+ 
++	if ( flags.bFlippable && pDMA == nullptr && !vulkan_has_drm_props() )
++		flags.bFlippable = false;
+ 	VkImageTiling tiling = (flags.bMappable || flags.bLinear) ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL;
+ 	VkImageUsageFlags usage = 0;
+ 	VkMemoryPropertyFlags properties;
+@@ -3110,6 +3165,8 @@ gamescope::OwningRc<CVulkanTexture> vulkan_create_flat_texture( uint32_t width,
+ 	flags.bFlippable = true;
+ 	flags.bSampled = true;
+ 	flags.bTransferDst = true;
++	if ( !vulkan_has_drm_props() )
++		flags.bFlippable = false;
+ 
+ 	gamescope::OwningRc<CVulkanTexture> texture = new CVulkanTexture();
+ 	bool bRes = texture->BInit( width, height, 1u, VulkanFormatToDRM( VK_FORMAT_B8G8R8A8_UNORM ), flags );
+@@ -3287,6 +3344,58 @@ bool vulkan_remake_swapchain( void )
+ 	return bRet;
+ }
+ 
++namespace rxnix_cma {
++    static int g_DmaHeapFd = -1;
++    static int dmaheap_alloc( size_t bytes ) {
++        if ( g_DmaHeapFd < 0 ) {
++            g_DmaHeapFd = open( "/dev/dma_heap/default_cma_region", O_RDWR | O_CLOEXEC );
++            if ( g_DmaHeapFd < 0 ) { vk_log.errorf_errno( "rxnix_cma: open dma_heap default_cma_region" ); return -1; }
++        }
++        struct dma_heap_allocation_data a = {};
++        a.len = bytes;
++        a.fd_flags = O_RDWR | O_CLOEXEC;
++        if ( ioctl( g_DmaHeapFd, DMA_HEAP_IOCTL_ALLOC, &a ) < 0 ) {
++            vk_log.errorf_errno( "rxnix_cma: DMA_HEAP_IOCTL_ALLOC %zu", bytes );
++            return -1;
++        }
++        return (int)a.fd;
++    }
++    static bool make_output_image( gamescope::OwningRc<CVulkanTexture> &outTex,
++                                   uint32_t width, uint32_t height, uint32_t drmFormat ) {
++        uint32_t stride_bytes = ( ( width * 4u ) + 255u ) & ~255u; // aligned pitch (import + VOP2 scanout)
++        size_t size = (size_t)stride_bytes * height;
++        int fd = dmaheap_alloc( size );
++        if ( fd < 0 ) return false;
++        struct wlr_dmabuf_attributes attrs = {};
++        attrs.width = (int)width;
++        attrs.height = (int)height;
++        attrs.format = drmFormat;
++        attrs.modifier = DRM_FORMAT_MOD_LINEAR;
++        attrs.n_planes = 1;
++        attrs.fd[0] = fd;
++        attrs.stride[0] = stride_bytes;
++        attrs.offset[0] = 0;
++        gamescope::OwningRc<gamescope::IBackendFb> pBackendFb = GetBackend()->ImportDmabufToBackend( &attrs );
++        if ( !pBackendFb ) {
++            vk_log.errorf( "rxnix_cma: ImportDmabufToBackend failed (%ux%u stride=%u fmt=0x%x)", width, height, stride_bytes, drmFormat );
++            close( fd );
++            return false;
++        }
++        CVulkanTexture::createFlags flags;
++        flags.bSampled = true;
++        flags.bStorage = true;
++        flags.bOutputImage = true;
++        flags.bTransferSrc = true;
++        gamescope::OwningRc<CVulkanTexture> pTex = new CVulkanTexture();
++        if ( !pTex->BInit( width, height, 1u, drmFormat, flags, &attrs, 0, 0, nullptr, std::move( pBackendFb ) ) ) {
++            vk_log.errorf( "rxnix_cma: BInit failed on CMA dma-buf (%ux%u stride=%u fmt=0x%x)", width, height, stride_bytes, drmFormat );
++            close( fd );
++            return false;
++        }
++        outTex = std::move( pTex );
++        return true;
++    }
++} // namespace rxnix_cma
+ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ {
+ 	CVulkanTexture::createFlags outputImageflags;
+@@ -3308,6 +3417,20 @@ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ 
+ 	uint32_t uDRMFormat = pOutput->uOutputFormat;
+ 
++	if ( !vulkan_has_drm_props() )
++	{
++		uint32_t fmt = ( uDRMFormat != DRM_FORMAT_INVALID ) ? uDRMFormat : DRM_FORMAT_ABGR8888;
++		for ( int i = 0; i < 3; i++ )
++		{
++			if ( !rxnix_cma::make_output_image( pOutput->outputImages[i], outputWidth, outputHeight, fmt ) )
++			{
++				vk_log.errorf( "rxnix_cma: output image %d alloc failed", i );
++				return false;
++			}
++		}
++		pOutput->temporaryHackyBlankImage = vulkan_create_debug_blank_texture( outputWidth, outputHeight );
++		return true;
++	}
+ 	pOutput->outputImages[0] = new CVulkanTexture();
+ 	bool bSuccess = pOutput->outputImages[0]->BInit( g_nOutputWidth, g_nOutputHeight, 1u, uDRMFormat, outputImageflags );
+ 	if ( bSuccess != true )
+@@ -4312,7 +4435,10 @@ static const struct wlr_drm_format_set *renderer_get_texture_formats( struct wlr
+ 
+ static int renderer_get_drm_fd( struct wlr_renderer *wlr_renderer )
+ {
+-	return g_device.drmRenderFd();
++	int fd = g_device.drmRenderFd();
++	if ( fd < 0 )
++		fd = g_device.drmAdvertiseFd();
++	return fd;
+ }
+ 
+ static struct wlr_texture *renderer_texture_from_buffer( struct wlr_renderer *wlr_renderer, struct wlr_buffer *buf )
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index b0ee208..0035641 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -802,6 +802,7 @@ public:
+ 	inline VkBuffer uploadBuffer() {return m_uploadBuffer;}
+ 	inline VkPipelineLayout pipelineLayout() {return m_pipelineLayout;}
+ 	inline int drmRenderFd() {return m_drmRendererFd;}
++	inline int drmAdvertiseFd() {return m_drmAdvertiseFd;}
+ 	inline bool supportsModifiers() {return m_bSupportsModifiers;}
+ 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
+ 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
+@@ -865,6 +866,7 @@ protected:
+ 	uint32_t m_generalQueueFamily = -1;
+ 
+ 	int m_drmRendererFd = -1;
++	int m_drmAdvertiseFd = -1;
+ 	dev_t m_drmPrimaryDevId = 0;
+ 
+ 	bool m_bSupportsFp16 = false;

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0009-wlserver-mali-buffer-sharing-for-libmali-EGL.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0009-wlserver-mali-buffer-sharing-for-libmali-EGL.patch
@@ -1,0 +1,145 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] wlserver: mali_buffer_sharing protocol for libMali EGL clients
+
+libMali EGL requires the mali_buffer_sharing global for eglInitialize to succeed; without it GLES clients (glmark2-es2-wayland) fail with EGL_NOT_INITIALIZED. Implement the server side in wlserver, backed by the existing wlr dmabuf buffer factory. Registered automatically when the Vulkan driver lacks VK_EXT_physical_device_drm (libMali); Mesa/PanVK unaffected.
+
+diff --git a/src/wlserver.cpp b/src/wlserver.cpp
+index 34cd5ae..f143c6a 100644
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -33,6 +33,7 @@
+ #include <wlr/render/wlr_renderer.h>
+ #include <wlr/types/wlr_compositor.h>
+ #include <wlr/types/wlr_keyboard.h>
++#include <wlr/types/wlr_linux_dmabuf_v1.h>
+ #include <wlr/types/wlr_keyboard_group.h>
+ #include <wlr/types/wlr_pointer.h>
+ #include <wlr/types/wlr_seat.h>
+@@ -2053,6 +2054,73 @@ bool wlserver_init( void ) {
+ 	// Someday, he will be purged.
+ 	wlr_drm_create(wlserver.display, wlserver.wlr.renderer);
+ 
++	extern bool vulkan_has_drm_props();
++	if ( !vulkan_has_drm_props() )
++	{
++		static const struct wl_interface *mali_create_buffer_types[] = {
++			&wl_buffer_interface, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
++		};
++		static const struct wl_message mali_buffer_sharing_requests[] = {
++			{ "create_buffer", "niiiuuuh", mali_create_buffer_types },
++		};
++		static const struct wl_interface mali_buffer_sharing_interface = {
++			"mali_buffer_sharing", 5, 1, mali_buffer_sharing_requests, 0, NULL,
++		};
++		struct mali_buffer_sharing_state {
++			struct wl_global *global;
++		};
++		static const struct wl_interface *s_iface = &mali_buffer_sharing_interface;
++		static auto mali_create_buffer_handler = [](
++				struct wl_client *client, struct wl_resource *resource,
++				uint32_t buffer_id,
++				int32_t width, int32_t height, int32_t stride,
++				uint32_t format, uint32_t modifier_hi, uint32_t modifier_lo,
++				int32_t fd) {
++			uint64_t modifier = ((uint64_t)modifier_hi << 32) | modifier_lo;
++			bool isAFBC = (modifier != 0);
++			wl_log.infof("mali_buffer_sharing: create_buffer %dx%d stride=%d fmt=0x%x mod=0x%x_%x fd=%d%s",
++				width, height, stride, format, modifier_hi, modifier_lo, fd,
++				isAFBC ? " [AFBC]" : " [LINEAR]");
++			struct wlr_dmabuf_attributes attribs = {};
++			attribs.width = width;
++			attribs.height = height;
++			attribs.format = format;
++			attribs.modifier = modifier;
++			attribs.n_planes = 1;
++			attribs.offset[0] = 0;
++			attribs.stride[0] = stride;
++			attribs.fd[0] = fd;
++			for (int i = 1; i < WLR_DMABUF_MAX_PLANES; i++)
++				attribs.fd[i] = -1;
++			struct wl_resource *buf = wlr_dmabuf_v1_buffer_create_immed(
++				client, buffer_id, &attribs);
++			if (!buf) {
++				wl_resource_post_error(resource, 0,
++					"mali_buffer_sharing: create_buffer failed");
++			}
++		};
++		typedef void (*mali_create_buffer_fn)(
++			struct wl_client *, struct wl_resource *,
++			uint32_t, int32_t, int32_t, int32_t,
++			uint32_t, uint32_t, uint32_t, int32_t);
++		struct mali_buffer_sharing_impl {
++			mali_create_buffer_fn create_buffer;
++		};
++		static const struct mali_buffer_sharing_impl mali_impl = {
++			.create_buffer = mali_create_buffer_handler,
++		};
++		static auto mali_bind = [](struct wl_client *client, void *data,
++				uint32_t version, uint32_t id) {
++			struct wl_resource *resource = wl_resource_create(client,
++				s_iface, version, id);
++			if (!resource) {
++				wl_client_post_no_memory(client);
++				return;
++			}
++			wl_resource_set_implementation(resource, &mali_impl, data, NULL);
++		};
++		wl_global_create(wlserver.display, s_iface, 5, NULL, mali_bind);
++	}
+ 	if ( GetBackend()->SupportsExplicitSync() )
+ 	{
+ 		create_explicit_sync();
+diff --git a/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h b/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h
+index cf967f9..53605fa 100644
+--- a/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h
++++ b/subprojects/wlroots/include/wlr/types/wlr_linux_dmabuf_v1.h
+@@ -134,4 +134,7 @@ struct wlr_linux_dmabuf_feedback_v1_init_options {
+ bool wlr_linux_dmabuf_feedback_v1_init_with_options(struct wlr_linux_dmabuf_feedback_v1 *feedback,
+ 	const struct wlr_linux_dmabuf_feedback_v1_init_options *options);
+ 
++struct wl_resource *wlr_dmabuf_v1_buffer_create_immed(
++		struct wl_client *client, uint32_t buffer_id,
++		struct wlr_dmabuf_attributes *attribs);
+ #endif
+diff --git a/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c b/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c
+index bfd9763..85bc46a 100644
+--- a/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c
++++ b/subprojects/wlroots/types/wlr_linux_dmabuf_v1.c
+@@ -1171,3 +1171,37 @@ error:
+ 	wlr_linux_dmabuf_feedback_v1_finish(feedback);
+ 	return false;
+ }
++struct wl_resource *wlr_dmabuf_v1_buffer_create_immed(
++		struct wl_client *client, uint32_t buffer_id,
++		struct wlr_dmabuf_attributes *attribs) {
++	if (attribs->width < 1 || attribs->height < 1) {
++		wlr_log(WLR_ERROR, "wlr_dmabuf_v1_buffer_create_immed: invalid dimensions %dx%d",
++			attribs->width, attribs->height);
++		wlr_dmabuf_attributes_finish(attribs);
++		return NULL;
++	}
++	if (attribs->n_planes < 1 || attribs->fd[0] < 0) {
++		wlr_log(WLR_ERROR, "wlr_dmabuf_v1_buffer_create_immed: no valid plane fd");
++		wlr_dmabuf_attributes_finish(attribs);
++		return NULL;
++	}
++	struct wlr_dmabuf_v1_buffer *buffer = calloc(1, sizeof(*buffer));
++	if (!buffer) {
++		wlr_dmabuf_attributes_finish(attribs);
++		return NULL;
++	}
++	wlr_buffer_init(&buffer->base, &buffer_impl, attribs->width, attribs->height);
++	buffer->resource = wl_resource_create(client, &wl_buffer_interface,
++		1, buffer_id);
++	if (!buffer->resource) {
++		wlr_dmabuf_attributes_finish(attribs);
++		free(buffer);
++		return NULL;
++	}
++	wl_resource_set_implementation(buffer->resource,
++		&wl_buffer_impl, buffer, buffer_handle_resource_destroy);
++	buffer->attributes = *attribs;
++	buffer->release.notify = buffer_handle_release;
++	wl_signal_add(&buffer->base.events.release, &buffer->release);
++	return buffer->resource;
++}

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0010-DRMBackend-rotate-composite-in-shader-rotated-panel.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0010-DRMBackend-rotate-composite-in-shader-rotated-panel.patch
@@ -1,0 +1,28 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] DRMBackend: rotate composite in-shader for rotated internal panels
+
+Embedded display planes (e.g. rockchip VOP) generally cannot hardware-rotate, so a physically-rotated internal panel (mounted 90/270) fails plane scanout with EINVAL - liftoff finds no plane that accepts the requested rotation, and nothing is presented. gamescope already carries a composite rotation shader (gated behind --use-rotation-shader); enable it automatically once the internal panel is detected as rotated, so the compositor bakes the rotation into its output and the scanout layer needs only rotation=identity. Applies to any GPU driver on such a panel.
+
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index a041491..8e950d3 100644
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -1763,6 +1763,18 @@ static void update_drm_effective_orientations( struct drm_t *drm, const drmModeM
+ 			pInternalMode = find_mode( pDRMInternalConnector->GetModeConnector(), 0, 0, 0 );
+ 
+ 		pDRMInternalConnector->UpdateEffectiveOrientation( pInternalMode );
++
++		// Embedded display planes (e.g. rockchip VOP) generally cannot
++		// hardware-rotate, so a physically-rotated internal panel fails plane
++		// scanout. Rotate in the composite shader instead (plane rotation stays
++		// identity) when the panel is mounted at 90/270 degrees.
++		GamescopePanelOrientation eInternalOrientation = pDRMInternalConnector->GetCurrentOrientation();
++		if ( eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_90 ||
++		     eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_270 )
++		{
++			g_bRotationShaderRequested = true;
++			g_bRotationShaderEnabled = true;
++		}
+ 	}
+ 
+ 	gamescope::IBackendConnector *pExternalConnector = GetBackend()->GetConnector( gamescope::GAMESCOPE_SCREEN_TYPE_EXTERNAL );

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0011-rendervulkan-join-pipeline-thread-on-shutdown.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0011-rendervulkan-join-pipeline-thread-on-shutdown.patch
@@ -1,0 +1,84 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan,steamcompmgr: join pipeline-compile thread on shutdown
+
+compileAllPipelines() runs on a detached background thread. On shutdown gamescope tears down the Vulkan device (steamcompmgr_exit) while that thread is still calling vkCreateComputePipelines, faulting inside the driver (seen on libMali) - a SIGSEGV during exit. Make the thread joinable, have its loop bail as soon as g_bRun is cleared by the signal handler, and join it at the start of steamcompmgr_exit before any device teardown. Shutdown is then clean (at most one in-flight pipeline compile is awaited).
+
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 0851089..e283db5 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -319,8 +319,7 @@ bool CVulkanDevice::BInit(VkInstance instance, VkSurfaceKHR surface)
+ 
+ 	m_bInitialized = true;
+ 
+-	std::thread piplelineThread([this](){compileAllPipelines();});
+-	piplelineThread.detach();
++	m_pipelineThread = std::thread([this](){compileAllPipelines();});
+ 
+ 	g_reshadeManager.init(this);
+ 
+@@ -1266,6 +1265,8 @@ void CVulkanDevice::compileAllPipelines()
+ 							continue;
+ 						if (blur_layers > layerCount)
+ 							continue;
++						if (!g_bRun)
++							return;
+ 
+ 						VkPipeline newPipeline = compilePipeline(layerCount, ycbcrMask, info.shaderType, blur_layers, info.compositeDebug, info.colorspaceMask, info.outputEOTF, info.itmEnable, rotation);
+ 						{
+@@ -1282,6 +1283,12 @@ void CVulkanDevice::compileAllPipelines()
+ 	}
+ }
+ 
++void CVulkanDevice::waitPipelines()
++{
++	if ( m_pipelineThread.joinable() )
++		m_pipelineThread.join();
++}
++
+ extern bool g_bSteamIsActiveWindow;
+ 
+ VkPipeline CVulkanDevice::pipeline(ShaderType type, uint32_t layerCount, uint32_t ycbcrMask, uint32_t blur_layers, uint32_t colorspace_mask, uint32_t output_eotf, bool itm_enable, uint32_t rotation)
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index ca1dcfa..ed34ddd 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -10,6 +10,7 @@
+ #include <array>
+ #include <bitset>
+ #include <mutex>
++#include <thread>
+ #include <optional>
+ 
+ #include "main.hpp"
+@@ -810,6 +811,7 @@ public:
+ 	inline int drmRenderFd() {return m_drmRendererFd;}
+ 	inline int drmAdvertiseFd() {return m_drmAdvertiseFd;}
+ 	inline bool supportsModifiers() {return m_bSupportsModifiers;}
++	void waitPipelines();
+ 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
+ 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
+ 	inline bool supportsFp16() {return m_bSupportsFp16;}
+@@ -887,6 +889,7 @@ protected:
+ 	std::array<VkShaderModule, SHADER_TYPE_COUNT> m_shaderModules;
+ 	std::unordered_map<PipelineInfo_t, VkPipeline> m_pipelineMap;
+ 	std::mutex m_pipelineMutex;
++	std::thread m_pipelineThread;
+ 
+ 	static constexpr uint32_t k_uMaxConcurrentSubmits = 8;
+ 
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index 72d9909..ab4c47c 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -6698,6 +6698,10 @@ error(Display *dpy, XErrorEvent *ev)
+ static void
+ steamcompmgr_exit(void)
+ {
++	// Stop the async pipeline-precompile thread before tearing down the Vulkan
++	// device, or it faults mid-compile inside the driver.
++	g_device.waitPipelines();
++
+ 	g_ImageWaiter.Shutdown();
+ 
+ 	// Clean up any commits.

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0012-DRMBackend-rendervulkan-foreign-device-scanout.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0012-DRMBackend-rendervulkan-foreign-device-scanout.patch
@@ -1,0 +1,107 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] DRMBackend,rendervulkan: scan out on the KMS display node with CMA output images
+
+gamescope derives its KMS/scanout device from the Vulkan render device's DRM
+node (vulkan_primary_dev_id) and allocates its output images on that render
+device. On a split render/display SoC that breaks two ways at once. On RK3576
+with panfrost the GPU is /dev/dri/card1 (render-only, no KMS) while the display
+is the rockchip VOP2 on /dev/dri/card0:
+
+  1. gamescope opens card1 for KMS, logs "is not a KMS device",
+     GetPreferredOutputFormat() returns nothing and vulkan_make_output aborts
+     ("failed to find Vulkan format suitable for KMS").
+  2. Even once scanning out on card0, the output images live in panfrost's GEM
+     space and cannot be turned into VOP2 framebuffers, so nothing is presented
+     (black screen; drmModeRmFB EBADF spam on teardown).
+
+Fix both: after picking the device, if it is not KMS-capable, enumerate DRM
+devices and switch scanout to the first KMS-capable primary node (the VOP2), and
+raise g_bGamescopeForeignScanout. When that flag is set, allocate the output
+images from the CMA dma-heap as LINEAR and import them for scanout (the same
+device-agnostic path already used for libMali via rxnix_cma) so the VOP2 can
+scan them out. No effect on unified render/display GPUs (device is already KMS,
+flag stays false) or on libMali (already takes the CMA path via absence of
+VK_EXT_physical_device_drm).
+
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index 2a3b4c5..6d7e8f9 100644
+--- a/src/Backends/DRMBackend.cpp
++++ /home/felixjones/rocknix/build.ROCKNIX-RK3576.aarch64/build/gamescope-61c74c18af1aaa4a2593f73b409a0c22b9314db4/src/Backends/DRMBackend.cpp	2026-07-05 15:18:57.387424763 +0200
+@@ -584,6 +584,7 @@
+ 
+ bool g_bSupportsAsyncFlips = false;
+ bool g_bSupportsSyncObjs = false;
++bool g_bGamescopeForeignScanout = false;
+ 
+ extern gamescope::GamescopeModeGeneration g_eGamescopeModeGeneration;
+ extern GamescopePanelOrientation g_DesiredInternalOrientation;
+@@ -1293,6 +1294,50 @@
+ 		drm_log.infof("warning: picking an arbitrary DRM device");
+ 	}
+ 
++
++	// The Vulkan render device is not necessarily the KMS/display device. On split
++	// render/display SoCs (e.g. panfrost render GPU + rockchip VOP2 display) the node
++	// selected above is render-only and not a KMS device; find the KMS-capable
++	// display node and scan out through that instead.
++	{
++		bool bDeviceIsKMS = false;
++		if ( drm->device_name )
++		{
++			int nCheckFd = open( drm->device_name, O_RDWR | O_CLOEXEC );
++			if ( nCheckFd >= 0 )
++			{
++				bDeviceIsKMS = drmIsKMS( nCheckFd );
++				close( nCheckFd );
++			}
++		}
++		if ( !bDeviceIsKMS )
++		{
++			drmDevicePtr devices[16] = {};
++			int nDevs = drmGetDevices2( 0, devices, 16 );
++			for ( int i = 0; i < nDevs; i++ )
++			{
++				if ( !( devices[i]->available_nodes & ( 1 << DRM_NODE_PRIMARY ) ) )
++					continue;
++				const char *pszNode = devices[i]->nodes[DRM_NODE_PRIMARY];
++				int nFd = open( pszNode, O_RDWR | O_CLOEXEC );
++				if ( nFd < 0 )
++					continue;
++				bool bKMS = drmIsKMS( nFd );
++				close( nFd );
++				if ( bKMS )
++				{
++					free( drm->device_name );
++					drm->device_name = strdup( pszNode );
++					drm_log.infof( "using KMS display node '%s' (render device is not a KMS device)", drm->device_name );
++					g_bGamescopeForeignScanout = true;
++					break;
++				}
++			}
++			if ( nDevs > 0 )
++				drmFreeDevices( devices, nDevs );
++		}
++	}
++
+ 	if ( drm->device_name )
+ 	{
+ 		struct stat targetSt = {};
+--- a/src/rendervulkan.cpp
++++ /home/felixjones/rocknix/build.ROCKNIX-RK3576.aarch64/build/gamescope-61c74c18af1aaa4a2593f73b409a0c22b9314db4/src/rendervulkan.cpp	2026-07-05 15:18:57.387663026 +0200
+@@ -3416,6 +3416,7 @@
+         return true;
+     }
+ } // namespace rxnix_cma
++extern bool g_bGamescopeForeignScanout;
+ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ {
+ 	CVulkanTexture::createFlags outputImageflags;
+@@ -3454,7 +3455,7 @@
+ 		}
+ 	}
+ 
+-	if ( !vulkan_has_drm_props() )
++	if ( !vulkan_has_drm_props() || g_bGamescopeForeignScanout )
+ 	{
+ 		uint32_t fmt = ( uDRMFormat != DRM_FORMAT_INVALID ) ? uDRMFormat : DRM_FORMAT_ABGR8888;
+ 		for ( int i = 0; i < 3; i++ )

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0013-rendervulkan-composite-ubo-explicit-range-panvk.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0013-rendervulkan-composite-ubo-explicit-range-panvk.patch
@@ -1,0 +1,57 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: bind the composite UBO with an explicit range (PanVK)
+
+The compute composite path binds its per-dispatch constants (scale, offset,
+opacity, CTM, colour-management) as the binding-0 uniform buffer, using
+VkDescriptorBufferInfo.range = VK_WHOLE_SIZE.
+
+On PanVK (Mesa panfrost Vulkan, e.g. Mali-G52 / RK3576) VK_WHOLE_SIZE is
+miscomputed for a uniform-buffer descriptor: the effective hardware UBO size
+ends up as 0, so every uniform read in the composite compute shader returns
+zero. The shader therefore sees scale=0, offset=0, opacity=0, CTM=0 and renders
+a solid black screen, even though the upload buffer at the bound offset holds
+the correct values. The compositor runs and page-flips normally (no crash, no
+KMS/IOMMU fault) so the panel is simply black; verified on RK3576 by mapping the
+CMA scanout dma-buf on the CPU (all-zero before this fix, ~29% non-zero after).
+
+Fix: remember the size of the last uploaded constants block and bind the UBO
+with an explicit range == that size instead of VK_WHOLE_SIZE. Falls back to
+VK_WHOLE_SIZE only for dispatches that did not upload any constants. Harmless on
+drivers that compute VK_WHOLE_SIZE correctly (libMali, desktop) since the
+explicit range is exactly the data the shader reads.
+
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -1000,6 +1000,7 @@
+ 	std::vector<VulkanTimelinePoint_t> m_ExternalSignals;
+ 
+ 	uint32_t m_renderBufferOffset = 0;
++	uint32_t m_renderBufferSize = 0;
+ };
+ 
+ uint32_t VulkanFormatToDRM( VkFormat vkFormat, std::optional<bool> obHasAlphaOverride = std::nullopt );
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -1698,6 +1698,7 @@
+ 
+ 	auto [ptr, offset] = m_device->uploadBufferData(sizeof(data));
+ 	m_renderBufferOffset = offset;
++	m_renderBufferSize = sizeof(data);
+ 	memcpy(ptr, &data, sizeof(data));
+ }
+ 
+@@ -1799,7 +1800,13 @@
+ 
+ 	scratchDescriptor.buffer = m_device->m_uploadBuffer;
+ 	scratchDescriptor.offset = m_renderBufferOffset;
+-	scratchDescriptor.range = VK_WHOLE_SIZE;
++	// PanVK (Mali) miscomputes VK_WHOLE_SIZE for a uniform-buffer descriptor: the
++	// effective hardware UBO size becomes 0, so every composite uniform (scale,
++	// offset, opacity, CTM, colour-management) reads back as zero and the compute
++	// composite renders solid black. Bind an explicit range equal to the uploaded
++	// constants size so the shader reads the real values; fall back to
++	// VK_WHOLE_SIZE only for dispatches that uploaded no constants.
++	scratchDescriptor.range = m_renderBufferSize ? (VkDeviceSize)m_renderBufferSize : VK_WHOLE_SIZE;
+ 
+ 	// Mali GPU drivers (libMali, PanVK) do not implement VK_EXT_robustness2, so a
+ 	// null combined-image-sampler faults them. Bind a valid blank view to every

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0014-meson-link-librga-when-available.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0014-meson-link-librga-when-available.patch
@@ -1,0 +1,39 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] meson: link librga for RGA hardware rotate/scale scanout when available
+
+Detect the airockchip librga (im2d) 2D-engine library via pkg-config and link it
+into gamescope when present, defining HAVE_LIBRGA. librga only builds for arm/aarch64,
+so on other arches the dependency is not found and the RGA scanout path (patch 0015)
+compiles out.
+---
+diff --git a/src/meson.build b/src/meson.build
+index 806fe5d..ec26f73 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -23,6 +23,9 @@ sdl2_dep = dependency('SDL2', required: get_option('sdl2_backend'))
+ avif_dep = dependency('libavif', version: '>=1.0.0', required: get_option('avif_screenshots'))
+ pixman_dep = dependency('pixman-1')
+ udev_dep = dependency('libudev')
++# ROCKNIX: optional Rockchip RGA 2D engine (librga) for HW rotate/scale scanout.
++# Only present for arm/aarch64; gamescope on other arches compiles the path out.
++rga_dep = dependency('librga', required: false)
+ 
+ wlroots_dep = dependency(
+   'wlroots-0.18',
+@@ -151,6 +154,7 @@ gamescope_cpp_args += '-DHAVE_SDL2=@0@'.format(sdl2_dep.found().to_int())
+ gamescope_cpp_args += '-DHAVE_AVIF=@0@'.format(avif_dep.found().to_int())
+ gamescope_cpp_args += '-DHAVE_LIBCAP=@0@'.format(cap_dep.found().to_int())
+ gamescope_cpp_args += '-DHAVE_LIBEIS=@0@'.format(eis_dep.found().to_int())
++gamescope_cpp_args += '-DHAVE_LIBRGA=@0@'.format(rga_dep.found().to_int())
+ gamescope_cpp_args += '-DHAVE_SCRIPTING=1'
+ 
+ src += spirv_shaders
+@@ -198,7 +202,7 @@ gamescope_version = configure_file(
+       xkbcommon, thread_dep, sdl2_dep, wlroots_dep,
+       vulkan_dep, liftoff_dep, dep_xtst, dep_xmu, cap_dep, epoll_dep, pipewire_dep, librt_dep,
+       stb_dep, displayinfo_dep, openvr_dep, dep_xcursor, avif_dep, dep_xi,
+-      libdecor_dep, eis_dep, luajit_dep, libinput_dep, pixman_dep, udev_dep,
++      libdecor_dep, eis_dep, luajit_dep, libinput_dep, pixman_dep, udev_dep, rga_dep,
+     ],
+     install: true,
+     cpp_args: gamescope_cpp_args,

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0015-rendervulkan-DRMBackend-RGA-rotate-scale-scanout.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0015-rendervulkan-DRMBackend-RGA-rotate-scale-scanout.patch
@@ -1,0 +1,577 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan,DRMBackend: RGA hardware rotate+scale scanout
+
+Offload rotated-panel rotation and the nested-to-native upscale onto the Rockchip
+RGA2 2D engine via librga, instead of the composite rotation shader. Enabled
+automatically when an internal panel is mounted at 90/270 and /dev/rga is usable;
+otherwise the rotation shader is used. Independent of the 3D GPU, so it works on
+libMali and panfrost with the same launch command.
+---
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index fb8d95e..9a183e7 100644
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -1814,9 +1814,13 @@ static void update_drm_effective_orientations( struct drm_t *drm, const drmModeM
+ 		// scanout. Rotate in the composite shader instead (plane rotation stays
+ 		// identity) when the panel is mounted at 90/270 degrees.
+ 		GamescopePanelOrientation eInternalOrientation = pDRMInternalConnector->GetCurrentOrientation();
+-		if ( eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_90 ||
+-		     eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_270 )
++		if ( ( eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_90 ||
++		       eInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_270 ) &&
++		     !vulkan_rxnix_rga_available() )
+ 		{
++			// When the Rockchip RGA 2D engine is available it rotates at scanout
++			// (see rendervulkan rxnix_rga), so the composite rotation shader and
++			// its pipeline permutations are skipped entirely.
+ 			g_bRotationShaderRequested = true;
+ 			g_bRotationShaderEnabled = true;
+ 		}
+@@ -2045,7 +2049,7 @@ LiftoffStateCacheEntry FrameInfoToLiftoffStateCacheEntry( struct drm_t *drm, con
+ 		uint64_t crtcW = srcWidth / frameInfo->layers[ i ].scale.x;
+ 		uint64_t crtcH = srcHeight / frameInfo->layers[ i ].scale.y;
+ 
+-		if (g_bRotated && !g_bRotationShaderEnabled)
++		if (g_bRotated && !g_bRotationShaderEnabled && !vulkan_rxnix_rga_enabled())
+ 		{
+ 			int64_t imageH = frameInfo->layers[ i ].tex->contentHeight() / frameInfo->layers[ i ].scale.y;
+ 
+@@ -2779,7 +2783,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
+ 			liftoff_layer_set_property( drm->lo_layers[ i ], "SRC_H", entry.layerState[i].srcH );
+ 
+ 			uint64_t ulOrientation = DRM_MODE_ROTATE_0;
+-			if ( !g_bRotationShaderEnabled )
++			if ( !g_bRotationShaderEnabled && !vulkan_rxnix_rga_enabled() )
+ 				switch ( drm->pConnector->GetCurrentOrientation() )
+ 				{
+ 				default:
+@@ -3672,10 +3676,47 @@ namespace gamescope
+ 			bNeedsFullComposite |= !!(g_uCompositeDebug & CompositeDebugFlag::Heatmap);
+ 			bNeedsFullComposite |= rotationShaderOrientation != GAMESCOPE_PANEL_ORIENTATION_0;
+ 
++			// ROCKNIX RGA direct-scanout fast path: when the base layer is
++			// a single fullscreen client buffer, hand it to the RGA 2D engine to
++			// rotate (and scale to the panel native resolution) directly into a
++			// scanout buffer, skipping the Vulkan composite entirely. Overlays are
++			// dropped in this path; on any unsupported buffer direct_rotate returns
++			// nullptr and we fall back to the RGA composite path below.
++			const FrameInfo_t *pScanoutFrameInfo = pFrameInfo;
++			FrameInfo_t rxnixDirectFrameInfo;
++			bool bRxnixDirect = false;
++			if ( vulkan_rxnix_rga_direct_enabled() && !bNeedsFullComposite && pFrameInfo->layerCount >= 1 )
++			{
++				const FrameInfo_t::Layer_t &rxnixBase = pFrameInfo->layers[0];
++				if ( rxnixBase.zpos == (int)g_zposBase && rxnixBase.opacity >= 1.0f && rxnixBase.tex != nullptr )
++				{
++					gamescope::Rc<CVulkanTexture> pRotated = vulkan_rxnix_rga_direct_rotate( rxnixBase.tex.get() );
++					if ( pRotated )
++					{
++						rxnixDirectFrameInfo = *pFrameInfo;
++						rxnixDirectFrameInfo.layerCount = 1; // drop overlays in the direct fast path
++						FrameInfo_t::Layer_t *pDirectLayer = &rxnixDirectFrameInfo.layers[0];
++						pDirectLayer->tex            = pRotated;
++						pDirectLayer->offset         = { 0.0f, 0.0f };
++						pDirectLayer->scale          = { 1.0f, 1.0f };
++						pDirectLayer->opacity        = 1.0f;
++						pDirectLayer->zpos           = g_zposBase;
++						pDirectLayer->applyColorMgmt = false;
++						pDirectLayer->filter         = GamescopeUpscaleFilter::NEAREST;
++						pScanoutFrameInfo            = &rxnixDirectFrameInfo;
++						bRxnixDirect                 = true;
++					}
++				}
++			}
++			// RGA composite path: force a full composite every frame so the RGA
++			// rotation/scaling is applied to the composited output - unless the
++			// direct fast path above already produced a scanout buffer.
++			bNeedsFullComposite |= ( vulkan_rxnix_rga_enabled() && !bRxnixDirect );
++
+ 			bool bDoComposite = true;
+ 			if ( !bNeedsFullComposite && !bWantsPartialComposite )
+ 			{
+-				int ret = drm_prepare( &g_DRM, bAsync, pFrameInfo );
++				int ret = drm_prepare( &g_DRM, bAsync, pScanoutFrameInfo );
+ 				if ( ret == 0 )
+ 					bDoComposite = false;
+ 				else if ( ret == -EACCES )
+@@ -3690,16 +3731,22 @@ namespace gamescope
+ 				// Scanout + Planes Path
+ 				m_bWasPartialCompositing = false;
+ 				m_bWasCompositing = false;
+-				if ( pFrameInfo->layerCount == 2 )
+-					m_nLastSingleOverlayZPos = pFrameInfo->layers[1].zpos;
++				if ( pScanoutFrameInfo->layerCount == 2 )
++					m_nLastSingleOverlayZPos = pScanoutFrameInfo->layers[1].zpos;
+ 
+-				return Commit( pFrameInfo );
++				return Commit( pScanoutFrameInfo );
+ 			}
+ 
+ 			// Composition Path
+ 			if ( kDisablePartialComposition )
+ 				bNeedsFullComposite = true;
+ 
++			// ROCKNIX RGA: the RGA composite path allocates no partial-overlay output
++			// images and RGA rotates/scales the whole composited frame, so always do a
++			// full composite here (never a partial one) when the RGA path is active.
++			if ( vulkan_rxnix_rga_enabled() )
++				bNeedsFullComposite = true;
++
+ 			FrameInfo_t compositeFrameInfo = *pFrameInfo;
+ 
+ 			if ( compositeFrameInfo.layerCount == 1 )
+@@ -3793,7 +3840,13 @@ namespace gamescope
+ 				baseLayer->opacity = 1.0;
+ 				baseLayer->zpos = g_zposBase;
+ 
+-				baseLayer->tex = vulkan_get_last_output_image( false, false );
++				if ( vulkan_rxnix_rga_enabled() )
++				{
++					gamescope::Rc<CVulkanTexture> pRot = vulkan_rxnix_rotate_output_for_present();
++					baseLayer->tex = pRot ? pRot : vulkan_get_last_output_image( false, false );
++				}
++				else
++					baseLayer->tex = vulkan_get_last_output_image( false, false );
+ 				baseLayer->applyColorMgmt = false;
+ 
+ 				baseLayer->filter = GamescopeUpscaleFilter::NEAREST;
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 0e58410..f945071 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -13,6 +13,15 @@
+ #include <dlfcn.h>
+ #include <sys/ioctl.h>
+ #include <linux/dma-heap.h>
++#if HAVE_LIBRGA
++#include <mutex>
++#include <unordered_map>
++#include <sys/stat.h>
++#include <sys/mman.h>
++#include <linux/dma-buf.h>
++#include <rga/im2d.h>
++#include <rga/rga.h>
++#endif
+ #include "vulkan_include.h"
+ #include "Utils/Algorithm.h"
+ 
+@@ -2421,6 +2430,28 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
+ 					.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
+ 					.fd = fd,
+ 			};
++
++			// ROCKNIX RGA direct-scanout: retain a dup'd copy of the client's
++			// dma-buf so the RGA 2D engine can import and rotate/scale it directly
++			// at scanout time (vulkan_rxnix_rga_direct_rotate). Only when the RGA
++			// offload is active; the dup'd fds are owned by this texture and freed
++			// by wlr_dmabuf_attributes_finish() in the destructor.
++			if ( vulkan_rxnix_rga_enabled() )
++			{
++				m_dmabuf.width    = pDMA->width;
++				m_dmabuf.height   = pDMA->height;
++				m_dmabuf.format   = pDMA->format;
++				m_dmabuf.modifier = pDMA->modifier;
++				m_dmabuf.n_planes = pDMA->n_planes;
++				for ( int i = 0; i < pDMA->n_planes; i++ )
++				{
++					m_dmabuf.offset[i] = pDMA->offset[i];
++					m_dmabuf.stride[i] = pDMA->stride[i];
++					m_dmabuf.fd[i]     = dup( pDMA->fd[i] );
++					if ( m_dmabuf.fd[i] < 0 )
++						vk_log.errorf_errno( "rxnix_rga: dup client dma-buf fd failed" );
++				}
++			}
+ 		}
+ 		
+ 		res = g_device.vk.AllocateMemory( g_device.device(), &allocInfo, nullptr, &memoryHandle );
+@@ -3421,6 +3452,345 @@ namespace rxnix_cma {
+     }
+ } // namespace rxnix_cma
+ extern bool g_bGamescopeForeignScanout;
++
++// ============================================================================
++// ROCKNIX RGA hardware rotate/scale scanout (automatic; no env vars).
++//
++// The rockchip VOP2 display planes cannot hardware-rotate, and libMali/PanVK
++// upscaling costs GPU fill. On a physically-rotated internal panel we offload
++// the rotation (and the nested game -> native upscale) to the Rockchip RGA2 2D
++// engine via librga (im2d API). Enabled purely by runtime detection: an internal
++// panel mounted at 90/270 and a usable /dev/rga. Works on BOTH GPU drivers
++// (libMali and panfrost) since the RGA is independent of the 3D GPU. When RGA is
++// unavailable gamescope falls back to the composite rotation shader untouched.
++//
++// Buffers are LINEAR ABGR8888 allocated from the CMA dma-heap (VOP2-scannable).
++// ============================================================================
++#if HAVE_LIBRGA
++namespace rxnix_rga {
++    static bool g_bLibTried = false, g_bLibOk = false;
++    static bool g_bEnabled  = false;   // composite rotate/scale path active
++    static int  g_nRotation = 0;       // IM_HAL_TRANSFORM_ROT_*
++    static uint32_t g_nativeW = 0, g_nativeH = 0;  // panel native, landscape-oriented
++    static uint32_t g_renderW = 0, g_renderH = 0;  // GPU composite size (may be < native)
++
++    struct CmaImage {
++        gamescope::OwningRc<CVulkanTexture> tex;
++        int fd = -1;
++        uint32_t w = 0, h = 0, stride = 0, drmFormat = 0;
++    };
++    static CmaImage g_composite[3];    // landscape composite targets (RGA src)
++    static CmaImage g_scanout[3];      // portrait scanout buffers   (RGA dst)
++    static CmaImage g_directPool[4];   // direct-scanout ring (client -> native)
++    static int      g_nDirectIdx = 0;
++    static bool     g_bDirectPool = false;
++
++    static bool lib_init() {
++        if ( g_bLibTried ) return g_bLibOk;
++        g_bLibTried = true;
++        if ( access( "/dev/rga", R_OK | W_OK ) != 0 ) {
++            vk_log.infof( "rxnix_rga: /dev/rga not usable; RGA offload disabled (using shader)" );
++            return false;
++        }
++        g_bLibOk = true;
++        return true;
++    }
++
++    static int drm_to_rga_format( uint32_t drmFormat ) {
++        switch ( drmFormat ) {
++            case DRM_FORMAT_ABGR8888: return RK_FORMAT_RGBA_8888;
++            case DRM_FORMAT_XBGR8888: return RK_FORMAT_RGBX_8888;
++            case DRM_FORMAT_ARGB8888: return RK_FORMAT_BGRA_8888;
++            case DRM_FORMAT_XRGB8888: return RK_FORMAT_BGRX_8888;
++            default: return -1;
++        }
++    }
++
++    static uint32_t cma_drm_format( uint32_t uDRMFormat ) {
++        return ( drm_to_rga_format( uDRMFormat ) >= 0 ) ? uDRMFormat : (uint32_t)DRM_FORMAT_ABGR8888;
++    }
++
++    // Per-fd RGA handle cache, validated by dma-buf inode. fd numbers get recycled
++    // as swapchain images are destroyed/recreated; the inode is unique per backing
++    // object, so an inode mismatch means re-import. Avoids a per-frame
++    // importbuffer_fd()/releasebuffer_handle() (ioctl + RGA IOMMU map/unmap each),
++    // which is otherwise the dominant per-frame cost.
++    struct HandleEntry { rga_buffer_handle_t handle; ino_t inode; uint32_t ws, h; int fmt; };
++    static std::mutex g_hmMutex;
++    static std::unordered_map<int, HandleEntry> g_handleCache;
++
++    static rga_buffer_handle_t import_cached( int fd, uint32_t ws, uint32_t h, int rgaFmt ) {
++        struct stat st = {};
++        ino_t inode = ( fstat( fd, &st ) == 0 ) ? st.st_ino : 0;
++        std::lock_guard<std::mutex> lk( g_hmMutex );
++        auto it = g_handleCache.find( fd );
++        if ( it != g_handleCache.end() ) {
++            HandleEntry &e = it->second;
++            if ( e.inode == inode && e.ws == ws && e.h == h && e.fmt == rgaFmt )
++                return e.handle;
++            releasebuffer_handle( e.handle );
++            g_handleCache.erase( it );
++        }
++        im_handle_param_t p = { ws, h, (uint32_t)rgaFmt };
++        rga_buffer_handle_t hnd = importbuffer_fd( fd, &p );
++        if ( hnd )
++            g_handleCache[fd] = HandleEntry{ hnd, inode, ws, h, rgaFmt };
++        return hnd;
++    }
++
++    // RGA rotate (g_nRotation) with implicit scale when src/dst differ in size.
++    static bool rotate_blit( int src_fd, uint32_t src_w, uint32_t src_h, uint32_t src_stride,
++                             int dst_fd, uint32_t dst_w, uint32_t dst_h, uint32_t dst_stride,
++                             uint32_t srcDrmFormat, uint32_t dstDrmFormat, int srcRdMode = 0 ) {
++        int srcRgaFmt = drm_to_rga_format( srcDrmFormat );
++        int dstRgaFmt = drm_to_rga_format( dstDrmFormat );
++        if ( srcRgaFmt < 0 || dstRgaFmt < 0 ) return false;
++        uint32_t src_ws = src_stride / 4, dst_ws = dst_stride / 4;
++        rga_buffer_handle_t sh = import_cached( src_fd, src_ws, src_h, srcRgaFmt );
++        rga_buffer_handle_t dh = import_cached( dst_fd, dst_ws, dst_h, dstRgaFmt );
++        if ( !sh || !dh ) return false;
++        // NB: wrapbuffer_handle_t (the C entry) takes (handle,w,h,wstride,hstride,format).
++        // The C++ wrapbuffer_handle() overload set has format as the 4th arg, so calling
++        // it with a stride there silently swaps stride/format -> RGA "unsupported".
++        rga_buffer_t src = wrapbuffer_handle_t( sh, (int)src_w, (int)src_h, (int)src_ws, (int)src_h, srcRgaFmt );
++        rga_buffer_t dst = wrapbuffer_handle_t( dh, (int)dst_w, (int)dst_h, (int)dst_ws, (int)dst_h, dstRgaFmt );
++        if ( srcRdMode ) src.rd_mode = srcRdMode;
++        IM_STATUS st = imrotate_t( src, dst, g_nRotation, 1 );
++        if ( st != IM_STATUS_SUCCESS ) {
++            static bool s_bLogged = false;
++            if ( !s_bLogged ) {
++                s_bLogged = true;
++                vk_log.errorf( "rxnix_rga: imrotate failed st=%d[%s] (src %ux%u -> dst %ux%u)",
++                    (int)st, imStrError_t( st ), src_w, src_h, dst_w, dst_h );
++            }
++            return false;
++        }
++        return true;
++    }
++
++    // RGA (unlike the Vulkan compositor, which does a foreign-queue release that
++    // flushes GPU caches) does not flush its destination to the point of coherency
++    // for the VOP2 display engine. Without this the panel scans out stale/black
++    // memory even though the RGA blit succeeded. A dma-buf CPU-access sync performs
++    // the cache maintenance that makes the RGA output visible to VOP2.
++    static void flush_for_scanout( int fd, size_t sz ) {
++        void *m = mmap( nullptr, sz, PROT_READ, MAP_SHARED, fd, 0 );
++        if ( m == MAP_FAILED ) return;
++        struct dma_buf_sync sy = {};
++        sy.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ; ioctl( fd, DMA_BUF_IOCTL_SYNC, &sy );
++        sy.flags = DMA_BUF_SYNC_END   | DMA_BUF_SYNC_READ; ioctl( fd, DMA_BUF_IOCTL_SYNC, &sy );
++        munmap( m, sz );
++    }
++
++    static bool make_cma_image( CmaImage &out, uint32_t width, uint32_t height,
++                                uint32_t drmFormat, bool bComposite ) {
++        uint32_t stride_bytes = ( ( width * 4u ) + 255u ) & ~255u; // aligned pitch (import + VOP2)
++        size_t size = (size_t)stride_bytes * height;
++        int fd = rxnix_cma::dmaheap_alloc( size );
++        if ( fd < 0 ) return false;
++        struct wlr_dmabuf_attributes attrs = {};
++        attrs.width = (int)width; attrs.height = (int)height;
++        attrs.format = drmFormat; attrs.modifier = DRM_FORMAT_MOD_LINEAR;
++        attrs.n_planes = 1; attrs.fd[0] = fd;
++        attrs.stride[0] = stride_bytes; attrs.offset[0] = 0;
++        gamescope::OwningRc<gamescope::IBackendFb> pBackendFb;
++        if ( !bComposite ) { // scanned-out buffers need a KMS framebuffer
++            pBackendFb = GetBackend()->ImportDmabufToBackend( &attrs );
++            if ( !pBackendFb ) {
++                vk_log.errorf( "rxnix_rga: ImportDmabufToBackend failed (%ux%u)", width, height );
++                close( fd ); return false;
++            }
++        }
++        CVulkanTexture::createFlags flags;
++        flags.bSampled = true;
++        if ( bComposite ) { flags.bStorage = true; flags.bOutputImage = true; flags.bTransferSrc = true; }
++        gamescope::OwningRc<CVulkanTexture> pTex = new CVulkanTexture();
++        if ( !pTex->BInit( width, height, 1u, drmFormat, flags, &attrs, 0, 0, nullptr, std::move( pBackendFb ) ) ) {
++            vk_log.errorf( "rxnix_rga: BInit failed on CMA dma-buf (%ux%u)", width, height );
++            close( fd ); return false;
++        }
++        out.tex = pTex; out.fd = fd;
++        out.w = width; out.h = height; out.stride = stride_bytes; out.drmFormat = drmFormat;
++        return true;
++    }
++
++    static bool ensure_direct_pool( uint32_t w, uint32_t h, uint32_t fmt ) {
++        if ( g_bDirectPool ) return true;
++        for ( int i = 0; i < 4; i++ ) {
++            if ( !make_cma_image( g_directPool[i], w, h, fmt, false ) ) {
++                vk_log.errorf( "rxnix_rga: direct pool %d alloc failed (%ux%u)", i, w, h );
++                return false;
++            }
++        }
++        g_nDirectIdx = 0; g_bDirectPool = true;
++        vk_log.infof( "rxnix_rga: direct scanout pool %ux%u x4 (LINEAR)", w, h );
++        return true;
++    }
++} // namespace rxnix_rga
++#endif // HAVE_LIBRGA
++
++// Allocate RGA composite + scanout images. Returns true if the RGA path is active
++// (rotated internal panel + usable /dev/rga); false to fall back to shader/normal.
++static bool rxnix_setup_output( VulkanOutput_t *pOutput, uint32_t uDRMFormat ) {
++#if HAVE_LIBRGA
++    using namespace rxnix_rga;
++    extern int g_nNestedWidth;
++    extern int g_nNestedHeight;
++    auto *pConn = GetBackend()->GetCurrentConnector();
++    if ( !pConn ) return g_bEnabled;
++    GamescopePanelOrientation eOrient = pConn->GetCurrentOrientation();
++    bool bRotated = ( eOrient == GAMESCOPE_PANEL_ORIENTATION_90 || eOrient == GAMESCOPE_PANEL_ORIENTATION_270 );
++
++    // One-time allocation of the persistent CMA composite + scanout images.
++    if ( !g_bEnabled )
++    {
++        if ( !bRotated || !lib_init() )
++            return false;
++        // RGA rotates the content by the inverse of the panel mounting angle so
++        // it lands upright on the physically-rotated panel.
++        g_nRotation = ( eOrient == GAMESCOPE_PANEL_ORIENTATION_90 ) ? IM_HAL_TRANSFORM_ROT_270 : IM_HAL_TRANSFORM_ROT_90;
++        g_nativeW = g_nOutputWidth;
++        g_nativeH = g_nOutputHeight;
++
++        // GPU composite (render) size. When the game runs at a smaller nested
++        // (-w/-h) size with the same aspect as the panel, composite at that size
++        // and let the RGA hardware upscale to native - offloading the scale from
++        // the GPU. Otherwise composite at native (RGA rotate only).
++        g_renderW = g_nativeW;
++        g_renderH = g_nativeH;
++        if ( g_nNestedWidth >= 64 && g_nNestedHeight >= 64 &&
++             (uint32_t)g_nNestedWidth <= g_nativeW && (uint32_t)g_nNestedHeight <= g_nativeH &&
++             (uint64_t)g_nNestedWidth * g_nativeH == (uint64_t)g_nNestedHeight * g_nativeW )
++        {
++            g_renderW = (uint32_t)g_nNestedWidth;
++            g_renderH = (uint32_t)g_nNestedHeight;
++        }
++
++        uint32_t fmt   = cma_drm_format( uDRMFormat );
++        uint32_t scanW = g_nativeH, scanH = g_nativeW;  // portrait scanout (panel native)
++        for ( int i = 0; i < 3; i++ )
++            if ( !make_cma_image( g_scanout[i], scanW, scanH, fmt, false ) ) return false;
++        for ( int i = 0; i < 3; i++ )
++            if ( !make_cma_image( g_composite[i], g_renderW, g_renderH, fmt, true ) ) return false;
++        g_bEnabled = true;
++        vk_log.infof( "rxnix_rga: ENABLED - composite %ux%u -> RGA rotate%s -> scanout %ux%u (orient=%d rot=%d)",
++            g_renderW, g_renderH,
++            ( g_renderW != g_nativeW || g_renderH != g_nativeH ) ? "+scale" : "",
++            scanW, scanH, (int)eOrient, g_nRotation );
++    }
++
++    // (Re)populate the output vectors on EVERY call. vulkan_make_output_images
++    // clears pOutput->outputImages and is re-invoked at runtime via
++    // vulkan_remake_output_images() (e.g. when a client establishes its surface),
++    // so we must always hand back our persistent CMA composite/scanout images or
++    // the next composite targets a null image.
++    g_bRotationShaderEnabled = false; // RGA performs the rotation instead of the shader
++    // Composite at the (possibly reduced) render resolution; RGA upscales to native.
++    g_nOutputWidth  = g_renderW;
++    g_nOutputHeight = g_renderH;
++    pOutput->rxnixScanoutImages.resize( 3 );
++    for ( int i = 0; i < 3; i++ )
++        pOutput->rxnixScanoutImages[i] = g_scanout[i].tex;
++    for ( int i = 0; i < 3; i++ )
++        pOutput->outputImages[i] = g_composite[i].tex;
++    pOutput->temporaryHackyBlankImage = vulkan_create_debug_blank_texture( g_renderW, g_renderH );
++    return true;
++#else
++    (void)pOutput; (void)uDRMFormat;
++    return false;
++#endif
++}
++
++bool vulkan_rxnix_rga_enabled() {
++#if HAVE_LIBRGA
++    return rxnix_rga::g_bEnabled;
++#else
++    return false;
++#endif
++}
++
++// Lightweight probe (usable before the Vulkan device exists) used by the DRM
++// backend to decide whether to request the composite rotation shader: when the
++// RGA 2D engine is present it will do the rotation, so the shader (and its
++// pipeline permutations) can be skipped entirely.
++bool vulkan_rxnix_rga_available() {
++#if HAVE_LIBRGA
++    return rxnix_rga::lib_init();
++#else
++    return false;
++#endif
++}
++
++bool vulkan_rxnix_rga_direct_enabled() {
++#if HAVE_LIBRGA
++    return rxnix_rga::g_bEnabled;
++#else
++    return false;
++#endif
++}
++
++// RGA-rotate the just-composited landscape output into its paired portrait
++// scanout buffer; returns that buffer for the DRM present, or nullptr to fall
++// back to the plain composited output.
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present() {
++#if HAVE_LIBRGA
++    using namespace rxnix_rga;
++    if ( !g_bEnabled || g_output.rxnixScanoutImages.size() != 3 ) return nullptr;
++    uint32_t nOut = ( g_output.nOutImage + 2 ) % 3; // mirror vulkan_get_last_output_image(false,false)
++    CmaImage &src = g_composite[nOut];
++    CmaImage &dst = g_scanout[nOut];
++    if ( src.fd < 0 || dst.fd < 0 ) return nullptr;
++    if ( !rotate_blit( src.fd, src.w, src.h, src.stride,
++                       dst.fd, dst.w, dst.h, dst.stride, src.drmFormat, dst.drmFormat ) )
++        return nullptr;
++    flush_for_scanout( dst.fd, (size_t)dst.stride * dst.h );
++    return g_output.rxnixScanoutImages[nOut];
++#else
++    return nullptr;
++#endif
++}
++
++// Rotate+scale a single fullscreen client buffer straight into a panel-native
++// portrait scanout buffer (skips the Vulkan composite). Returns nullptr (fall
++// back to the composite path) for any buffer the RGA2 cannot import directly.
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rga_direct_rotate( CVulkanTexture *pClient ) {
++#if HAVE_LIBRGA
++    using namespace rxnix_rga;
++    if ( !g_bEnabled || !pClient ) return nullptr;
++    const struct wlr_dmabuf_attributes &dma = pClient->dmabuf();
++    if ( dma.n_planes < 1 || dma.fd[0] < 0 ) return nullptr;
++    if ( drm_to_rga_format( dma.format ) < 0 ) return nullptr;
++    int srcRdMode = 0;
++    if ( dma.modifier != DRM_FORMAT_MOD_LINEAR && dma.modifier != DRM_FORMAT_MOD_INVALID && dma.modifier != 0 ) {
++        uint8_t vendor = (uint8_t)( dma.modifier >> 56 );
++        if ( vendor != 0x08 ) return nullptr;           // non-ARM modifier: fall back
++        uint8_t block = (uint8_t)( dma.modifier & 0xf );
++        if ( block == 2 ) srcRdMode = IM_AFBC32x8_MODE;  // AFBC 32x8 (RGA2P-decodable)
++        else return nullptr;                             // AFBC 16x16 etc: fall back
++    }
++    // Destination is always the panel native portrait size, so a game rendered at
++    // a smaller nested (-w/-h) resolution is upscaled by the RGA hardware.
++    uint32_t dstW = g_nativeH, dstH = g_nativeW;
++    uint32_t fmt  = cma_drm_format( DRM_FORMAT_INVALID );
++    if ( !ensure_direct_pool( dstW, dstH, fmt ) ) return nullptr;
++    CmaImage &dst = g_directPool[g_nDirectIdx];
++    if ( !rotate_blit( dma.fd[0], (uint32_t)dma.width, (uint32_t)dma.height, dma.stride[0],
++                       dst.fd, dst.w, dst.h, dst.stride, dma.format, dst.drmFormat, srcRdMode ) )
++        return nullptr;
++    flush_for_scanout( dst.fd, (size_t)dst.stride * dst.h );
++    g_nDirectIdx = ( g_nDirectIdx + 1 ) % 4;
++    static bool s_bLoggedDirect = false;
++    if ( !s_bLoggedDirect ) {
++        s_bLoggedDirect = true;
++        vk_log.infof( "rxnix_rga: DIRECT rotate/scale ACTIVE (client %ux%u -> scanout %ux%u, RGA does the upscale)",
++            (uint32_t)dma.width, (uint32_t)dma.height, dst.w, dst.h );
++    }
++    return dst.tex;
++#else
++    (void)pClient;
++    return nullptr;
++#endif
++}
+ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ {
+ 	CVulkanTexture::createFlags outputImageflags;
+@@ -3445,6 +3815,11 @@ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ 	uint32_t outputWidth = g_nOutputWidth;
+ 	uint32_t outputHeight = g_nOutputHeight;
+ 
++	// ROCKNIX: if the RGA 2D engine can drive the (rotated) panel, allocate
++	// CMA composite + scanout images and let RGA rotate/scale at present time.
++	if ( rxnix_setup_output( pOutput, uDRMFormat ) )
++		return true;
++
+ 	if ( g_bRotationShaderEnabled )
+ 	{
+ 		switch ( GetBackend()->GetCurrentConnector()->GetCurrentOrientation() )
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index cd1de00..3ef9d80 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -536,6 +536,10 @@ struct VulkanOutput_t
+ 	uint32_t nOutImage; // swapchain index in nested mode, or ping/pong between two RTs
+ 	std::vector<gamescope::OwningRc<CVulkanTexture>> outputImages;
+ 	std::vector<gamescope::OwningRc<CVulkanTexture>> outputImagesPartialOverlay;
++
++	// ROCKNIX RGA rotate/scale scanout: portrait CMA buffers that the RGA
++	// 2D engine rotates/scales the composited landscape output into for scanout.
++	std::vector<gamescope::OwningRc<CVulkanTexture>> rxnixScanoutImages;
+ 	gamescope::OwningRc<CVulkanTexture> temporaryHackyBlankImage;
+ 
+ 	uint32_t uOutputFormat = DRM_FORMAT_INVALID;
+@@ -568,6 +572,17 @@ enum ShaderType {
+ 
+ extern VulkanOutput_t g_output;
+ 
++// ROCKNIX RGA hardware rotate/scale scanout (automatic; no env vars).
++// enabled() is true on a rotated internal panel with a usable /dev/rga, on either
++// GPU driver. rotate_output_for_present() RGA-rotates the composited output into a
++// scanout buffer; direct_rotate() rotates+scales a single fullscreen client buffer
++// straight to the panel native size (skips the Vulkan composite).
++bool vulkan_rxnix_rga_enabled();
++bool vulkan_rxnix_rga_available();
++bool vulkan_rxnix_rga_direct_enabled();
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present();
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rga_direct_rotate( CVulkanTexture *pClient );
++
+ struct SamplerState
+ {
+ 	bool bNearest : 1;

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0016-rendervulkan-DRMBackend-RGA-direct-scanout-default.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0016-rendervulkan-DRMBackend-RGA-direct-scanout-default.patch
@@ -1,0 +1,108 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan,DRMBackend: RGA direct scanout as the default present mode
+
+Rotate and scale the client buffer straight to the display on the RGA with no
+Vulkan composite, as the default present path. Buffers the RGA cannot import fall
+back to the RGA composite path; integer scaling and forced composition still
+composite.
+---
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -3466,6 +3466,8 @@
+ //
+ // Buffers are LINEAR ABGR8888 allocated from the CMA dma-heap (VOP2-scannable).
+ // ============================================================================
++// --force-composition (disable direct scan-out). Defined in steamcompmgr.cpp.
++extern gamescope::ConVar<bool> cv_composite_force;
+ #if HAVE_LIBRGA
+ namespace rxnix_rga {
+     static bool g_bLibTried = false, g_bLibOk = false;
+@@ -3484,6 +3486,15 @@
+     static CmaImage g_directPool[4];   // direct-scanout ring (client -> native)
+     static int      g_nDirectIdx = 0;
+     static bool     g_bDirectPool = false;
++
++    // Integer scaling (-S integer) is the one mode that must be composited by
++    // Vulkan at the panel native resolution: the RGA scales only bilinearly, which
++    // would destroy the pixel-perfect look of integer upscaling. In that mode the
++    // composite is done at native and the RGA is left to rotate (1:1); the RGA
++    // direct-scanout fast path (which would scale) is also disabled.
++    static bool integer_scaling() {
++        return g_wantedUpscaleScaler == GamescopeUpscaleScaler::INTEGER;
++    }
+ 
+     static bool lib_init() {
+         if ( g_bLibTried ) return g_bLibOk;
+@@ -3658,7 +3669,8 @@
+         // the GPU. Otherwise composite at native (RGA rotate only).
+         g_renderW = g_nativeW;
+         g_renderH = g_nativeH;
+-        if ( g_nNestedWidth >= 64 && g_nNestedHeight >= 64 &&
++        if ( !integer_scaling() &&
++             g_nNestedWidth >= 64 && g_nNestedHeight >= 64 &&
+              (uint32_t)g_nNestedWidth <= g_nativeW && (uint32_t)g_nNestedHeight <= g_nativeH &&
+              (uint64_t)g_nNestedWidth * g_nativeH == (uint64_t)g_nNestedHeight * g_nativeW )
+         {
+@@ -3721,9 +3733,19 @@
+ #endif
+ }
+ 
++// Direct RGA scanout - rotate+scale the client buffer straight to the display
++// with no Vulkan composite - is the DEFAULT present path (best performance: the
++// RGA does both the scale and the rotate in hardware). It is disabled, so the
++// frame is composited by Vulkan and the RGA only rotates, in exactly two cases:
++//   * --force-composition (cv_composite_force): the user explicitly disables
++//     direct scan-out.
++//   * integer scaling (-S integer): the RGA is bilinear-only, so Vulkan must
++//     perform the pixel-perfect integer upscale.
+ bool vulkan_rxnix_rga_direct_enabled() {
+ #if HAVE_LIBRGA
+-    return rxnix_rga::g_bEnabled;
++    return rxnix_rga::g_bEnabled &&
++           !rxnix_rga::integer_scaling() &&
++           !cv_composite_force.Get();
+ #else
+     return false;
+ #endif
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -3676,12 +3676,15 @@
+ 			bNeedsFullComposite |= !!(g_uCompositeDebug & CompositeDebugFlag::Heatmap);
+ 			bNeedsFullComposite |= rotationShaderOrientation != GAMESCOPE_PANEL_ORIENTATION_0;
+ 
+-			// ROCKNIX RGA direct-scanout fast path: when the base layer is
+-			// a single fullscreen client buffer, hand it to the RGA 2D engine to
+-			// rotate (and scale to the panel native resolution) directly into a
+-			// scanout buffer, skipping the Vulkan composite entirely. Overlays are
+-			// dropped in this path; on any unsupported buffer direct_rotate returns
+-			// nullptr and we fall back to the RGA composite path below.
++			// ROCKNIX RGA direct scanout is the DEFAULT (best-performance) present
++			// path: when the base layer is a single fullscreen client buffer, hand
++			// it to the RGA 2D engine to rotate and scale to the panel native
++			// resolution directly into a scanout buffer, skipping the Vulkan
++			// compositor entirely. vulkan_rxnix_rga_direct_enabled() is false only
++			// for --force-composition and integer scaling, which fall through to the
++			// composite path below. Overlays are dropped in the direct path; on any
++			// client buffer the RGA cannot import directly, direct_rotate returns
++			// nullptr and we likewise fall back to the RGA composite path.
+ 			const FrameInfo_t *pScanoutFrameInfo = pFrameInfo;
+ 			FrameInfo_t rxnixDirectFrameInfo;
+ 			bool bRxnixDirect = false;
+@@ -3708,9 +3711,12 @@
+ 					}
+ 				}
+ 			}
+-			// RGA composite path: force a full composite every frame so the RGA
+-			// rotation/scaling is applied to the composited output - unless the
+-			// direct fast path above already produced a scanout buffer.
++			// RGA composite path (used when direct scanout is disabled by
++			// --force-composition / integer scaling, or the client buffer could not
++			// be imported directly): force a full composite so the RGA rotation
++			// (and scale, for the nested-composite case) is applied to the
++			// composited output - unless the default direct path above already
++			// produced a scanout buffer.
+ 			bNeedsFullComposite |= ( vulkan_rxnix_rga_enabled() && !bRxnixDirect );
+ 
+ 			bool bDoComposite = true;

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0017-rendervulkan-flush-rga-scanout-once-not-per-frame.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0017-rendervulkan-flush-rga-scanout-once-not-per-frame.patch
@@ -1,0 +1,35 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: flush the RGA scanout buffer once, not per-frame
+
+The scanout CMA dma-buf only needs its initial dirty cache lines invalidated once;
+afterwards the RGA and VOP2 both access it by DMA. Skipping the per-frame ~8MB cache
+flush removes a large present-thread stall in steady state.
+---
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 78e1ef7..3f48d7f 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -3584,7 +3584,23 @@ namespace rxnix_rga {
+     // for the VOP2 display engine. Without this the panel scans out stale/black
+     // memory even though the RGA blit succeeded. A dma-buf CPU-access sync performs
+     // the cache maintenance that makes the RGA output visible to VOP2.
++    // The scanout dma-buf is CPU-cached CMA. Right after allocation it holds dirty
++    // (zeroed) CPU cache lines; if those are written back to DRAM after the RGA has
++    // rendered the frame they clobber it and the panel scans out black - which is
++    // why a cache sync is needed at all. But it is needed only ONCE per buffer:
++    // discarding the initial dirty lines (a dma-buf CPU-access sync = cache
++    // invalidate) is enough, because afterwards nothing on the CPU writes the buffer
++    // - the RGA fills it and the VOP2 scans it out, both by DMA - so it stays
++    // coherent with no further maintenance. We therefore sync a buffer only for its
++    // first few uses (also covering any early access while the image is imported).
++    // The previous per-frame sync did an ~8 MB cache flush every frame (~5 ms),
++    // serialising the present thread; skipping it in steady state is a large win and
++    // was verified to leave the scanned-out content unchanged.
++    static std::unordered_map<int,int> g_flushed;
+     static void flush_for_scanout( int fd, size_t sz ) {
++        int &n = g_flushed[fd];
++        if ( n >= 3 ) return;
++        n++;
+         void *m = mmap( nullptr, sz, PROT_READ, MAP_SHARED, fd, 0 );
+         if ( m == MAP_FAILED ) return;
+         struct dma_buf_sync sy = {};

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0018-rendervulkan-DRMBackend-async-rga-scanout-fence.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0018-rendervulkan-DRMBackend-async-rga-scanout-fence.patch
@@ -1,0 +1,143 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan,DRMBackend: async RGA scanout via release fence
+
+Issue the composite-path RGA rotate non-blocking and hand its release fence to the
+scanout plane IN_FENCE_FD, so the VOP2 waits on the RGA in hardware while the present
+thread proceeds. Falls back to a synchronous blit where the kernel lacks RGA async
+support.
+---
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index b4fd0ad..cc6e60b 100644
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -2745,6 +2745,11 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
+ 
+ 	bool bSinglePlane = frameInfo->layerCount < 2 && cv_drm_single_plane_optimizations;
+ 
++	// Async RGA scanout: if the RGA rotate for this frame was issued non-blocking,
++	// use its release fence as the base scanout plane IN_FENCE_FD so the VOP2 waits
++	// on the RGA in hardware. rxnix_rga owns/closes the fence; we only read the fd.
++	const int nRxnixFence = ( !cv_drm_debug_disable_in_fence_fd && vulkan_rxnix_rga_enabled() ) ? vulkan_rxnix_scanout_fence() : -1;
++
+ 	for ( int i = 0; i < k_nMaxLayers; i++ )
+ 	{
+ 		if ( i < frameInfo->layerCount )
+@@ -2758,7 +2763,9 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
+ 				return -EINVAL;
+ 			}
+ 
+-			const int nFence = cv_drm_debug_disable_in_fence_fd ? -1 : g_nAlwaysSignalledSyncFile;
++			int nFence = cv_drm_debug_disable_in_fence_fd ? -1 : g_nAlwaysSignalledSyncFile;
++			if ( nRxnixFence >= 0 && pLayer->zpos == g_zposBase )
++				nFence = nRxnixFence;
+ 
+ 
+ 			liftoff_layer_set_property( drm->lo_layers[ i ], "FB_ID", pDrmFb->GetFbId());
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 3f48d7f..93b6ba2 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -3550,9 +3550,15 @@ namespace rxnix_rga {
+     }
+ 
+     // RGA rotate (g_nRotation) with implicit scale when src/dst differ in size.
++    // Release fence of the last async RGA scanout blit; owned here, closed on the next
++    // blit (its KMS commit has consumed it by then). -1 = last blit was synchronous.
++    static int g_nScanoutFence = -1;
++    // The Rockchip RGA async/fence mode needs CONFIG_ROCKCHIP_RGA_ASYNC in the kernel.
++    // Probe it once; if the driver rejects it, fall back to synchronous blits for good.
++    static bool g_bAsyncOk = true;
+     static bool rotate_blit( int src_fd, uint32_t src_w, uint32_t src_h, uint32_t src_stride,
+                              int dst_fd, uint32_t dst_w, uint32_t dst_h, uint32_t dst_stride,
+-                             uint32_t srcDrmFormat, uint32_t dstDrmFormat, int srcRdMode = 0 ) {
++                             uint32_t srcDrmFormat, uint32_t dstDrmFormat, int srcRdMode = 0, bool bAsync = false ) {
+         int srcRgaFmt = drm_to_rga_format( srcDrmFormat );
+         int dstRgaFmt = drm_to_rga_format( dstDrmFormat );
+         if ( srcRgaFmt < 0 || dstRgaFmt < 0 ) return false;
+@@ -3566,7 +3572,28 @@ namespace rxnix_rga {
+         rga_buffer_t src = wrapbuffer_handle_t( sh, (int)src_w, (int)src_h, (int)src_ws, (int)src_h, srcRgaFmt );
+         rga_buffer_t dst = wrapbuffer_handle_t( dh, (int)dst_w, (int)dst_h, (int)dst_ws, (int)dst_h, dstRgaFmt );
+         if ( srcRdMode ) src.rd_mode = srcRdMode;
+-        IM_STATUS st = imrotate_t( src, dst, g_nRotation, 1 );
++        // The previous async release fence has been consumed by its KMS commit by now
++        // (presents are serialised); close it before issuing the next blit.
++        if ( g_nScanoutFence >= 0 ) { close( g_nScanoutFence ); g_nScanoutFence = -1; }
++        IM_STATUS st;
++        if ( bAsync && g_bAsyncOk ) {
++            // Non-blocking rotate: hand the release fence to the scanout plane IN_FENCE_FD
++            // so the VOP2 waits on the RGA in hardware while the present thread and GPU
++            // proceed to the next frame.
++            int fence = -1;
++            st = imrotate( src, dst, g_nRotation, 0, &fence );
++            if ( st == IM_STATUS_SUCCESS && fence >= 0 ) {
++                g_nScanoutFence = fence;
++            } else {
++                // Kernel lacks CONFIG_ROCKCHIP_RGA_ASYNC (or async failed): disable async
++                // permanently and do a synchronous blit for this frame instead.
++                if ( fence >= 0 ) close( fence );
++                g_bAsyncOk = false;
++                st = imrotate_t( src, dst, g_nRotation, 1 );
++            }
++        } else {
++            st = imrotate_t( src, dst, g_nRotation, 1 );
++        }
+         if ( st != IM_STATUS_SUCCESS ) {
+             static bool s_bLogged = false;
+             if ( !s_bLogged ) {
+@@ -3597,6 +3624,7 @@ namespace rxnix_rga {
+     // serialising the present thread; skipping it in steady state is a large win and
+     // was verified to leave the scanned-out content unchanged.
+     static std::unordered_map<int,int> g_flushed;
++    static bool scanout_synced( int fd ) { auto it = g_flushed.find( fd ); return it != g_flushed.end() && it->second >= 3; }
+     static void flush_for_scanout( int fd, size_t sz ) {
+         int &n = g_flushed[fd];
+         if ( n >= 3 ) return;
+@@ -3654,6 +3682,17 @@ namespace rxnix_rga {
+         return true;
+     }
+ } // namespace rxnix_rga
++
++// The release fence of the last async RGA scanout blit (or -1). The DRM backend
++// hands it to the scanout plane IN_FENCE_FD so the VOP2 waits on the RGA in
++// hardware. Ownership stays in rxnix_rga (it closes the fence on the next blit).
++int vulkan_rxnix_scanout_fence() {
++#if HAVE_LIBRGA
++    return rxnix_rga::g_nScanoutFence;
++#else
++    return -1;
++#endif
++}
+ #endif // HAVE_LIBRGA
+ 
+ // Allocate RGA composite + scanout images. Returns true if the RGA path is active
+@@ -3778,10 +3817,16 @@ gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present() {
+     CmaImage &src = g_composite[nOut];
+     CmaImage &dst = g_scanout[nOut];
+     if ( src.fd < 0 || dst.fd < 0 ) return nullptr;
++    // Async only for the (triple-buffered) composite buffers, and only once the buffer
++    // no longer needs the initial CPU cache flush (which requires the RGA complete).
++    // The direct path stays synchronous: its source is the client buffer, which may be
++    // released/reused before an async read finishes.
++    bool bAsync = scanout_synced( dst.fd ) && g_bAsyncOk;
+     if ( !rotate_blit( src.fd, src.w, src.h, src.stride,
+-                       dst.fd, dst.w, dst.h, dst.stride, src.drmFormat, dst.drmFormat ) )
++                       dst.fd, dst.w, dst.h, dst.stride, src.drmFormat, dst.drmFormat, 0, bAsync ) )
+         return nullptr;
+-    flush_for_scanout( dst.fd, (size_t)dst.stride * dst.h );
++    if ( !bAsync )
++        flush_for_scanout( dst.fd, (size_t)dst.stride * dst.h );
+     return g_output.rxnixScanoutImages[nOut];
+ #else
+     return nullptr;
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index 3ef9d80..9852a67 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -578,6 +578,7 @@ extern VulkanOutput_t g_output;
+ // scanout buffer; direct_rotate() rotates+scales a single fullscreen client buffer
+ // straight to the panel native size (skips the Vulkan composite).
+ bool vulkan_rxnix_rga_enabled();
++int vulkan_rxnix_scanout_fence();
+ bool vulkan_rxnix_rga_available();
+ bool vulkan_rxnix_rga_direct_enabled();
+ gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present();

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0019-rendervulkan-libmali-direct-scanout-afbc-32x8.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0019-rendervulkan-libmali-direct-scanout-afbc-32x8.patch
@@ -1,0 +1,59 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: libMali direct scanout via RGA-safe AFBC-32x8
+
+Advertise only the non-YTR AFBC-32x8 modifier (plus LINEAR) to clients when there is
+no Mesa DRM render node, so libMali renders buffers the RGA can rotate straight to
+scanout instead of forcing a Vulkan composite. No-op on Mesa/PanVK.
+---
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -2991,7 +2991,18 @@
+ 					continue;
+ 			}
+ 
+-			wlr_drm_format_set_add( &sampledDRMFormats, drmFormat, modifier );
++			// ROCKNIX: hide ARM AFBC modifiers from the CLIENT-facing format set on libMali
++			// (no VK_EXT_physical_device_drm). Mali prefers AFBC whenever advertised, but the
++			// VOP2 cannot scan it out and the RK3576 RGA cannot decode Mali AFBC-16x16, so an
++			// AFBC window buffer forces a per-frame Vulkan composite. Advertising only LINEAR
++			// makes a zwp_linux_dmabuf client (MALI_WAYLAND_DMABUF_PROTOCOL=1) allocate a linear
++			// buffer the RGA rotates straight to scanout (direct path, no composite). gamescope's
++			// own AFBC import is unaffected: DRMModifierProps and s_SampledModifierFormats keep the
++			// full list. No-op on Mesa/PanVK (has drm props).
++			const bool bHideAfbcFromClient = !vulkan_has_drm_props() &&
++			    (uint8_t)( modifier >> 56 ) == 0x08 && modifier != 0x0800000000000062ULL;
++			if ( !bHideAfbcFromClient )
++				wlr_drm_format_set_add( &sampledDRMFormats, drmFormat, modifier );
+ 			s_SampledModifierFormats[ drmFormat ].emplace_back( modifier );
+ 		}
+ 
+@@ -3563,13 +3574,15 @@
+         int dstRgaFmt = drm_to_rga_format( dstDrmFormat );
+         if ( srcRgaFmt < 0 || dstRgaFmt < 0 ) return false;
+         uint32_t src_ws = src_stride / 4, dst_ws = dst_stride / 4;
+-        rga_buffer_handle_t sh = import_cached( src_fd, src_ws, src_h, srcRgaFmt );
++        uint32_t src_hs = src_h;
++        if ( srcRdMode ) { src_ws = ( src_ws + 31u ) & ~31u; src_hs = ( src_h + 7u ) & ~7u; }
++        rga_buffer_handle_t sh = import_cached( src_fd, src_ws, src_hs, srcRgaFmt );
+         rga_buffer_handle_t dh = import_cached( dst_fd, dst_ws, dst_h, dstRgaFmt );
+         if ( !sh || !dh ) return false;
+         // NB: wrapbuffer_handle_t (the C entry) takes (handle,w,h,wstride,hstride,format).
+         // The C++ wrapbuffer_handle() overload set has format as the 4th arg, so calling
+         // it with a stride there silently swaps stride/format -> RGA "unsupported".
+-        rga_buffer_t src = wrapbuffer_handle_t( sh, (int)src_w, (int)src_h, (int)src_ws, (int)src_h, srcRgaFmt );
++        rga_buffer_t src = wrapbuffer_handle_t( sh, (int)src_w, (int)src_h, (int)src_ws, (int)src_hs, srcRgaFmt );
+         rga_buffer_t dst = wrapbuffer_handle_t( dh, (int)dst_w, (int)dst_h, (int)dst_ws, (int)dst_h, dstRgaFmt );
+         if ( srcRdMode ) src.rd_mode = srcRdMode;
+         // The previous async release fence has been consumed by its KMS commit by now
+@@ -3865,8 +3878,8 @@
+     static bool s_bLoggedDirect = false;
+     if ( !s_bLoggedDirect ) {
+         s_bLoggedDirect = true;
+-        vk_log.infof( "rxnix_rga: DIRECT rotate/scale ACTIVE (client %ux%u -> scanout %ux%u, RGA does the upscale)",
+-            (uint32_t)dma.width, (uint32_t)dma.height, dst.w, dst.h );
++        vk_log.infof( "rxnix_rga: DIRECT rotate/scale ACTIVE (client %ux%u mod=0x%lx -> scanout %ux%u)",
++            (uint32_t)dma.width, (uint32_t)dma.height, (unsigned long)dma.modifier, dst.w, dst.h );
+     }
+     return dst.tex;
+ #else

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0020-rendervulkan-DRMBackend-async-composite-rga-acquire-fence.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0020-rendervulkan-DRMBackend-async-composite-rga-acquire-fence.patch
@@ -1,0 +1,308 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan,DRMBackend: async composite-to-RGA scanout via acquire fence
+
+Export the Vulkan composite completion as a sync_file and pass it to the RGA rotate
+as an acquire fence, so the RGA waits on the composite in hardware and the present
+thread no longer stalls on it. Falls back to a synchronous wait when fence export is
+unavailable.
+---
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+index cc6e60b..6d54cc3 100644
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -3836,7 +3836,22 @@ namespace gamescope
+ 				return -EINVAL;
+ 			}
+ 
+-			vulkan_wait( *oCompositeResult, true );
++			// libMali RGA composite path: rather than stalling the present thread on the
++			// GPU composite (vulkan_wait) before the RGA rotates it to scanout, hand the
++			// composite completion to the RGA as an in-kernel acquire fence and let the
++			// present thread proceed. vulkan_rxnix_rotate_output_for_present() performs (or
++			// defers) the wait itself; every other path keeps the synchronous CPU wait.
++			[[maybe_unused]] bool bCompositeWaited = false;
++			gamescope::Rc<CVulkanTexture> pRxnixScanout;
++			if ( vulkan_rxnix_rga_enabled() )
++			{
++				pRxnixScanout = vulkan_rxnix_rotate_output_for_present( *oCompositeResult, &bCompositeWaited );
++			}
++			else
++			{
++				vulkan_wait( *oCompositeResult, true );
++				bCompositeWaited = true;
++			}
+ 
+ 			FrameInfo_t presentCompFrameInfo = {};
+ 			presentCompFrameInfo.allowVRR = pFrameInfo->allowVRR;
+@@ -3855,8 +3870,14 @@ namespace gamescope
+ 
+ 				if ( vulkan_rxnix_rga_enabled() )
+ 				{
+-					gamescope::Rc<CVulkanTexture> pRot = vulkan_rxnix_rotate_output_for_present();
+-					baseLayer->tex = pRot ? pRot : vulkan_get_last_output_image( false, false );
++					// If the RGA rotate declined and we never awaited the composite, do so
++					// now before presenting the plain composited output as a fallback.
++					if ( !pRxnixScanout && !bCompositeWaited )
++					{
++						vulkan_wait( *oCompositeResult, true );
++						bCompositeWaited = true;
++					}
++					baseLayer->tex = pRxnixScanout ? pRxnixScanout : vulkan_get_last_output_image( false, false );
+ 				}
+ 				else
+ 					baseLayer->tex = vulkan_get_last_output_image( false, false );
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 1b12a69..f8a1f93 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -466,6 +466,9 @@ bool CVulkanDevice::createDevice()
+ 
+ 		if ( strcmp(ext.extensionName, VK_EXT_HDR_METADATA_EXTENSION_NAME) == 0 )
+ 			supportsHDRMetadata = true;
++
++		if ( strcmp(ext.extensionName, VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME) == 0 )
++			m_bSupportsExternalFenceFd = true;
+ 	}
+ 
+ 	vk_log.infof( "physical device %s DRM format modifiers", m_bSupportsModifiers ? "supports" : "does not support" );
+@@ -637,6 +640,11 @@ bool CVulkanDevice::createDevice()
+ 
+ 	enabledExtensions.push_back( VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME );
+ 
++	// Needed to export a composite completion fence as a sync_file for the RGA acquire
++	// fence (async composite -> RGA hand-off). Harmless where unused; guarded on support.
++	if ( m_bSupportsExternalFenceFd )
++		enabledExtensions.push_back( VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME );
++
+ #if 0
+ 	enabledExtensions.push_back( VK_KHR_MAINTENANCE_5_EXTENSION_NAME );
+ #endif
+@@ -1435,6 +1443,77 @@ uint64_t CVulkanDevice::submit( std::unique_ptr<CVulkanCmdBuffer> cmdBuffer)
+ 	return nextSeqNo;
+ }
+ 
++int CVulkanDevice::ExportTimelineSyncFile( uint64_t ulPoint )
++{
++	if ( !m_bSupportsExternalFenceFd || vk.GetFenceFdKHR == nullptr )
++		return -1;
++
++	VkFence &fence = m_exportSyncFences[ m_uExportSyncFenceIndex ];
++	m_uExportSyncFenceIndex = ( m_uExportSyncFenceIndex + 1 ) % k_uExportFencePoolSize;
++
++	if ( fence == VK_NULL_HANDLE )
++	{
++		const VkExportFenceCreateInfo exportInfo = {
++			.sType = VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO,
++			.handleTypes = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT,
++		};
++		const VkFenceCreateInfo fenceInfo = {
++			.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
++			.pNext = &exportInfo,
++		};
++		if ( vk.CreateFence( m_device, &fenceInfo, nullptr, &fence ) != VK_SUCCESS )
++		{
++			fence = VK_NULL_HANDLE;
++			m_bSupportsExternalFenceFd = false;
++			return -1;
++		}
++	}
++	else
++	{
++		// This pooled slot was last submitted k_uExportFencePoolSize presents ago. In
++		// the (unexpected) case its signal has not retired yet, skip the async path for
++		// this frame rather than risk resetting an in-flight fence.
++		if ( vk.GetFenceStatus( m_device, fence ) == VK_NOT_READY )
++			return -1;
++		vk.ResetFences( m_device, 1, &fence );
++	}
++
++	// Empty submit: wait until the scratch timeline reaches ulPoint (the composite
++	// completion), then signal the exportable fence. No command buffers, so this only
++	// creates a GPU-side sync point; the present thread does not block.
++	const VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
++	const VkTimelineSemaphoreSubmitInfo timelineInfo = {
++		.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
++		.waitSemaphoreValueCount = 1,
++		.pWaitSemaphoreValues = &ulPoint,
++	};
++	const VkSubmitInfo submitInfo = {
++		.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
++		.pNext = &timelineInfo,
++		.waitSemaphoreCount = 1,
++		.pWaitSemaphores = &m_scratchTimelineSemaphore,
++		.pWaitDstStageMask = &waitStage,
++	};
++	if ( vk.QueueSubmit( m_queue, 1, &submitInfo, fence ) != VK_SUCCESS )
++		return -1;
++
++	const VkFenceGetFdInfoKHR getFdInfo = {
++		.sType = VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR,
++		.fence = fence,
++		.handleType = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT,
++	};
++	int nFd = -1;
++	if ( vk.GetFenceFdKHR( m_device, &getFdInfo, &nFd ) != VK_SUCCESS || nFd < 0 )
++	{
++		// Driver advertises the extension but cannot export a SYNC_FD fence; disable
++		// the path permanently so the caller reverts to a CPU wait.
++		m_bSupportsExternalFenceFd = false;
++		return -1;
++	}
++
++	return nFd;
++}
++
+ void CVulkanDevice::garbageCollect( void )
+ {
+ 	uint64_t currentSeqNo;
+@@ -3567,9 +3646,14 @@ namespace rxnix_rga {
+     // The Rockchip RGA async/fence mode needs CONFIG_ROCKCHIP_RGA_ASYNC in the kernel.
+     // Probe it once; if the driver rejects it, fall back to synchronous blits for good.
+     static bool g_bAsyncOk = true;
++    // Hand the Vulkan composite completion to the RGA as an in-kernel acquire fence so
++    // the present thread never blocks on the GPU composite. Disabled permanently if the
++    // RGA job path ever rejects the fence (the caller then falls back to a CPU wait).
++    static bool g_bCompositeAcquireOk = true;
+     static bool rotate_blit( int src_fd, uint32_t src_w, uint32_t src_h, uint32_t src_stride,
+                              int dst_fd, uint32_t dst_w, uint32_t dst_h, uint32_t dst_stride,
+-                             uint32_t srcDrmFormat, uint32_t dstDrmFormat, int srcRdMode = 0, bool bAsync = false ) {
++                             uint32_t srcDrmFormat, uint32_t dstDrmFormat, int srcRdMode = 0, bool bAsync = false,
++                             int acquireFenceFd = -1 ) {
+         int srcRgaFmt = drm_to_rga_format( srcDrmFormat );
+         int dstRgaFmt = drm_to_rga_format( dstDrmFormat );
+         if ( srcRgaFmt < 0 || dstRgaFmt < 0 ) return false;
+@@ -3589,7 +3673,28 @@ namespace rxnix_rga {
+         // (presents are serialised); close it before issuing the next blit.
+         if ( g_nScanoutFence >= 0 ) { close( g_nScanoutFence ); g_nScanoutFence = -1; }
+         IM_STATUS st;
+-        if ( bAsync && g_bAsyncOk ) {
++        if ( acquireFenceFd >= 0 ) {
++            // Async rotate that waits on the Vulkan composite via an in-kernel acquire
++            // fence (the present thread never blocks on the GPU) and hands its release
++            // fence to the scanout plane. The single-task imrotate() entry cannot carry
++            // an acquire fence, so use the RGA job API. The kernel takes its own reference
++            // to the acquire fence during submit and the job path never closes our fd, so
++            // release it here in every case.
++            int fence = -1;
++            im_job_handle_t job = imbeginJob();
++            if ( job != 0 && imrotateTask( job, src, dst, g_nRotation ) == IM_STATUS_SUCCESS ) {
++                st = imendJob( job, IM_ASYNC, acquireFenceFd, &fence );
++            } else {
++                if ( job != 0 ) imcancelJob( job );
++                st = IM_STATUS_FAILED;
++            }
++            close( acquireFenceFd );
++            if ( st == IM_STATUS_SUCCESS ) {
++                if ( fence >= 0 ) g_nScanoutFence = fence;
++            } else if ( fence >= 0 ) {
++                close( fence );
++            }
++        } else if ( bAsync && g_bAsyncOk ) {
+             // Non-blocking rotate: hand the release fence to the scanout plane IN_FENCE_FD
+             // so the VOP2 waits on the RGA in hardware while the present thread and GPU
+             // proceed to the next frame.
+@@ -3821,10 +3926,15 @@ bool vulkan_rxnix_rga_direct_enabled() {
+ 
+ // RGA-rotate the just-composited landscape output into its paired portrait
+ // scanout buffer; returns that buffer for the DRM present, or nullptr to fall
+-// back to the plain composited output.
+-gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present() {
++// back to the plain composited output. Instead of the caller blocking on the
++// Vulkan composite before this rotate, the composite completion (ulCompositePoint)
++// is handed to the RGA as an in-kernel acquire fence. *pbCompositeWaited is set
++// true iff this function CPU-waited for the composite (so the caller knows whether
++// a plain-output fallback still needs a wait).
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present( uint64_t ulCompositePoint, bool* pbCompositeWaited ) {
+ #if HAVE_LIBRGA
+     using namespace rxnix_rga;
++    if ( pbCompositeWaited ) *pbCompositeWaited = false;
+     if ( !g_bEnabled || g_output.rxnixScanoutImages.size() != 3 ) return nullptr;
+     uint32_t nOut = ( g_output.nOutImage + 2 ) % 3; // mirror vulkan_get_last_output_image(false,false)
+     CmaImage &src = g_composite[nOut];
+@@ -3835,13 +3945,36 @@ gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present() {
+     // The direct path stays synchronous: its source is the client buffer, which may be
+     // released/reused before an async read finishes.
+     bool bAsync = scanout_synced( dst.fd ) && g_bAsyncOk;
++    // When the RGA blit is async, hand it the composite completion as an in-kernel
++    // acquire fence so the present thread does not block on the GPU. If the driver
++    // cannot export a sync_file, fall back to blocking for the composite here.
++    int acquireFd = -1;
++    if ( bAsync && g_bCompositeAcquireOk )
++        acquireFd = g_device.ExportTimelineSyncFile( ulCompositePoint );
++    if ( acquireFd < 0 ) {
++        vulkan_wait( ulCompositePoint, true );
++        if ( pbCompositeWaited ) *pbCompositeWaited = true;
++    }
+     if ( !rotate_blit( src.fd, src.w, src.h, src.stride,
+-                       dst.fd, dst.w, dst.h, dst.stride, src.drmFormat, dst.drmFormat, 0, bAsync ) )
++                       dst.fd, dst.w, dst.h, dst.stride, src.drmFormat, dst.drmFormat, 0, bAsync, acquireFd ) ) {
++        // rotate_blit consumed/closed acquireFd. If we handed it the composite fence
++        // (and thus skipped the CPU wait), stop using the acquire path and make sure the
++        // composite is complete before the caller presents the plain composited output.
++        if ( acquireFd >= 0 ) {
++            g_bCompositeAcquireOk = false;
++            if ( pbCompositeWaited && !*pbCompositeWaited ) {
++                vulkan_wait( ulCompositePoint, true );
++                *pbCompositeWaited = true;
++            }
++        }
+         return nullptr;
++    }
+     if ( !bAsync )
+         flush_for_scanout( dst.fd, (size_t)dst.stride * dst.h );
+     return g_output.rxnixScanoutImages[nOut];
+ #else
++    (void)ulCompositePoint;
++    if ( pbCompositeWaited ) *pbCompositeWaited = false;
+     return nullptr;
+ #endif
+ }
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index 9852a67..fdc123c 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -581,7 +581,7 @@ bool vulkan_rxnix_rga_enabled();
+ int vulkan_rxnix_scanout_fence();
+ bool vulkan_rxnix_rga_available();
+ bool vulkan_rxnix_rga_direct_enabled();
+-gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present();
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present( uint64_t ulCompositePoint, bool* pbCompositeWaited );
+ gamescope::Rc<CVulkanTexture> vulkan_rxnix_rga_direct_rotate( CVulkanTexture *pClient );
+ 
+ struct SamplerState
+@@ -726,6 +726,8 @@ static inline uint32_t div_roundup(uint32_t x, uint32_t y)
+ 	VK_FUNC(CreateSamplerYcbcrConversion) \
+ 	VK_FUNC(CreateSemaphore) \
+ 	VK_FUNC(GetSemaphoreFdKHR) \
++	VK_FUNC(GetFenceFdKHR) \
++	VK_FUNC(GetFenceStatus) \
+ 	VK_FUNC(ImportSemaphoreFdKHR) \
+ 	VK_FUNC(CreateShaderModule) \
+ 	VK_FUNC(CreateSwapchainKHR) \
+@@ -811,6 +813,11 @@ public:
+ 	std::shared_ptr<VulkanTimelineSemaphore_t> CreateTimelineSemaphore( uint64_t ulStartingPoint, bool bShared = false );
+ 	std::shared_ptr<VulkanTimelineSemaphore_t> ImportTimelineSemaphore( gamescope::CTimeline *pTimeline );
+ 
++	// Convert a scratch-timeline point (e.g. a completed composite) into a sync_file fd
++	// that non-Vulkan engines (the RGA) can wait on in-kernel. Returns -1 when the driver
++	// cannot export a SYNC_FD fence, in which case the caller should CPU-wait instead.
++	int ExportTimelineSyncFile( uint64_t ulPoint );
++
+ 	static const uint32_t upload_buffer_size = 1920 * 1080 * 4;
+ 
+ 	inline VkDevice device() { return m_device; }
+@@ -921,6 +928,14 @@ protected:
+ 	uint32_t m_uploadBufferOffset = 0;
+ 
+ 	VkSemaphore m_scratchTimelineSemaphore;
++
++	// Exportable fences used to turn a composite timeline point into a sync_file for the
++	// RGA acquire fence. Pooled so a slot is only reused once its previous signal (issued
++	// several presents ago) has retired. m_bSupportsExternalFenceFd gates the whole path.
++	bool m_bSupportsExternalFenceFd = false;
++	static constexpr uint32_t k_uExportFencePoolSize = 4;
++	std::array<VkFence, k_uExportFencePoolSize> m_exportSyncFences = {};
++	uint32_t m_uExportSyncFenceIndex = 0;
+ 	std::atomic<uint64_t> m_submissionSeqNo = { 0 };
+ 	std::vector<std::unique_ptr<CVulkanCmdBuffer>> m_unusedCmdBufs;
+ 	std::map<uint64_t, std::unique_ptr<CVulkanCmdBuffer>> m_pendingCmdBufs;

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0021-rendervulkan-identity-composite-fast-path.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0021-rendervulkan-identity-composite-fast-path.patch
@@ -1,0 +1,193 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: identity-passthrough composite fast-path
+
+Skip the per-pixel colour-management chain in the compute composite when it is a
+proven identity (SDR, default colorimetry, identity CTM). Bit-equivalent to the full
+path and gated purely on that proof, so it is a no-op on any other configuration or
+driver.
+---
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index f8a1f93..3cb2821 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -4461,6 +4461,12 @@ float g_flInternalDisplayBrightnessNits = 500.0f;
+ float g_flHDRItmSdrNits = 100.f;
+ float g_flHDRItmTargetNits = 1000.f;
+ 
++// RXNIX: raised once (in update_color_mgmt) when the SDR (Gamma22) output colour
++// management is an identity round-trip, so the libMali composite fast-path may
++// skip the per-pixel colour-management LUT lookups. Never set on non-default
++// colour config (nightmode, look LUT, gamut widening, gain, HDR, ...).
++extern bool g_bRxnixColorMgmtIdentitySDR;
++
+ #pragma pack(push, 1)
+ struct BlitPushData_t
+ {
+@@ -4480,6 +4486,8 @@ struct BlitPushData_t
+     float u_itmSdrNits; // unset
+     float u_itmTargetNits; // unset
+ 
++    uint32_t u_rxnixTrivial;
++
+ 	explicit BlitPushData_t(const struct FrameInfo_t *frameInfo)
+ 	{
+ 		u_shaderFilter = 0;
+@@ -4520,6 +4528,35 @@ struct BlitPushData_t
+ 		u_nitsToLinear = 1.0f / g_flInternalDisplayBrightnessNits;
+ 		u_itmSdrNits = g_flHDRItmSdrNits;
+ 		u_itmTargetNits = g_flHDRItmTargetNits;
++
++		// RXNIX composite fast-path selection. Gated purely on the driver-independent
++		// colour-management identity proof: SDR content whose output colour management
++		// is a proven identity round-trip, with every layer colorspace_linear and an
++		// identity CTM, so skipping the per-pixel colour-management LUTs yields a
++		// bit-equivalent result at a fraction of the cost. This holds on any Vulkan
++		// driver (the skipped work is a mathematical identity), so it is NOT gated on
++		// libMali: PanVK/panfrost needs it too whenever the Vulkan composite is
++		// mandatory (integer scaling, --force-composition), where the RGA cannot take
++		// over the scale. u_rxnixTrivial rides in the composite constants UBO whose
++		// explicit range (see 0013) covers it, so PanVK reads it correctly.
++		u_rxnixTrivial = 0u;
++		if ( g_bRxnixColorMgmtIdentitySDR
++		     && frameInfo->outputEncodingEOTF == EOTF_Gamma22
++		     && frameInfo->ycbcrMask() == 0
++		     && g_uCompositeDebug == 0 )
++		{
++			bool bAllTrivial = frameInfo->layerCount > 0;
++			for ( int i = 0; i < frameInfo->layerCount; i++ )
++			{
++				const FrameInfo_t::Layer_t *rxL = &frameInfo->layers[i];
++				if ( rxL->colorspace != GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR || rxL->ctm )
++				{
++					bAllTrivial = false;
++					break;
++				}
++			}
++			u_rxnixTrivial = bAllTrivial ? 1u : 0u;
++		}
+ 	}
+ 
+ 	explicit BlitPushData_t(float blit_scale) {
+@@ -4541,6 +4578,7 @@ struct BlitPushData_t
+ 		u_nitsToLinear = 1.0f / g_flInternalDisplayBrightnessNits;
+ 		u_itmSdrNits = g_flHDRItmSdrNits;
+ 		u_itmTargetNits = g_flHDRItmTargetNits;
++		u_rxnixTrivial = 0u;
+ 	}
+ };
+ 
+diff --git a/src/shaders/blit_push_data.h b/src/shaders/blit_push_data.h
+index caff0f3..0b7d465 100644
+--- a/src/shaders/blit_push_data.h
++++ b/src/shaders/blit_push_data.h
+@@ -16,5 +16,9 @@ uniform layers_t {
+     float u_nitsToLinear; // hdr -> sdr
+     float u_itmSdrNits;
+     float u_itmTargetNits;
++
++    // RXNIX libMali composite fast-path: set by the CPU when the per-layer colour
++    // management is a proven identity round-trip (see BlitPushData_t).
++    uint u_rxnixTrivial;
+ };
+ 
+diff --git a/src/shaders/cs_composite_blit.comp b/src/shaders/cs_composite_blit.comp
+index c0b7445..78782c6 100644
+--- a/src/shaders/cs_composite_blit.comp
++++ b/src/shaders/cs_composite_blit.comp
+@@ -19,6 +19,36 @@ vec4 sampleLayer(uint layerIdx, vec2 uv) {
+     return sampleLayer(s_samplers[layerIdx], layerIdx, uv, true);
+ }
+ 
++// RXNIX libMali composite fast-path sampler: identical sampling to sampleLayerEx
++// (including degamma, which is identity for colorspace_linear) but SKIPS the
++// per-layer CTM and apply_layer_color_mgmt. Only used when u_rxnixTrivial is set,
++// which the CPU raises exclusively on libMali once it has proven those steps are
++// an identity round-trip (all layers colorspace_linear, no CTM, and the output
++// colour-management LUT is identity). The compositing blend and encodeOutputColor
++// are preserved, so the result matches the full path while avoiding the redundant
++// per-pixel colour-management LUT lookups that dominate the composite cost.
++vec4 sampleLayerNoCM(uint layerIdx, vec2 uv) {
++    vec2 coord = ((uv + u_offset[layerIdx]) * u_scale[layerIdx]);
++    vec2 texSize = textureSize(s_samplers[layerIdx], 0);
++
++    if (coord.x < 0.0f       || coord.y < 0.0f ||
++        coord.x >= texSize.x || coord.y >= texSize.y) {
++        float border = (u_borderMask & (1u << layerIdx)) != 0 ? 1.0f : 0.0f;
++        return vec4(0.0f, 0.0f, 0.0f, border);
++    }
++
++    uint colorspace = get_layer_colorspace(layerIdx);
++    if (get_layer_shaderfilter(layerIdx) == filter_pixel) {
++        vec2 output_res = texSize / u_scale[layerIdx];
++        vec2 extent = max((texSize / output_res), vec2(1.0 / 256.0));
++        return sampleBandLimited(s_samplers[layerIdx], coord, vec2(1.0f), vec2(1.0f), extent, colorspace, true);
++    }
++    else if (get_layer_shaderfilter(layerIdx) == filter_linear_emulated) {
++        return sampleBilinear(s_samplers[layerIdx], coord, colorspace, true);
++    }
++    return sampleRegular(s_samplers[layerIdx], coord, colorspace);
++}
++
+ void main() {
+     uvec2 coord = uvec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
+     uvec2 outSize = imageSize(dst);
+@@ -27,6 +57,16 @@ void main() {
+     if (outCoord.x >= outSize.x || outCoord.y >= outSize.y)
+         return;
+ 
++    if (u_rxnixTrivial != 0u && c_compositing_debug == 0u) {
++        vec2 uvFast = vec2(coord);
++        vec4 rxColor = sampleLayerNoCM(0, uvFast) * u_opacity[0];
++        for (int i = 1; i < c_layerCount; i++)
++            rxColor = BlendLayer(i, rxColor, sampleLayerNoCM(i, uvFast), u_opacity[i]);
++        rxColor.rgb = encodeOutputColor(rxColor.rgb);
++        imageStore(dst, ivec2(outCoord), rxColor);
++        return;
++    }
++
+     vec2 uv = vec2(coord);
+     vec4 outputValue = vec4(0.0f);
+ 
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index ab4c47c..b6ca8ce 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -145,6 +145,12 @@ std::atomic<uint64_t> g_FocusedVROverlayKeyboard;
+ 
+ gamescope_color_mgmt_tracker_t g_ColorMgmt{};
+ 
++// RXNIX: true when the active SDR (Gamma22) output colour management is an identity
++// round-trip (default 709->709, no nightmode/look/gamut-widening, gain 1). Consumed
++// by the libMali composite fast-path in rendervulkan.cpp. Recomputed in
++// update_color_mgmt() whenever the colour-management config changes.
++bool g_bRxnixColorMgmtIdentitySDR = false;
++
+ static gamescope_color_mgmt_luts g_ColorMgmtLutsOverride[ EOTF_Count ];
+ std::atomic<std::shared_ptr<lut3d_t>> g_ColorMgmtLooks[EOTF_Count];
+ 
+@@ -498,6 +504,25 @@ update_color_mgmt()
+ 			g_ColorMgmtLuts[i].reset();
+ 	}
+ 
++	// RXNIX: recompute whether the SDR (Gamma22) output colour management is an
++	// identity round-trip, so the libMali composite fast-path may skip the per-pixel
++	// colour-management LUT lookups. Conservative: any non-default colour setting
++	// (nightmode, look LUT, gamut widening, non-unity gain, override LUT, HDR/non-G22
++	// output, or a display whose native and output colorimetry differ) disables it.
++	{
++		const gamescope_color_mgmt_t& cm = g_ColorMgmt.pending;
++		std::shared_ptr<lut3d_t> pLook = g_ColorMgmtLooks[EOTF_Gamma22];
++		bool bLook = pLook && pLook->lutEdgeSize > 0;
++		bool bOverride = g_ColorMgmtLutsOverride[EOTF_Gamma22].HasLuts();
++		g_bRxnixColorMgmtIdentitySDR =
++			cm.enabled && !bLook && !bOverride
++			&& cm.outputEncodingEOTF == EOTF_Gamma22
++			&& cm.flSDRInputGain == 1.f
++			&& cm.nightmode.amount == 0.f
++			&& cm.sdrGamutWideness < 0.f
++			&& cm.displayColorimetry == cm.outputEncodingColorimetry;
++	}
++
+ #ifdef COLOR_MGMT_MICROBENCH
+ 	clock_gettime(CLOCK_MONOTONIC_RAW, &t1);
+ #endif

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0022-rendervulkan-DRMBackend-rga-composite-blend-offload.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0022-rendervulkan-DRMBackend-rga-composite-blend-offload.patch
@@ -1,0 +1,240 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan,DRMBackend: RGA multi-layer composite blend offload
+
+When every layer of a composited frame is RGA-expressible, blend the stack on the
+RGA (Porter-Duff src-over) and rotate the result to scanout, leaving the 3D GPU idle.
+Any non-expressible frame falls back to the unchanged Vulkan composite path.
+---
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -3572,6 +3572,9 @@
+ // --force-composition (disable direct scan-out). Defined in steamcompmgr.cpp.
+ extern gamescope::ConVar<bool> cv_composite_force;
+ #if HAVE_LIBRGA
++// ROCKNIX: composite-blend eligibility reads these globals (defined later in this TU).
++extern bool g_bRxnixColorMgmtIdentitySDR;
++extern std::string g_reshade_effect;
+ namespace rxnix_rga {
+     static bool g_bLibTried = false, g_bLibOk = false;
+     static bool g_bEnabled  = false;   // composite rotate/scale path active
+@@ -3848,6 +3851,133 @@
+         vk_log.infof( "rxnix_rga: direct scanout pool %ux%u x4 (LINEAR)", w, h );
+         return true;
+     }
++    // ---- ROCKNIX: multi-layer composite blend offload to the RGA ----
++    // When a frame must be composited because overlays sit over the base (a cursor,
++    // HUD, notification ...) and every layer is expressible by the RGA 2D engine,
++    // blend the layers with the RGA (improcess src-over) instead of the Vulkan
++    // compute compositor, then rotate to scanout. The whole present then runs on the
++    // RGA and the 3D GPU stays idle, so the client keeps the entire core. Any frame
++    // the RGA cannot express (an AFBC client it cannot read, colour management, HDR,
++    // FSR/NIS/blur, integer scaling, per-layer opacity < 1, a scaling nearest/pixel
++    // filter ...) makes composite_eligible() return false and gamescope's Vulkan
++    // composite path runs unchanged. Driver-independent: works on libMali and PanVK.
++    static CmaImage g_blendComp;       // landscape blend scratch (RGA dst, then rotate src)
++    static CmaImage g_blendScan[3];    // portrait KMS scanout ring (RGA rotate dst)
++    static int      g_nBlendIdx = 0;
++    static bool     g_bBlendPool = false;
++
++    static bool ensure_blend_pool() {
++        if ( g_bBlendPool ) return true;
++        uint32_t fmt = cma_drm_format( DRM_FORMAT_INVALID );
++        uint32_t scanW = g_nativeH, scanH = g_nativeW;
++        if ( !make_cma_image( g_blendComp, g_renderW, g_renderH, fmt, true ) ) return false;
++        for ( int i = 0; i < 3; i++ )
++            if ( !make_cma_image( g_blendScan[i], scanW, scanH, fmt, false ) ) return false;
++        g_nBlendIdx = 0; g_bBlendPool = true;
++        vk_log.infof( "rxnix_rga: composite-blend pool ready (comp %ux%u -> scan %ux%u)", g_renderW, g_renderH, scanW, scanH );
++        return true;
++    }
++
++    // Map a layer's client buffer to an RGA source descriptor. Returns false for any
++    // buffer the RGA2P cannot import (bad format, or a non-LINEAR/non-AFBC32x8 modifier
++    // - notably Mali AFBC 16x16, which the RGA cannot decode).
++    static bool layer_rga_src_info( const FrameInfo_t::Layer_t *L, int *pFmt, int *pRdMode ) {
++        const struct wlr_dmabuf_attributes &dma = L->tex->dmabuf();
++        if ( dma.n_planes < 1 || dma.fd[0] < 0 ) return false;
++        int f = drm_to_rga_format( dma.format );
++        if ( f < 0 ) return false;
++        int rd = 0;
++        uint64_t mod = dma.modifier;
++        if ( mod != DRM_FORMAT_MOD_LINEAR && mod != DRM_FORMAT_MOD_INVALID && mod != 0 ) {
++            if ( (uint8_t)( mod >> 56 ) != 0x08 ) return false;   // non-ARM modifier
++            if ( (uint8_t)( mod & 0xf ) != 2 ) return false;      // only AFBC 32x8 decodable
++            rd = IM_AFBC32x8_MODE;
++        }
++        *pFmt = f; *pRdMode = rd;
++        return true;
++    }
++
++    // Destination rect of a layer in composite (landscape) pixels, matching the plane
++    // geometry gamescope computes for hardware planes: dst = ( -offset, texContent/scale ).
++    static void layer_dst_rect( const FrameInfo_t::Layer_t *L, int *x, int *y, int *w, int *h ) {
++        *x = (int)( -L->offset.x );
++        *y = (int)( -L->offset.y );
++        *w = (int)( (float)L->tex->contentWidth()  / L->scale.x + 0.5f );
++        *h = (int)( (float)L->tex->contentHeight() / L->scale.y + 0.5f );
++    }
++
++    static bool composite_eligible( const FrameInfo_t *fi ) {
++        if ( !g_bEnabled || integer_scaling() ) return false;
++        if ( cv_composite_force.Get() ) return false;
++        if ( fi->layerCount < 2 || fi->layerCount > 4 ) return false;  // 1 = other paths; cap RGA passes
++        if ( fi->useFSRLayer0 || fi->useNISLayer0 || fi->blurLayer0 || fi->bFadingOut ) return false;
++        if ( !g_reshade_effect.empty() ) return false;
++        if ( !g_bRxnixColorMgmtIdentitySDR ) return false;            // HDR / colour mgmt / night mode / sliders
++        if ( fi->outputEncodingEOTF != EOTF_Gamma22 ) return false;
++        if ( fi->ycbcrMask() != 0 ) return false;
++        if ( g_uCompositeDebug != 0 ) return false;                   // heatmap / markers
++        for ( int i = 0; i < fi->layerCount; i++ ) {
++            const FrameInfo_t::Layer_t *L = &fi->layers[i];
++            if ( !L->tex ) return false;
++            if ( L->colorspace != GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR || L->ctm ) return false;
++            if ( L->opacity < 1.0f ) return false;                    // per-pixel alpha only; fades -> GPU
++            if ( L->eAlphaBlendingMode != ALPHA_BLENDING_MODE_PREMULTIPLIED ) return false;
++            if ( L->filter != GamescopeUpscaleFilter::LINEAR && !L->isScreenSize() ) return false;
++            int f, rd;
++            if ( !layer_rga_src_info( L, &f, &rd ) ) return false;
++            int dx, dy, dw, dh; layer_dst_rect( L, &dx, &dy, &dw, &dh );
++            if ( dw <= 0 || dh <= 0 ) return false;
++            // Every layer must land fully inside the composite (no clip maths here).
++            // The composite is cleared to black first, so a letterboxed base is fine.
++            if ( dx < 0 || dy < 0 || dx + dw > (int)g_renderW || dy + dh > (int)g_renderH ) return false;
++        }
++        return true;
++    }
++
++    static bool blend_layers( const FrameInfo_t *fi, CmaImage &comp ) {
++        int compFmt = drm_to_rga_format( comp.drmFormat );
++        if ( compFmt < 0 ) return false;
++        rga_buffer_handle_t dhnd = import_cached( comp.fd, comp.stride / 4, comp.h, compFmt );
++        if ( !dhnd ) return false;
++        rga_buffer_t dst = wrapbuffer_handle_t( dhnd, (int)comp.w, (int)comp.h, (int)( comp.stride / 4 ), (int)comp.h, compFmt );
++        // Clear to black so a letterboxed/pillarboxed base leaves black borders and no
++        // stale content shows through any gap between layers.
++        { im_rect full = { 0, 0, (int)comp.w, (int)comp.h }; imfill( dst, full, 0x00000000, 1 ); }
++        for ( int i = 0; i < fi->layerCount; i++ ) {
++            const FrameInfo_t::Layer_t *L = &fi->layers[i];
++            const struct wlr_dmabuf_attributes &dma = L->tex->dmabuf();
++            int sfmt, rd;
++            if ( !layer_rga_src_info( L, &sfmt, &rd ) ) return false;
++            uint32_t sws = dma.stride[0] / 4, shs = (uint32_t)dma.height;
++            if ( rd ) { sws = ( sws + 31u ) & ~31u; shs = ( shs + 7u ) & ~7u; }
++            rga_buffer_handle_t shnd = import_cached( dma.fd[0], sws, shs, sfmt );
++            if ( !shnd ) return false;
++            rga_buffer_t src = wrapbuffer_handle_t( shnd, (int)dma.width, (int)dma.height, (int)sws, (int)shs, sfmt );
++            if ( rd ) src.rd_mode = rd;
++            im_rect srect = { 0, 0, (int)L->tex->contentWidth(), (int)L->tex->contentHeight() };
++            im_rect drect = {};
++            int usage;
++            if ( i == 0 ) {
++                int dx, dy, dw, dhh; layer_dst_rect( L, &dx, &dy, &dw, &dhh );
++                drect.x = dx; drect.y = dy; drect.width = dw; drect.height = dhh; // base at its rect (may be letterboxed)
++                usage = 0;                                            // scaled copy
++            } else {
++                int dx, dy, dw, dhh; layer_dst_rect( L, &dx, &dy, &dw, &dhh );
++                drect.x = dx; drect.y = dy; drect.width = dw; drect.height = dhh;
++                usage = IM_ALPHA_BLEND_SRC_OVER; // premultiplied => NO IM_ALPHA_BLEND_PRE_MUL
++            }
++            im_rect prect = {};
++            rga_buffer_t pat = {};
++            IM_STATUS st = improcess( src, dst, pat, srect, drect, prect, -1, nullptr, nullptr, usage );
++            if ( st != IM_STATUS_SUCCESS ) {
++                static bool s_bLogged = false;
++                if ( !s_bLogged ) { s_bLogged = true;
++                    vk_log.errorf( "rxnix_rga: composite-blend layer %d improcess st=%d[%s]", i, (int)st, imStrError_t( st ) ); }
++                return false;
++            }
++        }
++        return true;
++    }
+ } // namespace rxnix_rga
+ 
+ // The release fence of the last async RGA scanout blit (or -1). The DRM backend
+@@ -3860,6 +3990,37 @@
+     return -1;
+ #endif
+ }
++
++// ROCKNIX: blend a multi-layer frame on the RGA 2D engine and rotate it to
++// a panel-native portrait scanout buffer, with NO Vulkan compute composite - the 3D
++// GPU stays idle so the client keeps the whole core. Returns the scanout buffer to
++// present, or nullptr (the frame is not RGA-expressible; the caller GPU-composites).
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rga_composite_rotate( const struct FrameInfo_t *fi ) {
++#if HAVE_LIBRGA
++    using namespace rxnix_rga;
++    if ( !fi || !composite_eligible( fi ) ) return nullptr;
++    if ( !ensure_blend_pool() ) return nullptr;
++    CmaImage &comp = g_blendComp;
++    CmaImage &scan = g_blendScan[g_nBlendIdx];
++    if ( comp.fd < 0 || scan.fd < 0 ) return nullptr;
++    if ( !blend_layers( fi, comp ) ) return nullptr;
++    // Rotate the landscape composite into the portrait scanout. Synchronous: the single
++    // landscape scratch is reused next present, so it must be consumed now.
++    if ( !rotate_blit( comp.fd, comp.w, comp.h, comp.stride,
++                       scan.fd, scan.w, scan.h, scan.stride,
++                       comp.drmFormat, scan.drmFormat, 0, false, -1 ) )
++        return nullptr;
++    flush_for_scanout( scan.fd, (size_t)scan.stride * scan.h );
++    g_nBlendIdx = ( g_nBlendIdx + 1 ) % 3;
++    static bool s_bLogged = false;
++    if ( !s_bLogged ) { s_bLogged = true;
++        vk_log.infof( "rxnix_rga: multi-layer COMPOSITE-BLEND active (RGA blends %d layers, GPU idle)", fi->layerCount ); }
++    return scan.tex;
++#else
++    (void)fi;
++    return nullptr;
++#endif
++}
+ #endif // HAVE_LIBRGA
+ 
+ // Allocate RGA composite + scanout images. Returns true if the RGA path is active
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -583,6 +583,7 @@
+ bool vulkan_rxnix_rga_direct_enabled();
+ gamescope::Rc<CVulkanTexture> vulkan_rxnix_rotate_output_for_present( uint64_t ulCompositePoint, bool* pbCompositeWaited );
+ gamescope::Rc<CVulkanTexture> vulkan_rxnix_rga_direct_rotate( CVulkanTexture *pClient );
++gamescope::Rc<CVulkanTexture> vulkan_rxnix_rga_composite_rotate( const struct FrameInfo_t *fi );
+ 
+ struct SamplerState
+ {
+diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -3718,6 +3718,33 @@
+ 					}
+ 				}
+ 			}
++			// ROCKNIX: multi-layer composite blend on the RGA. If the direct fast
++			// path did not take the frame (overlays or a cursor sit over the base) but every
++			// layer is RGA-expressible, blend the layers with the RGA 2D engine and rotate to
++			// scanout - the 3D GPU stays idle so the client keeps the whole core. Any frame the
++			// RGA cannot express returns nullptr and falls through to the Vulkan composite below.
++			if ( !bRxnixDirect && vulkan_rxnix_rga_enabled() )
++			{
++				gamescope::Rc<CVulkanTexture> pRgaComposited = vulkan_rxnix_rga_composite_rotate( pFrameInfo );
++				if ( pRgaComposited )
++				{
++					rxnixDirectFrameInfo = *pFrameInfo;
++					rxnixDirectFrameInfo.layerCount = 1; // present the single RGA-composited buffer
++					FrameInfo_t::Layer_t *pCompLayer = &rxnixDirectFrameInfo.layers[0];
++					pCompLayer->tex            = pRgaComposited;
++					pCompLayer->offset         = { 0.0f, 0.0f };
++					pCompLayer->scale          = { 1.0f, 1.0f };
++					pCompLayer->opacity        = 1.0f;
++					pCompLayer->zpos           = g_zposBase;
++					pCompLayer->applyColorMgmt = false;
++					pCompLayer->filter         = GamescopeUpscaleFilter::NEAREST;
++					pCompLayer->ctm            = nullptr;
++					pScanoutFrameInfo          = &rxnixDirectFrameInfo;
++					bRxnixDirect               = true;
++					bNeedsFullComposite        = false; // fully composited by the RGA already
++					bWantsPartialComposite     = false;
++				}
++			}
+ 			// RGA composite path (used when direct scanout is disabled by
+ 			// --force-composition / integer scaling, or the client buffer could not
+ 			// be imported directly): force a full composite so the RGA rotation

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0023-wlserver-advertise-viewporter-subcompositor-single-pixel.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0023-wlserver-advertise-viewporter-subcompositor-single-pixel.patch
@@ -1,0 +1,82 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] wlserver: advertise viewporter, subcompositor and single-pixel-buffer
+
+Create the wp_viewporter, wl_subcompositor and wp_single_pixel_buffer_manager globals
+in wlserver_init. Standard optional protocols that some Wayland video clients require
+to start; harmless to clients that do not bind them, and unconditional so the same
+launch works on every driver.
+---
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -44,6 +44,7 @@
+ #include <wlr/types/wlr_relative_pointer_v1.h>
+ #include <wlr/types/wlr_pointer_constraints_v1.h>
+ #include <wlr/types/wlr_layer_shell_v1.h>
++#include <wlr/types/wlr_viewporter.h>
+ #include <wlr/util/region.h>
+ #include "wlr_end.hpp"
+ 
+@@ -2029,6 +2030,14 @@
+ 
+ 	wl_signal_add( &wlserver.wlr.compositor->events.new_surface, &new_surface_listener );
+ 
++	// wp_viewporter: some Wayland video clients
++	// require the viewporter global for their video output and abort with "Missing
++	// wayland viewporter" when it is absent. The bundled wlroots implements it but
++	// wlserver_init never created the global; advertise it. Standard/optional protocol,
++	// harmless to clients that do not use it, and unconditional so the same launch works
++	// on every GPU driver.
++	wlr_viewporter_create( wlserver.display );
++
+ 	create_ime_manager( &wlserver );
+ 
+ 	create_reshade();
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -45,6 +45,7 @@
+ #include <wlr/types/wlr_pointer_constraints_v1.h>
+ #include <wlr/types/wlr_layer_shell_v1.h>
+ #include <wlr/types/wlr_viewporter.h>
++#include <wlr/types/wlr_subcompositor.h>
+ #include <wlr/util/region.h>
+ #include "wlr_end.hpp"
+ 
+@@ -2038,6 +2039,13 @@
+ 	// on every GPU driver.
+ 	wlr_viewporter_create( wlserver.display );
+ 
++	// wl_subcompositor: a Wayland video backend such as SDL3
++	// binds wl_subcompositor at init and calls wl_subcompositor_get_subsurface(); when
++	// the global is absent it dereferences a NULL proxy in wl_proxy_get_version() and
++	// crashes. wlroots implements subcompositor/subsurface on wlr_surface; advertise it.
++	// Standard core-adjacent protocol, harmless to clients that do not use it.
++	wlr_subcompositor_create( wlserver.display );
++
+ 	create_ime_manager( &wlserver );
+ 
+ 	create_reshade();
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -46,6 +46,7 @@
+ #include <wlr/types/wlr_layer_shell_v1.h>
+ #include <wlr/types/wlr_viewporter.h>
+ #include <wlr/types/wlr_subcompositor.h>
++#include <wlr/types/wlr_single_pixel_buffer_v1.h>
+ #include <wlr/util/region.h>
+ #include "wlr_end.hpp"
+ 
+@@ -2046,6 +2047,14 @@
+ 	// Standard core-adjacent protocol, harmless to clients that do not use it.
+ 	wlr_subcompositor_create( wlserver.display );
+ 
++	// wp_single_pixel_buffer_manager: a Wayland video client's output
++	// creates a 1x1 solid-colour wl_buffer (the letterbox/background fill) via
++	// wp_single_pixel_buffer_manager_v1.create_u32_rgba_buffer(); without the global it
++	// dereferences a NULL manager proxy in wl_proxy_get_version() and segfaults right
++	// after "Video initialized: wayland". gamescope's own Wayland backend uses the very
++	// same pattern for its black fill; advertise the global so nested clients can too.
++	wlr_single_pixel_buffer_manager_v1_create( wlserver.display );
++
+ 	create_ime_manager( &wlserver );
+ 
+ 	create_reshade();

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0024-rendervulkan-rga-yuv-to-rgba.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0024-rendervulkan-rga-yuv-to-rgba.patch
@@ -1,0 +1,199 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] rendervulkan: RGA-convert planar and semi-planar YUV to RGBA
+
+libMali's Vulkan cannot sample YUV dma-bufs, so convert planar (YU12/I420/YV12) and
+semi-planar (NV12/NV21) buffers to RGBA on the RGA before import. Output is drawn from
+a reused 4-deep ring. No-op where /dev/rga is unavailable.
+---
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -2977,6 +2977,11 @@
+   return res == VK_SUCCESS;
+ }
+ 
++#if HAVE_LIBRGA
++bool vulkan_rxnix_rga_yuv_available();
++gamescope::OwningRc<CVulkanTexture> vulkan_rxnix_yuv_to_rgba( const struct wlr_dmabuf_attributes *pDMA );
++#endif
++
+ bool vulkan_init_format(VkFormat format, uint32_t drmFormat)
+ {
+ 	// First, check whether the Vulkan format is supported
+@@ -3114,6 +3119,22 @@
+ 			vulkan_init_format(srgbFormat, drmFormat);
+ 	}
+ 
++#if HAVE_LIBRGA
++	// ROCKNIX: advertise planar YUV (YU12/I420, YV12) even though libMali's Vulkan cannot
++	// sample 3-plane YUV - vulkan_create_texture_from_dmabuf RGA-converts it to RGBA on
++	// import. Lets planar-YUV Wayland video clients (e.g. a software
++	// H.264 decode) present their frames; a no-op where /dev/rga is unavailable.
++	// Advertise LINEAR only (NOT MOD_INVALID): wlroots' linux_dmabuf sends only INVALID
++	// for a format whose modifier set is exactly {INVALID, LINEAR} (an XWayland quirk),
++	// but such clients want an explicit "mod 0" (LINEAR) match.
++	if ( vulkan_rxnix_rga_yuv_available() )
++	{
++		wlr_drm_format_set_add( &sampledDRMFormats, DRM_FORMAT_YUV420, DRM_FORMAT_MOD_LINEAR );
++		wlr_drm_format_set_add( &sampledDRMFormats, DRM_FORMAT_YVU420, DRM_FORMAT_MOD_LINEAR );
++		wlr_drm_format_set_add( &sampledShmFormats, DRM_FORMAT_YUV420, DRM_FORMAT_MOD_LINEAR );
++	}
++#endif
++
+ 	vk_log.infof( "supported DRM formats for sampling usage:" );
+ 	for ( size_t i = 0; i < sampledDRMFormats.len; i++ )
+ 	{
+@@ -3579,6 +3600,10 @@
+     static CmaImage g_directPool[4];   // direct-scanout ring (client -> native)
+     static int      g_nDirectIdx = 0;
+     static bool     g_bDirectPool = false;
++    static CmaImage g_yuvPool[4];      // YUV->RGBA convert ring (video clients)
++    static int      g_nYuvIdx = 0;
++    static bool     g_bYuvPool = false;
++    static uint32_t g_yuvW = 0, g_yuvH = 0;
+ 
+     // Integer scaling (-S integer) is the one mode that must be composited by
+     // Vulkan at the panel native resolution: the RGA scales only bilinearly, which
+@@ -3802,6 +3827,31 @@
+         vk_log.infof( "rxnix_rga: direct scanout pool %ux%u x4 (LINEAR)", w, h );
+         return true;
+     }
++
++    // Reused RGBA output ring for the YUV->RGBA convert (video clients). Allocating a
++    // fresh CMA image + Vulkan import per frame was expensive and, because each frame got a
++    // new fd, also defeated the flush_for_scanout skip (an ~8 MB cache flush every frame).
++    // A 4-deep ring (like g_directPool) removes both: reuse-while-in-flight is bounded
++    // exactly as the proven scanout/direct pools.
++    static bool ensure_yuv_pool( uint32_t w, uint32_t h ) {
++        if ( g_bYuvPool && g_yuvW == w && g_yuvH == h ) return true;
++        if ( g_bYuvPool ) {
++            for ( int i = 0; i < 4; i++ ) {
++                if ( g_yuvPool[i].fd >= 0 ) close( g_yuvPool[i].fd );
++                g_yuvPool[i] = CmaImage{};
++            }
++            g_bYuvPool = false;
++        }
++        for ( int i = 0; i < 4; i++ ) {
++            if ( !make_cma_image( g_yuvPool[i], w, h, DRM_FORMAT_XBGR8888, true ) ) {
++                vk_log.errorf( "rxnix_rga: yuv convert pool %d alloc failed (%ux%u)", i, w, h );
++                return false;
++            }
++        }
++        g_yuvW = w; g_yuvH = h; g_nYuvIdx = 0; g_bYuvPool = true;
++        vk_log.infof( "rxnix_rga: YUV->RGBA convert pool %ux%u x4 (LINEAR)", w, h );
++        return true;
++    }
+     // ---- ROCKNIX: multi-layer composite blend offload to the RGA ----
+     // When a frame must be composited because overlays sit over the base (a cursor,
+     // HUD, notification ...) and every layer is expressible by the RGA 2D engine,
+@@ -4181,6 +4231,72 @@
+     return nullptr;
+ #endif
+ }
++// ROCKNIX: libMali's Vulkan cannot sample 3-plane planar YUV (YU12/I420, YV12) buffers,
++// which a Wayland video client's software video decode presents. Convert
++// them to RGBA with the RGA 2D engine (hardware YUV->RGB colour-space conversion) into a
++// fresh CMA image that the compositor samples and rotates like any other client texture.
++// Returns nullptr where /dev/rga is unavailable so the caller falls back to Vulkan import.
++gamescope::OwningRc<CVulkanTexture> vulkan_rxnix_yuv_to_rgba( const struct wlr_dmabuf_attributes *pDMA )
++{
++#if HAVE_LIBRGA
++	using namespace rxnix_rga;
++	if ( !pDMA || pDMA->fd[0] < 0 || !lib_init() )
++		return nullptr;
++	int srcRgaFmt;
++	switch ( pDMA->format )
++	{
++		case DRM_FORMAT_YUV420: srcRgaFmt = RK_FORMAT_YCbCr_420_P; break; // I420 / YU12
++		case DRM_FORMAT_YVU420: srcRgaFmt = RK_FORMAT_YCrCb_420_P; break; // YV12
++		default: return nullptr;
++	}
++	const uint32_t w = (uint32_t)pDMA->width, h = (uint32_t)pDMA->height;
++	const uint32_t srcWs = pDMA->stride[0] ? (uint32_t)pDMA->stride[0] : w;
++	uint32_t srcHs = h;
++	if ( pDMA->n_planes > 1 && (uint32_t)pDMA->offset[1] > (uint32_t)pDMA->offset[0] && srcWs > 0 )
++		srcHs = ( (uint32_t)pDMA->offset[1] - (uint32_t)pDMA->offset[0] ) / srcWs; // Y rows incl. padding, so RGA locates U/V correctly
++
++	if ( !ensure_yuv_pool( w, h ) )
++		return nullptr;
++	CmaImage &rgba = g_yuvPool[ g_nYuvIdx ];
++	g_nYuvIdx = ( g_nYuvIdx + 1 ) % 4;
++
++	im_handle_param_t sp = { srcWs, srcHs, (uint32_t)srcRgaFmt };
++	im_handle_param_t dp = { rgba.stride / 4u, rgba.h, (uint32_t)RK_FORMAT_RGBA_8888 };
++	rga_buffer_handle_t sh = importbuffer_fd( pDMA->fd[0], &sp );
++	rga_buffer_handle_t dh = importbuffer_fd( rgba.fd, &dp );
++	IM_STATUS st = IM_STATUS_FAILED;
++	if ( sh && dh )
++	{
++		rga_buffer_t src = wrapbuffer_handle_t( sh, (int)w, (int)h, (int)srcWs, (int)srcHs, srcRgaFmt );
++		rga_buffer_t dst = wrapbuffer_handle_t( dh, (int)rgba.w, (int)rgba.h, (int)( rgba.stride / 4u ), (int)rgba.h, RK_FORMAT_RGBA_8888 );
++		st = imcvtcolor( src, dst, srcRgaFmt, RK_FORMAT_RGBA_8888, IM_COLOR_SPACE_DEFAULT, 1 );
++	}
++	if ( dh ) releasebuffer_handle( dh );
++	if ( sh ) releasebuffer_handle( sh );
++	if ( st == IM_STATUS_SUCCESS )
++		flush_for_scanout( rgba.fd, (size_t)rgba.stride * rgba.h );
++	gamescope::OwningRc<CVulkanTexture> tex = rgba.tex; // pooled buffer; fd kept open for reuse
++	if ( st != IM_STATUS_SUCCESS )
++	{
++		static bool s_bLogged = false;
++		if ( !s_bLogged ) { s_bLogged = true; vk_log.errorf( "rxnix_rga: YUV->RGBA convert failed st=%d", (int)st ); }
++		return nullptr;
++	}
++	return tex;
++#else
++	(void)pDMA; return nullptr;
++#endif
++}
++
++bool vulkan_rxnix_rga_yuv_available()
++{
++#if HAVE_LIBRGA
++	return rxnix_rga::lib_init();
++#else
++	return false;
++#endif
++}
++
+ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
+ {
+ 	CVulkanTexture::createFlags outputImageflags;
+@@ -4518,6 +4634,17 @@
+ 	//fprintf(stderr, "pDMA->width: %d pDMA->height: %d pDMA->format: 0x%x pDMA->modifier: 0x%lx pDMA->n_planes: %d\n",
+ 	//	pDMA->width, pDMA->height, pDMA->format, pDMA->modifier, pDMA->n_planes);
+ 	
++#if HAVE_LIBRGA
++	// libMali cannot Vulkan-sample 3-plane planar YUV (a Wayland video client's decoded
++	// frames); hand those to the RGA for a hardware colour-convert to an RGBA texture.
++	if ( pDMA->format == DRM_FORMAT_YUV420 || pDMA->format == DRM_FORMAT_YVU420 )
++	{
++		gamescope::OwningRc<CVulkanTexture> pRgba = vulkan_rxnix_yuv_to_rgba( pDMA );
++		if ( pRgba )
++			return pRgba;
++	}
++#endif
++
+ 	if ( pTex->BInit( pDMA->width, pDMA->height, 1u, pDMA->format, texCreateFlags, pDMA, 0, 0, nullptr, pBackendFb ) == false )
+ 		return nullptr;
+ 	
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -4247,6 +4247,8 @@
+ 	{
+ 		case DRM_FORMAT_YUV420: srcRgaFmt = RK_FORMAT_YCbCr_420_P; break; // I420 / YU12
+ 		case DRM_FORMAT_YVU420: srcRgaFmt = RK_FORMAT_YCrCb_420_P; break; // YV12
++		case DRM_FORMAT_NV12:   srcRgaFmt = RK_FORMAT_YCbCr_420_SP; break; // NV12 (V4L2 Request rkvdec HW decode)
++		case DRM_FORMAT_NV21:   srcRgaFmt = RK_FORMAT_YCrCb_420_SP; break; // NV21
+ 		default: return nullptr;
+ 	}
+ 	const uint32_t w = (uint32_t)pDMA->width, h = (uint32_t)pDMA->height;
+@@ -4637,7 +4639,8 @@
+ #if HAVE_LIBRGA
+ 	// libMali cannot Vulkan-sample 3-plane planar YUV (a Wayland video client's decoded
+ 	// frames); hand those to the RGA for a hardware colour-convert to an RGBA texture.
+-	if ( pDMA->format == DRM_FORMAT_YUV420 || pDMA->format == DRM_FORMAT_YVU420 )
++	if ( pDMA->format == DRM_FORMAT_YUV420 || pDMA->format == DRM_FORMAT_YVU420 ||
++	     pDMA->format == DRM_FORMAT_NV12   || pDMA->format == DRM_FORMAT_NV21 )
+ 	{
+ 		gamescope::OwningRc<CVulkanTexture> pRgba = vulkan_rxnix_yuv_to_rgba( pDMA );
+ 		if ( pRgba )

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0025-steamcompmgr-wlserver-composite-subsurface-video.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0025-steamcompmgr-wlserver-composite-subsurface-video.patch
@@ -1,0 +1,293 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] steamcompmgr,wlserver: composite Wayland subsurface video on-panel
+
+gamescope only paints a window's root surface, so video presented on a wl_subsurface
+was never displayed. Capture each subsurface's latest buffer and composite the video
+subsurface (identified by its planar-YUV format, at any resolution) as a full-screen
+top layer, regardless of focus. Inert for clients with no subsurfaces.
+---
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -50,6 +50,9 @@
+ #include <wlr/types/wlr_single_pixel_buffer_v1.h>
+ #include <wlr/util/region.h>
+ #include "wlr_end.hpp"
++#include <mutex>
++#include <unordered_map>
++#include <vector>
+ 
+ #include "gamescope-xwayland-protocol.h"
+ #include "gamescope-pipewire-protocol.h"
+@@ -205,6 +208,44 @@
+ 
+ std::list<PendingCommit_t> g_PendingCommits;
+ 
++// Some Wayland clients render streamed video onto a wl_subsurface
++// of their toplevel. gamescope's compositor only draws a window's root surface, so
++// these commits fall through xwayland_surface_commit()'s x11/xdg role dispatch. Keep
++// the latest committed buffer for each subsurface here (keyed by its wl_surface, with
++// parent + surface-relative position) so the paint path can composite them as extra
++// layers. Empty for clients with no subsurfaces, so this is inert on the normal path.
++struct GamescopeSubsurfaceState_t
++{
++	struct wlr_surface *parent;
++	int32_t x, y;
++	struct wlr_buffer *buf; // locked; released on replace / surface destroy
++};
++static std::mutex g_SubsurfaceMutex;
++static std::unordered_map<struct wlr_surface *, GamescopeSubsurfaceState_t> g_SubsurfaceCommits;
++
++std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_subsurfaces_for( struct wlr_surface *parent )
++{
++	std::vector<GamescopeSubsurfaceLayer_t> out;
++	std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
++	for ( auto &entry : g_SubsurfaceCommits )
++	{
++		if ( entry.second.parent == parent && entry.second.buf )
++			out.push_back( GamescopeSubsurfaceLayer_t{ wlr_buffer_lock( entry.second.buf ), entry.second.x, entry.second.y } );
++	}
++	return out;
++}
++
++void wlserver_release_subsurfaces( std::vector<GamescopeSubsurfaceLayer_t> &subs )
++{
++	std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
++	for ( GamescopeSubsurfaceLayer_t &sub : subs )
++	{
++		if ( sub.buf )
++			wlr_buffer_unlock( sub.buf );
++	}
++	subs.clear();
++}
++
+ void wlserver_xdg_commit(struct wlr_surface *surf, struct wlr_buffer *buf)
+ {
+ 	std::optional<ResListEntry_t> oEntry = PrepareCommit( surf, buf );
+@@ -264,7 +305,21 @@
+ 	}
+ 	else
+ 	{
+-		g_PendingCommits.push_back(PendingCommit_t{ wlr_surface, buf });
++		struct wlr_subsurface *subsurface = wlr_subsurface_try_from_wlr_surface( wlr_surface );
++		if ( subsurface && subsurface->parent )
++		{
++			// A client presents its streamed video on a wl_subsurface; keep the latest
++			// buffer keyed by surface so the paint path can composite it as a layer.
++			std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
++			auto existing = g_SubsurfaceCommits.find( wlr_surface );
++			if ( existing != g_SubsurfaceCommits.end() && existing->second.buf )
++				wlr_buffer_unlock( existing->second.buf );
++			g_SubsurfaceCommits[ wlr_surface ] = GamescopeSubsurfaceState_t{ subsurface->parent, subsurface->current.x, subsurface->current.y, buf };
++		}
++		else
++		{
++			g_PendingCommits.push_back(PendingCommit_t{ wlr_surface, buf });
++		}
+ 	}
+ }
+ 
+@@ -606,6 +661,23 @@
+ 		wlserver.kb_focus_surface = nullptr;
+ 
+ 	wlserver.current_dropdown_surfaces.erase( surf->wlr );
++
++	{
++		// Drop any captured subsurface buffers for this surface (as subsurface or
++		// as a destroyed parent) so we never composite a stale/freed buffer.
++		std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
++		for ( auto it = g_SubsurfaceCommits.begin(); it != g_SubsurfaceCommits.end(); )
++		{
++			if ( it->first == surf->wlr || it->second.parent == surf->wlr )
++			{
++				if ( it->second.buf )
++					wlr_buffer_unlock( it->second.buf );
++				it = g_SubsurfaceCommits.erase( it );
++			}
++			else
++				it++;
++		}
++	}
+ 
+ 	for (auto it = g_PendingCommits.begin(); it != g_PendingCommits.end();)
+ 	{
+--- a/src/wlserver.hpp
++++ b/src/wlserver.hpp
+@@ -292,6 +292,19 @@
+ void wlserver_past_present_timing( struct wlr_surface *surface, uint32_t present_id, uint64_t desired_present_time, uint64_t actual_present_time, uint64_t earliest_present_time, uint64_t present_margin );
+ void wlserver_refresh_cycle( struct wlr_surface *surface, uint64_t refresh_cycle );
+ 
++// Some Wayland clients present video on a wl_subsurface of their
++// toplevel; gamescope composites these as extra layers. wlserver_lock_subsurfaces_for
++// returns the latest buffer (locked) and surface-relative position for every
++// subsurface of `parent`; the caller must return the vector to
++// wlserver_release_subsurfaces once the buffers have been turned into textures.
++struct GamescopeSubsurfaceLayer_t
++{
++	struct wlr_buffer *buf;
++	int32_t x, y;
++};
++std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_subsurfaces_for( struct wlr_surface *parent );
++void wlserver_release_subsurfaces( std::vector<GamescopeSubsurfaceLayer_t> &subs );
++
+ void wlserver_app_presented( uint32_t app_id, uint64_t frametime_ns );
+ 
+ void wlserver_shutdown();
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -2262,6 +2262,48 @@
+ 	return layer;
+ }
+ 
++// Some Wayland clients present streamed video on a wl_subsurface of
++// their toplevel. gamescope's compositor only draws a window's root surface, so walk
++// the window's captured subsurfaces and add each committed buffer as an extra layer at
++// its surface-relative offset, inheriting the root layer's scale/colour so it tracks
++// window scaling and the panel rotation shader. Clients without subsurfaces contribute
++// nothing here, so this is inert on the normal (game) path.
++static void
++paint_window_subsurfaces( steamcompmgr_win_t *w, FrameInfo_t::Layer_t *base, struct FrameInfo_t *frameInfo )
++{
++	if ( !w || !base )
++		return;
++
++	struct wlr_surface *root = w->main_surface();
++	if ( !root )
++		return;
++
++	std::vector<GamescopeSubsurfaceLayer_t> subs = wlserver_lock_subsurfaces_for( root );
++	for ( GamescopeSubsurfaceLayer_t &sub : subs )
++	{
++		if ( !sub.buf || frameInfo->layerCount >= k_nMaxLayers )
++			continue;
++
++		gamescope::OwningRc<CVulkanTexture> tex = vulkan_create_texture_from_wlr_buffer( sub.buf, {} );
++		if ( tex == nullptr )
++			continue;
++
++		int curLayer = frameInfo->layerCount++;
++		FrameInfo_t::Layer_t *layer = &frameInfo->layers[ curLayer ];
++		*layer = *base;
++
++		layer->tex = tex;
++		// base->scale holds 1/ratio and base->offset the negated on-screen origin, so
++		// shift by the subsurface's surface-local position scaled into output space.
++		layer->offset.x = base->offset.x - (float)sub.x / base->scale.x;
++		layer->offset.y = base->offset.y - (float)sub.y / base->scale.y;
++		layer->zpos = g_zposBase;
++		layer->blackBorder = false;
++	}
++
++	wlserver_release_subsurfaces( subs );
++}
++
+ static void
+ paint_window(steamcompmgr_win_t *w, steamcompmgr_win_t *scaleW, struct FrameInfo_t *frameInfo,
+ 			  MouseCursor *cursor, PaintWindowFlags flags = 0, float flOpacityScale = 1.0f, steamcompmgr_win_t *fit = nullptr )
+@@ -2293,6 +2335,8 @@
+ 	}
+ 
+ 	FrameInfo_t::Layer_t *layer = paint_window_commit( lastCommit, w, scaleW, frameInfo, cursor, flags, flOpacityScale, fit );
++
++	paint_window_subsurfaces( w, layer, frameInfo );
+ 
+ 	if ( layer && ( flags & PaintWindowFlag::BasePlane ) )
+ 	{
+--- a/src/Backends/DRMBackend.cpp
++++ b/src/Backends/DRMBackend.cpp
+@@ -3695,7 +3695,7 @@ namespace gamescope
+ 			const FrameInfo_t *pScanoutFrameInfo = pFrameInfo;
+ 			FrameInfo_t rxnixDirectFrameInfo;
+ 			bool bRxnixDirect = false;
+-			if ( vulkan_rxnix_rga_direct_enabled() && !bNeedsFullComposite && pFrameInfo->layerCount >= 1 )
++			if ( vulkan_rxnix_rga_direct_enabled() && !bNeedsFullComposite && pFrameInfo->layerCount == 1 )
+ 			{
+ 				const FrameInfo_t::Layer_t &rxnixBase = pFrameInfo->layers[0];
+ 				if ( rxnixBase.zpos == (int)g_zposBase && rxnixBase.opacity >= 1.0f && rxnixBase.tex != nullptr )
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -2729,6 +2729,48 @@ paint_all( global_focus_t *pFocus, bool async )
+ 		//update_touch_scaling( &frameInfo );
+ 	}
+ 
++	// A client presents its streamed video on a full-screen wl_subsurface of its own SDL
++	// native-Wayland toplevel, which gamescope does not focus or paint (its Qt UI is a
++	// separate X11 window). Composite the largest captured native-Wayland subsurface as a
++	// full-screen top layer so the streamed video is displayed regardless of focus. Inert
++	// for clients without captured subsurfaces (games / glmark / the pre-stream menu).
++	{
++		std::vector<GamescopeSubsurfaceLayer_t> videoLayers = wlserver_lock_all_subsurfaces();
++		for ( GamescopeSubsurfaceLayer_t &vs : videoLayers )
++		{
++			if ( !vs.buf || frameInfo.layerCount >= k_nMaxLayers )
++				continue;
++			// Composite only the streamed video (a planar-YUV subsurface), never the small ARGB
++			// status overlays. Identifying it by pixel format rather than size keeps this working
++			// at any stream resolution - a size threshold skipped the video entirely at e.g. 480p.
++			struct wlr_dmabuf_attributes vdma;
++			if ( !wlr_buffer_get_dmabuf( vs.buf, &vdma ) ||
++			     ( vdma.format != DRM_FORMAT_YUV420 && vdma.format != DRM_FORMAT_YVU420 &&
++			       vdma.format != DRM_FORMAT_NV12 && vdma.format != DRM_FORMAT_NV21 ) )
++				continue;
++			gamescope::OwningRc<CVulkanTexture> vtex = vulkan_create_texture_from_wlr_buffer( vs.buf, {} );
++			if ( vtex == nullptr )
++				continue;
++			int curLayer = frameInfo.layerCount++;
++			FrameInfo_t::Layer_t *layer = &frameInfo.layers[ curLayer ];
++			layer->scale.x = g_nOutputWidth == vtex->width() ? 1.0f : vtex->width() / (float)g_nOutputWidth;
++			layer->scale.y = g_nOutputHeight == vtex->height() ? 1.0f : vtex->height() / (float)g_nOutputHeight;
++			layer->offset.x = 0.0f;
++			layer->offset.y = 0.0f;
++			layer->opacity = 1.0f;
++			layer->zpos = g_zposOverlay;
++			layer->applyColorMgmt = g_ColorMgmt.pending.enabled;
++			layer->eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
++			layer->colorspace = GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR;
++			layer->hdr_metadata_blob = nullptr;
++			layer->ctm = nullptr;
++			layer->tex = vtex;
++			layer->filter = GamescopeUpscaleFilter::LINEAR;
++			layer->blackBorder = true;
++		}
++		wlserver_release_subsurfaces( videoLayers );
++	}
++
+ 	// If we have any layers that aren't a cursor or overlay, then we have valid contents for presentation.
+ 	const bool bValidContents = frameInfo.layerCount > 0;
+ 
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -235,6 +235,16 @@ std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_subsurfaces_for( struct wl
+ 	return out;
+ }
+ 
++std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_all_subsurfaces()
++{
++	std::vector<GamescopeSubsurfaceLayer_t> out;
++	std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
++	for ( auto &entry : g_SubsurfaceCommits )
++		if ( entry.second.buf )
++			out.push_back( GamescopeSubsurfaceLayer_t{ wlr_buffer_lock( entry.second.buf ), entry.second.x, entry.second.y } );
++	return out;
++}
++
+ void wlserver_release_subsurfaces( std::vector<GamescopeSubsurfaceLayer_t> &subs )
+ {
+ 	std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
+@@ -315,6 +325,7 @@ void xwayland_surface_commit(struct wlr_surface *wlr_surface) {
+ 			if ( existing != g_SubsurfaceCommits.end() && existing->second.buf )
+ 				wlr_buffer_unlock( existing->second.buf );
+ 			g_SubsurfaceCommits[ wlr_surface ] = GamescopeSubsurfaceState_t{ subsurface->parent, subsurface->current.x, subsurface->current.y, buf };
++			force_repaint();
+ 		}
+ 		else
+ 		{
+--- a/src/wlserver.hpp
++++ b/src/wlserver.hpp
+@@ -303,6 +303,7 @@ struct GamescopeSubsurfaceLayer_t
+ 	int32_t x, y;
+ };
+ std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_subsurfaces_for( struct wlr_surface *parent );
++std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_all_subsurfaces();
+ void wlserver_release_subsurfaces( std::vector<GamescopeSubsurfaceLayer_t> &subs );
+ 
+ void wlserver_app_presented( uint32_t app_id, uint64_t frametime_ns );

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0026-steamcompmgr-wlserver-route-input-to-video-window.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0026-steamcompmgr-wlserver-route-input-to-video-window.patch
@@ -1,0 +1,128 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] steamcompmgr,wlserver: route input focus to the subsurface-video window
+
+When a game-id X11 UI window wins paint focus but the video and input live on a
+separate native-Wayland toplevel, route input and keyboard focus to the toplevel that
+owns the captured video subsurface. Focus is re-rolled when the video is first
+captured. Inert unless a video subsurface is live.
+---
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -4330,6 +4330,28 @@ determine_and_apply_focus( global_focus_t *pFocus )
+ 		pFocus->keyboardFocusWindow = pFocus->overrideWindow ? pFocus->overrideWindow : pFocus->focusWindow;
+ 	}
+ 
++	// A client may present its streamed video on a native-Wayland (XDG) toplevel, while its
++	// Qt UI is a separate X11 window that carries a game-id and therefore wins paint focus.
++	// Route input + keyboard focus to the XDG window that owns the video subsurface so the
++	// streaming window receives keyboard/pointer/touch and SDL reports it as focused (which
++	// is what gates the client's controller forwarding). Inert unless a video subsurface is
++	// live, so games / glmark / the pre-stream menu are unaffected.
++	{
++		struct wlr_surface *videoParent = wlserver_get_video_subsurface_parent();
++		if ( videoParent )
++		{
++			for ( auto &xdgwin : g_steamcompmgr_xdg_wins )
++			{
++				if ( xdgwin->main_surface() == videoParent )
++				{
++					pFocus->inputFocusWindow = xdgwin.get();
++					pFocus->keyboardFocusWindow = xdgwin.get();
++					break;
++				}
++			}
++		}
++	}
++
+ 	if ( !gamescope::VirtualConnectorIsSingleOutput() )
+ 	{
+ 		uint64_t ulFocusedKeyboardOverlayVR = g_FocusedVROverlayKeyboard;
+--- a/src/steamcompmgr.hpp
++++ b/src/steamcompmgr.hpp
+@@ -135,6 +135,7 @@ extern uint64_t g_lastWinSeq;
+ 
+ void nudge_steamcompmgr( void );
+ void force_repaint( void );
++void MakeFocusDirty( void );
+ 
+ extern void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns );
+ struct wlr_surface *steamcompmgr_get_server_input_surface( size_t idx );
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -64,6 +64,7 @@
+ #include "wlserver.hpp"
+ #include "hdmi.h"
+ #include "main.hpp"
++#include <drm_fourcc.h>
+ #include "steamcompmgr.hpp"
+ #include "color_helpers.h"
+ #include "log.hpp"
+@@ -245,6 +246,33 @@ std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_all_subsurfaces()
+ 	return out;
+ }
+ 
++struct wlr_surface *wlserver_get_video_subsurface_parent()
++{
++	std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
++	struct wlr_surface *best = nullptr;
++	int bestw = -1;
++	for ( auto &entry : g_SubsurfaceCommits )
++	{
++		struct wlr_buffer *buf = entry.second.buf;
++		if ( !buf )
++			continue;
++		// The streamed video is the planar-YUV subsurface at any resolution; identify it by
++		// format (not size) so input routing works at e.g. 480p and never picks a UI overlay.
++		struct wlr_dmabuf_attributes vdma;
++		if ( !wlr_buffer_get_dmabuf( buf, &vdma ) )
++			continue;
++		if ( vdma.format != DRM_FORMAT_YUV420 && vdma.format != DRM_FORMAT_YVU420 &&
++		     vdma.format != DRM_FORMAT_NV12 && vdma.format != DRM_FORMAT_NV21 )
++			continue;
++		if ( buf->width > bestw )
++		{
++			bestw = buf->width;
++			best = entry.second.parent;
++		}
++	}
++	return best;
++}
++
+ void wlserver_release_subsurfaces( std::vector<GamescopeSubsurfaceLayer_t> &subs )
+ {
+ 	std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
+@@ -322,10 +350,22 @@ void xwayland_surface_commit(struct wlr_surface *wlr_surface) {
+ 			// buffer keyed by surface so the paint path can composite it as a layer.
+ 			std::lock_guard<std::mutex> lock( g_SubsurfaceMutex );
+ 			auto existing = g_SubsurfaceCommits.find( wlr_surface );
++			bool bNewSubsurface = ( existing == g_SubsurfaceCommits.end() );
+ 			if ( existing != g_SubsurfaceCommits.end() && existing->second.buf )
+ 				wlr_buffer_unlock( existing->second.buf );
+ 			g_SubsurfaceCommits[ wlr_surface ] = GamescopeSubsurfaceState_t{ subsurface->parent, subsurface->current.x, subsurface->current.y, buf };
+ 			force_repaint();
++			// A newly-appearing video subsurface must re-roll focus so input is routed to the
++			// streaming window; determine_and_apply_focus otherwise may not re-run after capture,
++			// leaving keyboard/pointer/controller input stuck on the Qt UI window.
++			if ( bNewSubsurface )
++			{
++				struct wlr_dmabuf_attributes vdma;
++				if ( wlr_buffer_get_dmabuf( buf, &vdma ) &&
++				     ( vdma.format == DRM_FORMAT_YUV420 || vdma.format == DRM_FORMAT_YVU420 ||
++				       vdma.format == DRM_FORMAT_NV12 || vdma.format == DRM_FORMAT_NV21 ) )
++					MakeFocusDirty();
++			}
+ 		}
+ 		else
+ 		{
+--- a/src/wlserver.hpp
++++ b/src/wlserver.hpp
+@@ -304,6 +304,9 @@ struct GamescopeSubsurfaceLayer_t
+ };
+ std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_subsurfaces_for( struct wlr_surface *parent );
+ std::vector<GamescopeSubsurfaceLayer_t> wlserver_lock_all_subsurfaces();
++// The toplevel (parent) surface currently carrying a video-sized captured subsurface,
++// or nullptr when none; used to route input focus to the streaming window.
++struct wlr_surface *wlserver_get_video_subsurface_parent();
+ void wlserver_release_subsurfaces( std::vector<GamescopeSubsurfaceLayer_t> &subs );
+ 
+ void wlserver_app_presented( uint32_t app_id, uint64_t frametime_ns );

--- a/projects/ROCKNIX/packages/apps/gamescope/patches/0027-steamcompmgr-rendervulkan-skip-offscreen-overlay-layers.patch
+++ b/projects/ROCKNIX/packages/apps/gamescope/patches/0027-steamcompmgr-rendervulkan-skip-offscreen-overlay-layers.patch
@@ -1,0 +1,52 @@
+From: Felix "Xilefian" Jones
+Subject: [PATCH] steamcompmgr,rendervulkan: skip non-RGA-importable overlay layers on the RGA path
+
+Two always-present overlay layers forced every frame onto the slow Vulkan composite:
+the fully-transparent warm-up placeholder and the hidden cursor parked off-screen.
+Drop the placeholder on the RGA path and skip off-screen non-base layers in the RGA
+composite-blend. Visually identical; an on-screen cursor still composites via Vulkan.
+---
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -2675,7 +2675,14 @@
+ 			if ( overlay == pFocus->inputFocusWindow && pFocus == GetCurrentFocus() )
+ 				update_touch_scaling( &frameInfo );
+ 		}
+-		else if ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() )
++		// ROCKNIX: this inserts a fullscreen, fully-transparent placeholder overlay purely to
++		// keep a Vulkan-swapchain overlay plane warm (avoids a toggle stutter). On the RGA
++		// rotated-panel scanout path there is no such plane, and this n_planes==0 (Vulkan-only)
++		// placeholder makes every streamed frame ineligible for the RGA composite-blend -
++		// forcing a slow libMali Vulkan composite that caps the stream at ~15fps. It is fully
++		// transparent, so dropping it here is visually identical and lets the RGA composite the
++		// real layers (video + UI) with the GPU idle.
++		else if ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() && !vulkan_rxnix_rga_enabled() )
+ 		{
+ 			auto tex = vulkan_get_hacky_blank_texture();
+ 			if ( tex != nullptr )
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -3920,6 +3920,13 @@ namespace rxnix_rga {
+         for ( int i = 0; i < fi->layerCount; i++ ) {
+             const FrameInfo_t::Layer_t *L = &fi->layers[i];
+             if ( !L->tex ) return false;
++            // A non-base layer parked entirely off-screen - notably the cursor, which
++            // gamescope hides by positioning at an infinite offset - contributes no pixels.
++            // Skip it (this also guards the dst-rect maths below against a non-finite offset)
++            // instead of rejecting the whole frame to the slow GPU composite.
++            if ( i > 0 && !( L->offset.x > -1e9f && L->offset.x < 1e9f &&
++                             L->offset.y > -1e9f && L->offset.y < 1e9f ) )
++                continue;
+             if ( L->colorspace != GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR || L->ctm ) return false;
+             if ( L->opacity < 1.0f ) return false;                    // per-pixel alpha only; fades -> GPU
+             if ( L->eAlphaBlendingMode != ALPHA_BLENDING_MODE_PREMULTIPLIED ) return false;
+@@ -3946,6 +3953,9 @@ namespace rxnix_rga {
+         { im_rect full = { 0, 0, (int)comp.w, (int)comp.h }; imfill( dst, full, 0x00000000, 1 ); }
+         for ( int i = 0; i < fi->layerCount; i++ ) {
+             const FrameInfo_t::Layer_t *L = &fi->layers[i];
++            if ( i > 0 && !( L->offset.x > -1e9f && L->offset.x < 1e9f &&
++                             L->offset.y > -1e9f && L->offset.y < 1e9f ) )
++                continue; // hidden/off-screen overlay (e.g. parked cursor): draws nothing
+             const struct wlr_dmabuf_attributes &dma = L->tex->dmabuf();
+             int sfmt, rd;
+             if ( !layer_rga_src_info( L, &sfmt, &rd ) ) return false;

--- a/projects/ROCKNIX/packages/graphics/librga/package.mk
+++ b/projects/ROCKNIX/packages/graphics/librga/package.mk
@@ -2,11 +2,13 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="librga"
-PKG_VERSION="ccfec13d6c48e3f0c7f24810b3dac162c40cdda8"
+PKG_VERSION="57a1067a246c71fa6c9a355d1668884fda155dd5"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="Apache-2.0"
 PKG_DEPENDS_TARGET="toolchain libdrm"
-PKG_SITE="https://github.com/varphone/rockchip-linux-rga"
+PKG_SITE="https://github.com/JeffyCN/mirrors"
 PKG_URL="${PKG_SITE}.git"
+PKG_GIT_CLONE_BRANCH="linux-rga-multi"
+PKG_GIT_CLONE_SINGLE="yes"
 PKG_LONGDESC="RGA is an independent 2D hardware acceleration userspace driver"
 PKG_TOOLCHAIN="meson"


### PR DESCRIPTION
I feel like I'm going to be the RGA guy from now on...

## Summary

This is a follow up to [#2983](https://github.com/ROCKNIX/distribution/pull/2983) using hardware RGA enabled by [#2977](https://github.com/ROCKNIX/distribution/pull/2977). `f73203aabe355cc25e00693b4eb250513b3665b1` onwards is the active change, dependent commits have been left in.

This PR offloads panel rotation, scaling, and multi-layer compositing onto the RGA2 2D engine (via librga). Falls back to the stock Vulkan/GPU path when the RGA (or a required buffer format/kernel feature) isn't available.

It also adds the Wayland pieces needed to display a nested Wayland video client on-panel (Steamlink was the test case I used to build this part, but the code is generic to any client using these protocols).

## Testing

About a month ago I was developing this with Steam x86 FEX, and this was good enough for software rendered CEF. The past week and a bit I've been bringing it up targeting the Steamlink app, which led to the Wayland video client additions.

## Additional Context

It's a meaty amount of changes. Steamlink works great with this, I might return to getting Steam x86 running again. I'm happy to answer questions.

---

### AI Usage

The code comments are generated by Copilot, there was a heck of a lot of scar tissue I had to crawl through when cleaning these up for PR and most of the comments I had originally left for myself, now they are a lot more verbose and more explainy as AI tends to do with comments. As a result, there's more comment lines then there are active lines of code (I did try to keep this as minimal as possible).
