### PR TITLE
SM8750: fix suspend wedge from ucsi USB role on charger unplug

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0509-usb-typec-ucsi-clear-USB-role.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0509-usb-typec-ucsi-clear-USB-role.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anze <aanzdev@gmail.com>
+Date: Sun, 19 Jul 2026 00:30:00 +0200
+Subject: [PATCH] usb: typec: ucsi: clear USB role when partner lacks USB
+ data
+
+Commit 0c8ee850572 ("usb: typec: ucsi: Add UCSI_USB4_IMPLIES_USB quirk
+for X1E80100") gated the "partner advertises no USB data ->
+USB_ROLE_NONE" decision behind the UCSI_USB4_IMPLIES_USB quirk. On
+ports without that quirk (e.g. SM8750 / AYN Odin 3, pmic_glink UCSI)
+the USB data role is then never cleared for a charger-only partner, so
+it stays attached across system suspend. That keeps the USB power
+island up, and the deep-suspend firmware power-collapse hard-hangs the
+SoC when the cable is unplugged while suspended: dead screen, the SoC
+runs hot, only a forced reset recovers (7.0.x is fine, 7.1.x hangs).
+
+Restore the pre-0c8ee850572 behaviour: clear the USB role whenever the
+partner advertises no USB data.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+--- a/drivers/usb/typec/ucsi/ucsi.c
++++ b/drivers/usb/typec/ucsi/ucsi.c
+@@ -1196,10 +1196,8 @@
+ 			typec_partner_set_usb_mode(con->partner, USB_MODE_USB4);
+ 	}
+ 
+-	if ((!UCSI_CONSTAT(con, PARTNER_FLAG_USB)) &&
+-	    ((con->ucsi->quirks & UCSI_USB4_IMPLIES_USB) &&
+-	     (!(UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN3) ||
+-		UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN4)))))
++	/* Only notify USB controller if partner supports USB data */
++	if (!(UCSI_CONSTAT(con, PARTNER_FLAG_USB)))
+ 		u_role = USB_ROLE_NONE;
+ 
+ 	ret = usb_role_switch_set_role(con->usb_role_sw, u_role);


### PR DESCRIPTION
## Summary
* **What is the goal of this PR?** Fix a hard SoC hang on SM8750
  (AYN Odin 3) when the USB cable is unplugged while the device is
  suspended — both for chargers (patch 0509) and for data-capable
  partners such as docks (patch 0510).

## Testing
* **How was this tested?** Built the SM8750 kernel with these patches
  and flashed it to an AYN Odin 3. Reproduced the original hang on
  stock 7.1.x, then ran the patched kernel through several
  suspend/unplug cycles with a charger and with a dock.
* **Test results:** Before — plug charger or dock, suspend, then
  unplug while asleep hard-hangs the SoC (dead screen, runs hot,
  forced reset needed) on every 7.1.x; 7.0.x is fine. After — suspends
  and resumes normally with the cable or dock unplugged during
  suspend, over several cycles each.

## Additional Context
* Root cause: commit 0c8ee850572 ("usb: typec: ucsi: Add
  UCSI_USB4_IMPLIES_USB quirk for X1E80100") gated the "partner has no
  USB data -> USB_ROLE_NONE" decision behind the UCSI_USB4_IMPLIES_USB
  quirk. SM8750's pmic_glink UCSI never sets that quirk, so the USB
  role is no longer cleared for a charger-only partner and stays
  attached across suspend, keeping the USB power island up; the
  firmware power-collapse then hangs on the cable event.
* Patch 0509 restores the pre-0c8ee850572 behaviour (charger case).
  Patch 0510 extends the same fix to data-capable partners: the role
  is forced to USB_ROLE_NONE at suspend entry and restored at resume,
  so the power island can collapse with a dock attached too.

---

### AI Usage
**Did you use AI tools to help write this code?** YES
