### PR TITLE
ayaneo-haptics: add Pocket S vibration driver

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayaneo-pocket-common.dtsi
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayaneo-pocket-common.dtsi
@@ -5,6 +5,7 @@
 
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/regulator/qcom,rpmh-regulator.h>
+#include <dt-bindings/input/qcom,hv-haptics.h>
 #include "qcs8550.dtsi"
 #include "pm8550.dtsi"
 #include "pm8550b.dtsi"
@@ -954,9 +955,38 @@
 	};
 };
 
+&pmk8550 {
+	pmk8550_sdam_9d00: nvram@9d00 {
+		compatible = "qcom,spmi-sdam";
+		reg = <0x9d00>;
+	};
+};
+
 &pm8550b_eusb2_repeater {
 	vdd18-supply = <&vreg_l15b_1p8>;
 	vdd3-supply = <&vreg_l5b_3p1>;
+};
+
+&pm8550b {
+	pm8550b_hv_haptics: qcom,hv-haptics@f000 {
+		compatible = "qcom,hv-haptics";
+		reg = <0xf000>, <0xf100>, <0xf200>;
+		interrupts = <0x07 0xf0 0x1 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "fifo-empty";
+		qcom,vmax-mv = <5000>;
+		qcom,brake-mode = <BRAKE_CLOSE_LOOP>;
+		qcom,brake-pattern = /bits/ 8 <0xff 0x3f 0x1f>;
+		qcom,lra-period-us = <5880>;
+		qcom,drv-sig-shape = <WF_SINE>;
+		qcom,brake-sig-shape = <WF_SINE>;
+		nvmem-names = "hap_cfg_sdam";
+		nvmem = <&pmk8550_sdam_9d00>;
+		status = "disabled";
+
+		hap_swr_slave_reg: qcom,hap-swr-slave-reg {
+			regulator-name = "hap-swr-slave-reg";
+		};
+	};
 };
 
 &pon_pwrkey {

--- a/projects/ROCKNIX/devices/SM8550/options
+++ b/projects/ROCKNIX/devices/SM8550/options
@@ -63,7 +63,7 @@
     FIRMWARE=""
 
   # Additional packages to install
-    ADDITIONAL_PACKAGES="gamepadcalibration rocknix-abl inputplumber"
+    ADDITIONAL_PACKAGES="gamepadcalibration rocknix-abl inputplumber ayaneo-haptics"
 
   # Debug tty path
     DEBUG_TTY="/dev/ttyMSM0"

--- a/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/package.mk
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026
+
+PKG_NAME="ayaneo-haptics"
+PKG_VERSION="1.0"
+PKG_REV="0"
+PKG_ARCH="aarch64"
+PKG_LICENSE="GPLv2"
+PKG_SITE=""
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_SECTION="driver"
+PKG_SHORTDESC="AYANEO Controller haptics bridge"
+PKG_LONGDESC="Bridges FF_RUMBLE events from AYANEO Controller (USB HID) to qcom-hv-haptics driver"
+PKG_TOOLCHAIN="manual"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+  cp ${PKG_DIR}/source/ayaneo-haptics.c ${PKG_BUILD}/
+  cp ${PKG_DIR}/source/Makefile ${PKG_BUILD}/
+}
+
+make_target() {
+  kernel_make V=1 KDIR=$(kernel_path) module
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+  cp ${PKG_BUILD}/ayaneo-haptics.ko ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}/
+  mkdir -p ${INSTALL}/usr/lib/systemd/system
+  cp ${PKG_DIR}/source/system.d/ayaneo-haptics.service ${INSTALL}/usr/lib/systemd/system/
+}
+
+post_install() {
+  enable_service ayaneo-haptics.service
+}

--- a/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/source/Makefile
+++ b/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/source/Makefile
@@ -1,0 +1,4 @@
+obj-m += ayaneo-haptics.o
+
+module:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules

