### PR TITLE
mangohud: bump to v0.8.4

### DIFF
--- a/projects/ROCKNIX/packages/apps/mangohud/package.mk
+++ b/projects/ROCKNIX/packages/apps/mangohud/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2025-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="mangohud"
-PKG_VERSION="330c42a5956e005a4d102473f5782bb0e3d94b6f" # v0.8.3
+PKG_VERSION="992103e4fb744897826de04ea00a2f71e7018214" # v0.8.4
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/flightlessmango/MangoHud"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
## Summary

mangohud: bump to v0.8.4

## Testing

Tested on my OGU (S922X)

RK3326, S922X, SM6115, SM8250, SM8550, SM8650, SM8750 builds ok here: https://github.com/porschemad911/rocknix-distribution/actions/runs/30359413015

---

### AI Usage

**Did you use AI tools to help write this code?** NO
