### PR TITLE
SM8550: AYN Odin 2 - expose the two back buttons as gpio-keys

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayn_mcu.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/capability_maps/ayn_mcu.yaml
@@ -151,7 +151,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: RightPaddle1
+        button: RightPaddle2
 
   - name: Left Paddle
     source_events:
@@ -161,7 +161,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: LeftPaddle1
+        button: LeftPaddle2
 
   - name: Right Stick
     source_events:

--- a/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-controller.yaml
+++ b/projects/ROCKNIX/devices/SM8550/filesystem/usr/share/inputplumber/devices/02-ayn-controller.yaml
@@ -62,6 +62,17 @@ source_devices:
       handler: event*
     capability_map_id: ayn_mcu
 
+  # AYN Odin 2 back buttons (M1/M2): a separate gpio-keys device from the
+  # Odin 2 dts emitting BTN_Z (M1) / BTN_C (M2). Matched by name because
+  # its phys_path is shared with the other gpio-keys node. The ayn_mcu map
+  # turns them into Left/RightPaddle2, which the ds5-edge target emits as
+  # the Edge's real back-lever buttons.
+  - group: gamepad
+    evdev:
+      name: gpio-keys-paddles
+      handler: event*
+    capability_map_id: ayn_mcu
+
 # Optional configuration for the composite device
 options:
   # If true, InputPlumber will automatically try to manage the input device. If
@@ -69,7 +80,10 @@ options:
   # external service enables management of the device. Defaults to 'false'
   auto_manage: true
 
-# The target input device(s) to emulate by default
+# The target input device(s) to emulate by default. ds5-edge is the DualSense
+# variant with back paddles, so the Odin 2's physical back buttons can be
+# emitted as the Edge's real removable back-lever buttons (see ayn_mcu.yaml;
+# decoded by the hid-playstation Edge support in patches/mainline/0006).
 target_devices:
-  - ds5
+  - ds5-edge
   - keyboard

--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-odin2.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-odin2.dts
@@ -322,3 +322,44 @@
 &spk_amp_r {
 	firmware-name = "qcom/sm8550/ayn/odin2/aw883xx_acf.bin";
 };
+
+&tlmm {
+	paddle_keys_default: paddle-keys-default-state {
+		pins = "gpio57", "gpio58";
+		function = "gpio";
+		bias-pull-up;
+		drive-strength = <2>;
+	};
+};
+
+/*
+ * AYN Odin 2 has two extra back buttons (M1, M2) on the lower back of
+ * the device. They are plain active-low SoC TLMM GPIOs (M1 = GPIO_57,
+ * M2 = GPIO_58), not on the gamepad MCU UART and not ADC (despite AYN's
+ * Android "adckey"/keydetect.ko naming). Expose them as a gpio-keys
+ * device emitting BTN_Z (M1) / BTN_C (M2); ROCKNIX's InputPlumber map
+ * (ayn_mcu.yaml) routes BTN_Z -> LeftPaddle2 and BTN_C -> RightPaddle2.
+ * RE'd from the AYN Android keydetect driver (gpio_request 358/359 =
+ * TLMM base 301 + offsets 57/58), same scheme as the AYN Odin 3.
+ */
+/ {
+	gpio-keys-paddles {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&paddle_keys_default>;
+
+		key-paddle-m1 {
+			label = "Back Paddle M1";
+			linux,code = <BTN_Z>;
+			gpios = <&tlmm 57 GPIO_ACTIVE_LOW>;
+			debounce-interval = <15>;
+		};
+
+		key-paddle-m2 {
+			label = "Back Paddle M2";
+			linux,code = <BTN_C>;
+			gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
+			debounce-interval = <15>;
+		};
+	};
+};


### PR DESCRIPTION
## Summary

* **Goal:** Make the AYN Odin 2's two back buttons (M1, M2) work. On stock ROCKNIX they emit nothing because there is no driver for them. This replicates #2940 (AYN Odin 3) on SM8550: a `gpio-keys-paddles` node in the Odin 2 dts so they report buttons.
* They are not on the gamepad MCU UART (`rsinput`) and not ADC despite AYN's Android `adckey`/`keydetect.ko` naming — they are plain active-low SoC TLMM GPIOs: **M1 = GPIO 57 → `BTN_Z`**, **M2 = GPIO 58 → `BTN_C`** (TLMM base 301 + offsets 57/58, RE'd from AYN's `keydetect.ko` `gpio_request(358/359)` and confirmed on hardware by watching the TLMM `GPIO_IN` registers while pressing the buttons).
* Mirrors the Odin 3 InputPlumber integration on the SM8550 side: source the new device in `02-ayn-controller.yaml`, route `BTN_Z`/`BTN_C` to Left/RightPaddle2 in `ayn_mcu.yaml`, and switch the target to `ds5-edge` so the buttons are emitted as the DualSense Edge's real back-lever buttons (hid-playstation Edge support from `patches/mainline/0006` already applies to SM8550 kernels).

## Testing

* Pin discovery and end-to-end flow verified on an AYN Odin 2 base running ROCKNIX `next` 20260701: an equivalent runtime GPIO driver for pins 57/58 produces clean press/release (`evtest`) with no chatter, and the events reach the virtual controller through InputPlumber's AYN composite.
* This dts: compile-tested against linux-7.1.2 + the full SM8550 patch set (`qcs8550-ayn-odin2.dtb` builds; decompiled blob contains the node). I could not build a full image — happy to flash a CI artifact on my Odin 2 and report back.

## Additional Context

* Same scheme as #2940 — thanks @aanze for the template. Odin 2 differs only in SoC, pins (57/58) and vendor gpiochip base (301).
* Pins referenced by TLMM offset (`<&tlmm 57>`, `<&tlmm 58>`), input + pull-up, 15ms debounce.
* The `ds5-edge` target / Paddle2 changes are in the shared SM8550 AYN files also covering Odin 2 Mini / Odin 2 Portal / Retroid Pocket 6 — cosmetic for devices without the buttons (presents as an Edge with unused levers), same situation as SM8750. Happy to split per-device if preferred.
* Only the base Odin 2 dts gains the node; Mini/Portal very likely share the wiring but I don't own them to test.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY — reverse-engineering and patch authoring assisted by AI; hardware findings verified on-device.
