### PR TITLE
SM8750: map the Odin 3 right home button to the Steam QAM

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/filesystem/usr/share/inputplumber/capability_maps/ayn_mcu.yaml
+++ b/projects/ROCKNIX/devices/SM8750/filesystem/usr/share/inputplumber/capability_maps/ayn_mcu.yaml
@@ -83,14 +83,17 @@ mapping:
       gamepad:
         button: Select
 
-  - name: F1 Key
+  # Right "home" button: Steam reads QuickAccess over the InputPlumber
+  # DBus target and opens the Quick Access Menu.
+  - name: QAM Button
     source_events:
       - evdev:
           event_type: KEY
           event_code: BTN_BACK
           value_type: button
     target_event:
-      keyboard: KeyF1
+      gamepad:
+        button: QuickAccess
 
   - name: Right Trigger
     source_events:


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the AYN Odin 3's right home button open Steam's Quick Access Menu. It was mapped to KeyF1, which does nothing in EmulationStation or Steam.

## Testing

* **How was this tested?** Odin 3, Steam Big Picture: modified capability map bind-mounted, `inputplumber` restarted, right home button pressed.
* **Test results:** The QAM opens on a single press. The left home button (Guide) and the Steam menu are unchanged.

## Additional Context

* Works with the existing `ds5` target, so no Steam Deck / horipad target switch is needed.
* A capability map entry allows a single `target_event`, so the previous Home+B chord cannot be reproduced from one button.
* Freeze is active, so this needs the `bugfix` label or it can wait for the window to lift.

---

### AI Usage

**Did you use AI tools to help write this code?** YES
