### PR TITLE
SM8550/SM8250: fix fourth analog stick LED zone control

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 2 Portal/bin/analog_sticks_ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 2 Portal/bin/analog_sticks_ledcontrol
@@ -10,7 +10,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_brightness() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/brightness
     n=$(( n + 1 ))
   done
@@ -18,7 +18,7 @@ function led_brightness() {
 
 function led_rgb() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} ${3} ${4} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/multi_intensity
     n=$(( n + 1 ))
   done

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 2 Portal/bin/battery_led_status
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 2 Portal/bin/battery_led_status
@@ -12,7 +12,7 @@ LED_PATH="/sys/devices/platform/"
 
 function bat_led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -23,7 +23,7 @@ function bat_led_off() {
 
 function bat_led_red() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -34,7 +34,7 @@ function bat_led_red() {
 
 function bat_led_green() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 255 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -45,7 +45,7 @@ function bat_led_green() {
 
 function bat_led_orange() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 20 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -56,7 +56,7 @@ function bat_led_orange() {
 
 function bat_led_yellow() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 125 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 2 Portal/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Odin 2 Portal/bin/ledcontrol
@@ -8,7 +8,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/analog_sticks_ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/analog_sticks_ledcontrol
@@ -10,7 +10,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_brightness() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/brightness
     n=$(( n + 1 ))
   done
@@ -18,7 +18,7 @@ function led_brightness() {
 
 function led_rgb() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} ${3} ${4} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/multi_intensity
     n=$(( n + 1 ))
   done

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/battery_led_status
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/battery_led_status
@@ -12,7 +12,7 @@ LED_PATH="/sys/devices/platform/"
 
 function bat_led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -23,7 +23,7 @@ function bat_led_off() {
 
 function bat_led_red() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -34,7 +34,7 @@ function bat_led_red() {
 
 function bat_led_green() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 255 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -45,7 +45,7 @@ function bat_led_green() {
 
 function bat_led_orange() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 20 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -56,7 +56,7 @@ function bat_led_orange() {
 
 function bat_led_yellow() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 125 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/ledcontrol
@@ -8,7 +8,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Retroid Pocket 6/bin/analog_sticks_ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Retroid Pocket 6/bin/analog_sticks_ledcontrol
@@ -10,7 +10,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_brightness() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/brightness
     n=$(( n + 1 ))
   done
@@ -18,7 +18,7 @@ function led_brightness() {
 
 function led_rgb() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} ${3} ${4} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/multi_intensity
     n=$(( n + 1 ))
   done

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Retroid Pocket 6/bin/battery_led_status
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Retroid Pocket 6/bin/battery_led_status
@@ -12,7 +12,7 @@ LED_PATH="/sys/devices/platform/"
 
 function bat_led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -23,7 +23,7 @@ function bat_led_off() {
 
 function bat_led_red() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -34,7 +34,7 @@ function bat_led_red() {
 
 function bat_led_green() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 255 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -45,7 +45,7 @@ function bat_led_green() {
 
 function bat_led_orange() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 20 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -56,7 +56,7 @@ function bat_led_orange() {
 
 function bat_led_yellow() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 125 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Retroid Pocket 6/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Retroid Pocket 6/bin/ledcontrol
@@ -8,7 +8,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/analog_sticks_ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/analog_sticks_ledcontrol
@@ -10,7 +10,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_brightness() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/brightness
     n=$(( n + 1 ))
   done
@@ -18,7 +18,7 @@ function led_brightness() {
 
 function led_rgb() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo ${2} ${3} ${4} >  ${LED_PATH}/multi-led${1}${n}/leds/rgb:${1}${n}/multi_intensity
     n=$(( n + 1 ))
   done

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/battery_led_status
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/battery_led_status
@@ -13,7 +13,7 @@ LED_PATH="/sys/devices/platform/"
 
 function bat_led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -24,7 +24,7 @@ function bat_led_off() {
 
 function bat_led_red() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -35,7 +35,7 @@ function bat_led_red() {
 
 function bat_led_green() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 255 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -46,7 +46,7 @@ function bat_led_green() {
 
 function bat_led_orange() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 20 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
@@ -57,7 +57,7 @@ function bat_led_orange() {
 
 function bat_led_yellow() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 125 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8250/bin/ledcontrol
@@ -9,7 +9,7 @@ LED_PATH="/sys/devices/platform/"
 
 function led_off() {
   n=1
-  while [ "$n" -lt 4 ]; do
+  while [ "$n" -lt 5 ]; do
     echo 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
     echo 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity


### PR DESCRIPTION
## Summary

Four zones are defined but [4] is never iterated on. This PR turns on the fourth RGB zone.

## Testing

* **How was this tested?** 

Tested on RP6, dim spots now illuminated.

---

### AI Usage

**Did you use AI tools to help write this code?** YES, used to investigate and automate testing on live device.
