### PR TITLE
SM8750: persist RTC offset in SDAM

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0602-ROCKNIX-odin3-rtc-persist-offset-sdam.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0602-ROCKNIX-odin3-rtc-persist-offset-sdam.patch
@@ -1,0 +1,33 @@
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn-common: SDAM RTC offset
+
+RTC regs are TZ-locked; rtc-pm8xxx stores wall-clock as an offset.
+Android maintains that offset in userspace (time_daemon, persisted
+to /persist), which ROCKNIX does not inherit, so the clock resets
+to epoch every boot.
+
+Back it with an nvmem cell in the always-on PMK8550 SDAM at 0x72,
+a free 4-byte slot below the ADSP-owned alarm-log at 0x76-0x7b,
+verified on Odin 3 to survive cold power-off.
+---
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -1268,3 +1268,18 @@
+ 
+ 	status = "okay";
+ };
++
++/* RTC regs are TZ-locked; persist the wall-clock offset in an SDAM
++ * nvmem cell (Android keeps it in userspace, not shared with us).
++ * 0x72 sits just below the ADSP-owned alarm-log at 0x76-0x7b.
++ */
++&pmk8550_rtc {
++	nvmem-cells = <&rtc_offset>;
++	nvmem-cell-names = "offset";
++};
++
++&pmk8550_sdam_2 {
++	rtc_offset: rtc-offset@72 {
++		reg = <0x72 0x4>;
++	};
++};


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

pmk8550 RTC is a monotonic counter; rtc-pm8xxx stores wall-clock as an offset to it. Android maintains that offset in userspace with time_daemon and a record under /persist.

Mainline driver for pmk8550 supports either UEFI backing (with uefivars) or SDAM nonvolatile memory. 0x72(4 bytes) is a free slot in the scratch window (0x40-0x7f), sitting right below the 6 byte span that the mainline DTSI points out belongs to alarm-log (ADSP). Scrubbed all Android DT's for occupancy of other offsets&ranges and other than the aforementioned comment, only PON turned up.

This is the direction mainline is taking, and Qualcomm reps are visibly involved; see thread in https://lkml.org/lkml/2025/2/19/956

## Testing

Verified on Odin 3 to survive cold power-off

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
