### PR TITLE
yaps2-sa: fix savestates / memorycards dirs

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/config/S922X/YAPS2/inis/PCSX2.ini
+++ b/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/config/S922X/YAPS2/inis/PCSX2.ini
@@ -20,8 +20,8 @@ MainWindowState = AAAA/wAAAAD9AAAAAAAAAoAAAAKnAAAABAAAAAQAAAAIAAAACPwAAAABAAAAAg
 [Folders]
 Bios = /storage/roms/bios/yaps2
 Snapshots = snaps
-Savestates = sstates
-MemoryCards = memcards
+Savestates = /storage/roms/savestates/ps2
+MemoryCards = /storage/roms/ps2
 Logs = logs
 Cheats = cheats
 Patches = patches

--- a/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/config/inputplumber/YAPS2/inis/PCSX2.ini
+++ b/projects/ROCKNIX/packages/emulators/standalone/yaps2-sa/config/inputplumber/YAPS2/inis/PCSX2.ini
@@ -20,8 +20,8 @@ MainWindowState = AAAA/wAAAAD9AAAAAAAAAoAAAAKnAAAABAAAAAQAAAAIAAAACPwAAAABAAAAAg
 [Folders]
 Bios = /storage/roms/bios/yaps2
 Snapshots = snaps
-Savestates = sstates
-MemoryCards = memcards
+Savestates = /storage/roms/savestates/ps2
+MemoryCards = /storage/roms/ps2
 Logs = logs
 Cheats = cheats
 Patches = patches


### PR DESCRIPTION
## Summary

yaps2-sa: fix savestates / memorycards dirs

## Testing

Tested on my OGU

## Additional Context

Apply same settings as aethersx2-sa to match ROCKNIX folder structure:
```
Savestates = /storage/roms/savestates/ps2
MemoryCards = /storage/roms/ps2
```

---

### AI Usage

**Did you use AI tools to help write this code?** NO