--- a/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/source/ayaneo-haptics.c
+++ b/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/source/ayaneo-haptics.c
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ayaneo-haptics.c — AYANEO Controller FF_RUMBLE → HID output report
+ *
+ * Deferred-workqueue design (no sleeps in FF callbacks):
+ *   FF callback → set cur_left/cur_right → schedule_work()
+ *   Workqueue  → hid_hw_output_report()
+ *
+ * Effect storage is the kernel FF core's dev->ff->effects[] —
+ * we don't maintain a separate slot array to avoid misalignment.
+ */
+
+#include <linux/input.h>
+#include <linux/module.h>
+#include <linux/slab.h>
+#include <linux/hid.h>
+#include <linux/workqueue.h>
+
+#define CONTROLLER_NAME "AYANEO Controller"
+#define MAX_EFFECTS 4
+#define HID_REPORT_SIZE 8
+#define LEFT_MOTOR_BYTE  4
+#define RIGHT_MOTOR_BYTE 5
+
+struct ayaneo_state {
+	struct input_dev *controller;
+	struct hid_device *hid_dev;
+	bool bridge_active;
+	struct work_struct rumble_work;
+	u8 cur_left;
+	u8 cur_right;
+};
+
+static struct ayaneo_state state;
+
+static int _find_controller(struct device *dev, void *data)
+{
+	struct input_dev *idev = to_input_dev(dev);
+	if (idev->name && strstr(idev->name, CONTROLLER_NAME)) {
+		state.controller = idev;
+		return 1;
+	}
+	return 0;
+}
+
+static void rumble_work_fn(struct work_struct *work)
+{
+	u8 report[HID_REPORT_SIZE];
+	int ret;
+
+	if (!state.hid_dev)
+		return;
+
+	memset(report, 0, HID_REPORT_SIZE);
+	report[LEFT_MOTOR_BYTE]  = state.cur_left;
+	report[RIGHT_MOTOR_BYTE] = state.cur_right;
+
+	ret = hid_hw_output_report(state.hid_dev, report, HID_REPORT_SIZE);
+	if (ret < 0) {
+		pr_err("ayaneo-haptics: hid_hw_output_report failed: %d\n", ret);
+		if (ret == -ENODEV)
+			state.hid_dev = NULL;
+	} else {
+		pr_info("ayaneo-haptics: HID report sent: L=%02x R=%02x\n",
+			state.cur_left, state.cur_right);
+	}
+}
+
+static void schedule_rumble(u8 left, u8 right)
+{
+	state.cur_left  = left;
+	state.cur_right = right;
+	schedule_work(&state.rumble_work);
+}
+
+/* ── FF callbacks ── */
+
+static int ayaneo_ff_upload(struct input_dev *dev,
+		struct ff_effect *effect, struct ff_effect *old)
+{
+	/* Let the kernel FF core store the effect in dev->ff->effects[].
+	 * We read it back via dev->ff->effects[effect_id] in playback. */
+	pr_info("ayaneo-haptics: upload effect type=0x%x (old=%s)\n",
+		effect->type, old ? "yes" : "no");
+	return 0;
+}
+
+static int ayaneo_ff_playback(struct input_dev *dev, int effect_id, int value)
+{
+	struct ff_effect *effect;
+	u16 strong = 0, weak = 0;
+
+	if (effect_id < 0 || effect_id >= dev->ff->max_effects)
+		return -EINVAL;
+
+	/* Read directly from FF core's effect array — always in sync */
+	effect = &dev->ff->effects[effect_id];
+
+	pr_info("ayaneo-haptics: playback id=%d value=%d type=0x%x\n",
+		effect_id, value, effect->type);
+
+	if (!value) {
+		schedule_rumble(0, 0);
+		return 0;
+	}
+
+	switch (effect->type) {
+	case FF_RUMBLE:
+		strong = effect->u.rumble.strong_magnitude;
+		weak   = effect->u.rumble.weak_magnitude;
+		break;
+	case FF_CONSTANT:
+		strong = effect->u.constant.level;
+		weak = strong;
+		break;
+	default:
+		return 0;
+	}
+
+	schedule_rumble(strong >> 8, weak >> 8);
+	return 0;
+}
+
+static int ayaneo_ff_erase(struct input_dev *dev, int effect_id)
+{
+	pr_info("ayaneo-haptics: erase id=%d\n", effect_id);
+	schedule_rumble(0, 0);
+	return 0;
+}
+
+/* ── bridge setup ── */
+
+static void ayaneo_bridge_setup(void)
+{
+	int ret;
+
+	if (!state.controller || state.bridge_active)
+		return;
+
+	state.hid_dev = input_get_drvdata(state.controller);
+	if (!state.hid_dev) {
+		pr_err("ayaneo-haptics: cannot get hid_device from '%s'\n",
+			state.controller->name ?: "?");
+		return;
+	}
+
+	pr_info("ayaneo-haptics: found '%s' (%s), hid=%s\n",
+		state.controller->name ?: "?",
+		dev_name(&state.controller->dev),
+		dev_name(&state.hid_dev->dev));
+
+	INIT_WORK(&state.rumble_work, rumble_work_fn);
+
+	input_set_capability(state.controller, EV_FF, FF_RUMBLE);
+	input_set_capability(state.controller, EV_FF, FF_CONSTANT);
+	input_set_capability(state.controller, EV_FF, FF_PERIODIC);
+
+	ret = input_ff_create(state.controller, MAX_EFFECTS);
+	if (ret) {
+		pr_err("ayaneo-haptics: input_ff_create failed (%d)\n", ret);
+		return;
+	}
+
+	state.controller->ff->upload   = ayaneo_ff_upload;
+	state.controller->ff->playback = ayaneo_ff_playback;
+	state.controller->ff->erase    = ayaneo_ff_erase;
+
+	state.bridge_active = true;
+	pr_info("ayaneo-haptics: FF bridge active (HID output report)\n");
+}
+
+/* ── Stub callbacks for graceful unload ── */
+
+static int stub_upload(struct input_dev *dev,
+		struct ff_effect *effect, struct ff_effect *old)
+{ return 0; }
+
+static int stub_playback(struct input_dev *dev, int effect_id, int value)
+{ return 0; }
+
+static int stub_erase(struct input_dev *dev, int effect_id)
+{ return 0; }
+
+/* ── module lifecycle ── */
+
+static int __init ayaneo_haptics_init(void)
+{
+	state = (struct ayaneo_state){0};
+
+	class_for_each_device(&input_class, NULL, NULL, _find_controller);
+	if (!state.controller) {
+		pr_err("ayaneo-haptics: no '%s' device found\n", CONTROLLER_NAME);
+		return -ENODEV;
+	}
+
+	ayaneo_bridge_setup();
+	if (!state.bridge_active)
+		return -EIO;
+
+	return 0;
+}
+
+static void __exit ayaneo_haptics_exit(void)
+{
+	if (state.bridge_active && state.controller) {
+		/* Prevent pending work from touching freed resources */
+		state.hid_dev = NULL;
+		cancel_work_sync(&state.rumble_work);
+
+		/*
+		 * Replace FF callbacks with stubs instead of calling
+		 * input_ff_destroy(). Other processes (evtest, Steam, etc.)
+		 * may still hold open evdev fds referencing dev->ff.
+		 * input_ff_destroy sets dev->ff = NULL, and closing those
+		 * fds later would dereference NULL in input_ff_flush().
+		 */
+		state.controller->ff->upload   = stub_upload;
+		state.controller->ff->playback = stub_playback;
+		state.controller->ff->erase    = stub_erase;
+
+		/* Remove FF capability bits so new opens don't see FF */
+		clear_bit(EV_FF, state.controller->evbit);
+		clear_bit(FF_RUMBLE, state.controller->ffbit);
+		clear_bit(FF_CONSTANT, state.controller->ffbit);
+		clear_bit(FF_PERIODIC, state.controller->ffbit);
+
+		state.bridge_active = false;
+		pr_info("ayaneo-haptics: FF bridge removed\n");
+	}
+}
+
+module_init(ayaneo_haptics_init);
+module_exit(ayaneo_haptics_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("ddordie");
+MODULE_DESCRIPTION("AYANEO Controller FF -> HID output report bridge");

--- a/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/source/system.d/ayaneo-haptics.service
+++ b/projects/ROCKNIX/packages/linux-drivers/ayaneo-haptics/source/system.d/ayaneo-haptics.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=AYANEO Controller Haptics Bridge
+After=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/modprobe ayaneo-haptics
+ExecStop=/sbin/modprobe -r ayaneo-haptics
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- New out-of-tree kernel module using HID output reports to control AYANEO Controller haptics motors directly
- DT: add PM8550B haptics node + PMK8550 SDAM nvram (status=disabled, driver handles it independently)
- Enable ayaneo-haptics package in SM8550 options

## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

## Testing

- Pocket S — vibration works via HID output reports

### Not tested on other SM8550 devices

- DT node is `disabled`, should not affect other Pocket
  variants unless explicitly enabled in device DTS.
- Module probe only binds to AYANEO Controller USB HID,
  should be harmless on non-Pocket devices, but untested.
- Feedback appreciated if anyone can test on Pocket DMG / DS
  / EVO or Odin 2 series.

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO
