### PR TITLE
S922X: add yaps2-sa

### DIFF
--- a/documentation/PER_DEVICE_DOCUMENTATION/S922X/SUPPORTED_EMULATORS_AND_CORES.md
+++ b/documentation/PER_DEVICE_DOCUMENTATION/S922X/SUPPORTED_EMULATORS_AND_CORES.md
@@ -118,7 +118,7 @@
 |SNK|Neo Geo Pocket (ngp)|1998|`ngp`|.ngp .ngc .zip .7z|**retroarch:** beetle_ngp (default)<br>**retroarch:** race<br>|
 |SNK|Neo Geo Pocket Color (ngpc)|1999|`ngpc`|.ngp .ngc .zip .7z|**retroarch:** beetle_ngp (default)<br>**retroarch:** race<br>|
 |Sony|PlayStation (psx)|1994|`psx`|.bin .cue .img .mdf .pbp .toc .cbn .m3u .ccd .chd .iso|**retroarch:** pcsx_rearmed (default)<br>**retroarch:** beetle_psx<br>**retroarch:** duckstation<br>**duckstation:** duckstation-sa<br>**retroarch:** swanstation<br>|
-|Sony|PlayStation 2 (ps2)|2000|`ps2`|.iso .mdf .nrg .bin .img .dump .gz .cso .chd|**aethersx2:** aethersx2-sa (default)<br>|
+|Sony|PlayStation 2 (ps2)|2000|`ps2`|.iso .mdf .nrg .bin .img .dump .gz .cso .chd|**aethersx2:** aethersx2-sa (default)<br>**yaps2:** yaps2-sa<br>|
 |Sony|PlayStation Portable (psp)|2004|`psp`|.iso .cso .pbp .chd|**ppsspp:** ppsspp-sa (default)<br>**retroarch:** ppsspp<br>|
 |Sony|PlayStation Vita (psvita)|2011|`psvita`|.pkg .psvita .zip|**vita3k:** vita3k-sa (default)<br>|
 |Sony|PSP Minis (pspminis)|2004|`pspminis`|.iso .cso .pbp .chd|**ppsspp:** ppsspp-sa (default)<br>**retroarch:** ppsspp<br>|

--- a/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/package.mk
@@ -11,39 +11,40 @@ PKG_DEPENDS_TARGET="toolchain llvm:host SDL3 libpng zlib libjpeg-turbo zstd lz4 
 PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="speed"
 
-PCSX2_CMAKE_BASE=(
-  -DCMAKE_BUILD_TYPE=Release
-  # Full-tree IPO stays off for Qt (not worth it)...
-  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
-  # ...but stays on for just the recompiler/VU/EE/IOP core:
-  -DLTO_PCSX2_CORE=ON
-  -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
-  -DUSE_VULKAN=ON
-  -DUSE_OPENGL=ON
-  -DUSE_BACKTRACE=OFF
-  -DENABLE_QT_UI=ON
-  -DENABLE_QT_DEBUGGER=OFF
-  -DWAYLAND_API=ON
-  -DX11_API=ON
-  -DCMAKE_LINKER_TYPE=LLD
-)
-
 PATCHES_URL="https://github.com/PCSX2/pcsx2_patches/archive/refs/tags/latest.zip"
 
-make_target() {
-  case ${TARGET_ARCH} in
-    aarch64)
-      for _v in CFLAGS CXXFLAGS LDFLAGS; do
-        export ${_v}="$(echo ${!_v} | sed 's/-march=[^ ]*//g; s/-mabi=lp64//g; s/-mtune=[^ ]*//g')"
-      done
-    ;;
-    x86_64)
-      for _v in CFLAGS CXXFLAGS LDFLAGS; do
-        export ${_v}="$(echo ${!_v} | sed 's/-mabi=lp64//g; s/-mtune=[^ ]*//g')"
-      done
-    ;;
-  esac
+get_graphicdrivers() {
+  if listcontains "${GRAPHIC_DRIVERS}" "(panfrost)"; then
+    GRAPHICS_DRIVER="panfrost"
+  elif listcontains "${GRAPHIC_DRIVERS}" "(freedreno)"; then
+    GRAPHICS_DRIVER="freedreno"
+  fi
+}
 
+pre_configure_target() {
+  PCSX2_CMAKE_BASE=(
+    -DCMAKE_BUILD_TYPE=Release
+    # Full-tree IPO stays off for Qt (not worth it)...
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+    # ...but stays on for just the recompiler/VU/EE/IOP core:
+    -DLTO_PCSX2_CORE=ON
+    -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+    -DUSE_VULKAN=ON
+    -DUSE_OPENGL=ON
+    -DUSE_BACKTRACE=OFF
+    -DENABLE_QT_UI=ON
+    -DENABLE_QT_DEBUGGER=OFF
+    -DWAYLAND_API=ON
+    -DX11_API=ON
+    -DCMAKE_LINKER_TYPE=LLD
+  )
+
+  for _v in CFLAGS CXXFLAGS LDFLAGS; do
+    export ${_v}="$(echo ${!_v} | sed 's/-mabi=lp64//g; s/-mtune=[^ ]*//g')"
+  done
+}
+
+make_target() {
   mkdir -p "${PKG_BUILD}/.${TARGET_NAME}"
   cd "${PKG_BUILD}/.${TARGET_NAME}"
 

--- a/projects/ROCKNIX/packages/virtual/emulators/package.mk
+++ b/projects/ROCKNIX/packages/virtual/emulators/package.mk
@@ -77,7 +77,7 @@ case "${DEVICE}" in
     ;;
   S922X)
     [ "${ENABLE_32BIT}" == "true" ] && EMUS_32BIT="box86 pcsx_rearmed-lr"
-    PKG_EMUS+=" aethersx2-sa azahar-sa dolphin-sa drastic-sa duckstation-sa melonds-sa vita3k-sa"
+    PKG_EMUS+=" aethersx2-sa azahar-sa dolphin-sa drastic-sa duckstation-sa melonds-sa vita3k-sa yaps2-sa"
     LIBRETRO_CORES+=" beetle-psx-lr beetle-saturn-lr bsnes-lr bsnes-hd-lr dolphin-lr"
     ;;
   AMD64)
@@ -1171,7 +1171,7 @@ makeinstall_target() {
   RK3399|RK3576|RK3566|RK3588|SM6115|SM8250|SM8550|SM8650|SM8750|S922X)
     add_emu_core ps2 aethersx2 aethersx2-sa true
     case ${DEVICE} in
-      SM8250|SM8550|SM8650|SM8750)
+      S922X|SM8250|SM8550|SM8650|SM8750)
         add_emu_core ps2 yaps2 yaps2-sa false
         install_script "Start YAPS2.sh"
       ;;


### PR DESCRIPTION
## Summary

yaps2-sa: SDL frontend for libmali platforms (S922X)

## Testing

Tested on my OGU

## Additional Context

Required bumping qt6 to v6.10.3 to avoid segfaults with Azahar

---

### AI Usage

**Did you use AI tools to help write this code?** NO
