### PR TITLE
Add custom RetroAchievements host support to standalone Dolphin

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/cheevos_dolphin.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/cheevos_dolphin.sh
@@ -15,6 +15,7 @@ enabled=$(get_setting "global.retroachievements")
 hardcore=$(get_setting "global.retroachievements.hardcore")
 encore=$(get_setting "global.retroachievements.encore")
 unofficial=$(get_setting "global.retroachievements.testunofficial")
+hosturl=$(get_setting "global.retroachievements.customhost")
 
 # Check if RetroAchievements are enabled in Emulation Station
 if [ "${enabled}" = 1 ]; then
@@ -63,4 +64,5 @@ SpectatorEnabled = False
 UnofficialEnabled = ${unofficial}
 Username = ${username}
 ApiToken = ${token}
+HostUrl = ${hosturl}
 EOF


### PR DESCRIPTION
## Summary
- Standalone Dolphin's `cheevos_dolphin.sh` fully regenerates `RetroAchievements.ini` on every launch, with no way to point achievements traffic at a custom host.
- RetroArch's custom-host support on ROCKNIX today isn't a native setting: [RAOfflineProxy](https://raofflineproxy.com/) patches `retroarch.cfg` directly instead. That approach doesn't work for Dolphin, since its script does a full config overwrite rather than a targeted edit (like PPSSPP's `sed`-based patch does). So this adds a proper `system.cfg`-level setting instead, a new `global.retroachievements.customhost` key, following the same pattern as the existing `global.retroachievements.*` settings already read by this script, written into Dolphin's `RetroAchievements.ini` as `HostUrl`.
- When unset, `get_setting` returns an empty string, so `HostUrl` stays empty and behavior is unchanged from today (Dolphin falls back to the official RetroAchievements server).

## Motivation
Building ROCKNIX support for [RAOfflineProxy](https://raofflineproxy.com/). RetroArch and standalone PPSSPP already support the custom-host pattern; Dolphin is the remaining gap, since its cheevos script does a full config overwrite instead of a targeted `sed` edit like PPSSPP's does.
