### PR TITLE
SM8550: drop gfx vote from gpucc

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0120-20250728_konradybcio_gpu_cc_power_requirements_reality_check.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0120-20250728_konradybcio_gpu_cc_power_requirements_reality_check.patch
@@ -14,21 +14,20 @@ function. Ensure that's conveyed to the OS.
 Fixes: 9f7579423d2d ("arm64: dts: qcom: sm8550: Add graphics clock controller")
 Signed-off-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
 ---
- arch/arm64/boot/dts/qcom/sm8550.dtsi | 6 ++++++
+ arch/arm64/boot/dts/qcom/sm8550.dtsi | 5 +++++
  1 file changed, 6 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8550.dtsi b/arch/arm64/boot/dts/qcom/sm8550.dtsi
 index 45713d46f3c52487d2638b7ab194c111f58679ce..28eade49526dc9bb0a7b211f96dd350873489029 100644
 --- a/arch/arm64/boot/dts/qcom/sm8550.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8550.dtsi
-@@ -2572,6 +2572,12 @@ gpucc: clock-controller@3d90000 {
+@@ -2572,6 +2572,11 @@ gpucc: clock-controller@3d90000 {
  			clocks = <&bi_tcxo_div2>,
  				 <&gcc GCC_GPU_GPLL0_CLK_SRC>,
  				 <&gcc GCC_GPU_GPLL0_DIV_CLK_SRC>;
 +
 +			power-domains = <&rpmhpd RPMHPD_CX>,
 +					<&rpmhpd RPMHPD_MX>,
-+					<&rpmhpd RPMHPD_GFX>,
 +					<&rpmhpd RPMHPD_MXC>;
 +
  			#clock-cells = <1>;


### PR DESCRIPTION


## Summary

* **What is the goal of this PR?** 

Per Akhil on original thread GMU manages.

"GMU is allowed to collapse some of the rails in some cases (GX/MXC/GXMXC etc). So there should not be any other vote for these resources on behalf of GPU/GMU from the KMD side. You may have to vote some resources for GPUCC block itself (I know it is in AO domain, but still). I don't know the specifics. Can you reach out to QC clk team (Taniya/Jagadeesh etc) for necessary details? We should be careful here. Just boot up testing is not sufficient when it comes to clk/power."

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
