### PR TITLE
retroarch-joypads: fix malformed rg arc config

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/retroarch/retroarch-joypads/gamepads/rg_arc_joypad.cfg
+++ b/projects/ROCKNIX/packages/emulators/libretro/retroarch/retroarch-joypads/gamepads/rg_arc_joypad.cfg
@@ -19,7 +19,7 @@ input_l2_btn = "8"
 input_r2_btn = "9"
 
 input_up_btn = "12"
-input_down_btn = 13"
+input_down_btn = "13"
 input_left_btn = "14"
 input_right_btn = "15"
 


### PR DESCRIPTION
The RG ARC RetroArch joypad autoconfig had a typo in the D-pad down binding — the value was missing its opening quote.

**File:** `projects/ROCKNIX/packages/emulators/libretro/retroarch/retroarch-joypads/gamepads/rg_arc_joypad.cfg`

Before:
```
input_down_btn = 13"
```

After:
```
input_down_btn = "13"
```

Every other button value in the file is quoted; only this one was malformed.