### PR TITLE
qt6: bump to v6.10.3

### DIFF
--- a/projects/ROCKNIX/packages/graphics/qt6/package.mk
+++ b/projects/ROCKNIX/packages/graphics/qt6/package.mk
@@ -7,20 +7,8 @@ PKG_SITE="https://download.qt.io"
 PKG_DEPENDS_TARGET="toolchain qt6:host openssl libjpeg-turbo libpng pcre2 sqlite zlib freetype SDL2 gstreamer gst-plugins-base gst-plugins-good gst-libav"
 PKG_DEPENDS_HOST="gcc:host llvm:host mesa:host"
 PKG_LONGDESC="A cross-platform application and UI framework"
-
-# Mali devices require pinning to v6.8.3 or azahar-sa will segfault
-case ${DEVICE} in
-  RK35*|S922X)
-    PKG_VERSION_MAJOR="6.8"
-    PKG_VERSION="${PKG_VERSION_MAJOR}.3"
-  ;;
-  *)
-    PKG_VERSION_MAJOR="6.10"
-    PKG_VERSION="${PKG_VERSION_MAJOR}.1"
-  ;;
-esac
-
-# Package URL depends on version derived above
+PKG_VERSION_MAJOR="6.10"
+PKG_VERSION="${PKG_VERSION_MAJOR}.3"
 PKG_URL="${PKG_SITE}/archive/qt/${PKG_VERSION_MAJOR}/${PKG_VERSION}/single/qt-everywhere-src-${PKG_VERSION}.tar.xz"
 
 # Apply project-specific patches


### PR DESCRIPTION
## Summary

qt6: bump to v6.10.3

## Testing

Tested on my OGU (S922X) - runs qt6 apps (eg azahar) without segfaults

## Additional Context

Contains bugfix for segfaults: https://qt-project.atlassian.net/issues?jql=project%20%3D%20%22QTBUG%22%20AND%20component%20%3D%20%22QPA%3A%20EGLFS%22&selectedIssue=QTBUG-143495

---

### AI Usage

**Did you use AI tools to help write this code?** NO
