### PR TITLE
yaps2-sa: bump to dbb7eade6

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2025-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="yaps2-sa"
-PKG_VERSION="891f3b5191e54d2283e71aad7f134451e96d8517"
+PKG_VERSION="dbb7eade69c1befc6410fe636811010d340ef886"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/yaps2/yaps2"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Bumps `yaps2-sa` from `891f3b519` to upstream main `dbb7eade6`.

Maybe my final release, but should be a firm competitor with aethersx2 now.