### PR TITLE
SM8750: q6apm-lpass start RX port at prepare for Odin3 speakers

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0612-ROCKNIX-odin3-q6apm-start-mi2s-port-at-prepare.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0612-ROCKNIX-odin3-q6apm-start-mi2s-port-at-prepare.patch
@@ -1,0 +1,33 @@
+Subject: [PATCH] ASoC: qdsp6: q6apm-lpass: start RX port at prepare
+
+Port start moved from .prepare to .trigger, so the MI2S bit-clock now
+starts after the codec DAPM widgets power up. The Odin3 aw88166 amps
+check their PLL against BCLK at DAPM PRE_PMU, before the trigger, and
+fail PLL lock with no clock, leaving the speakers silent.
+
+Start the playback port at prepare again so BCLK is up before PRE_PMU.
+The trigger's !is_port_started guard no-ops; capture is unchanged.
+---
+--- a/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
++++ b/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
+@@ -224,6 +224,20 @@
+ 		dev_err(dai->dev, "Failed to prepare Graph %d\n", rc);
+ 		goto err;
+ 	}
++
++	/*
++	 * aw88166 checks its PLL against BCLK at DAPM PRE_PMU, before the
++	 * PCM trigger; start the port here so BCLK is up in time. The
++	 * trigger's !is_port_started guard then no-ops. Playback only.
++	 */
++	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {
++		rc = q6apm_graph_start(dai_data->graph[dai->id]);
++		if (rc < 0) {
++			dev_err(dai->dev, "Failed to start APM port %d\n", dai->id);
++			goto err;
++		}
++		dai_data->is_port_started[dai->id] = true;
++	}
+ 	return 0;
+ err:
+ 	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {


### PR DESCRIPTION
## Summary

Fixing a race with aw88166.

Port start moved from .prepare to .trigger, so the MI2S bit-clock now starts after the codec DAPM widgets power up. The Odin3 aw88166 amps check their PLL against BCLK at DAPM PRE_PMU, before the trigger, and fail PLL lock with no clock, leaving the speakers silent.

Start the playback port at prepare again so BCLK is up before PRE_PMU. The trigger's !is_port_started guard no-ops; capture is unchanged.

## Testing

Audio plays, no dmesg errors now.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
