### PR TITLE
rocknix: rocknix-info - support batteryplus

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-info
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-info
@@ -19,10 +19,19 @@ info_quirks() {
   done
 }
 
+### Grab battery capacity now as it is used in a couple of different places
+### Cater for batteryplus
+BATTERYPLUS_PERCENT="/tmp/battery.percent"
+
+if [[ -f "${BATTERYPLUS_PERCENT}" ]]; then
+  BATT=$(<${BATTERYPLUS_PERCENT})
+else
+  BATT=$(awk 'BEGIN {FS="="} /POWER_SUPPLY_CAPACITY=/ {print $2; exit}' /sys/class/power_supply/[Bb][Aa][Tt]*/uevent 2>/dev/null)
+fi
+
 ### short version (for osd)
 if test "$1" = "--short"
 then
-    BATT=$(awk 'BEGIN {FS="="} /POWER_SUPPLY_CAPACITY=/ {print $2; exit}' /sys/class/power_supply/[Bb][Aa][Tt]*/uevent 2>/dev/null)
     DT=$(date +%H:%M)
     if test -n "${BATT}"
     then
@@ -87,8 +96,6 @@ MEMAV=$(grep MemAvailable /proc/meminfo | sed 's/[^0-9]*//g')
 MEMAV=$((${MEMAV} / 1000))
 
 # battery
-BATT=$(awk 'BEGIN {FS="="} /POWER_SUPPLY_CAPACITY=/ {print $2; exit}' /sys/class/power_supply/[Bb][Aa][Tt]*/uevent 2>/dev/null)
-
 case ${HW_ARCH} in
   aarch64)
     declare -a CF MF


### PR DESCRIPTION
## Summary

rocknix-info - support batteryplus for battery stats

## Testing

Tested on S922X (with batteryplus) and SM6115 (without batteryplus)

## Additional Context

Currently on S922X different battery percentages show in different parts of the system

---

### AI Usage

**Did you use AI tools to help write this code?** NO
