### PR TITLE
SM8750: restore dock DisplayPort output broken by the 7.1 bump

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:03 2001
+From: Anze <aanzdev@gmail.com>
+Date: Mon, 27 Jul 2026 18:00:00 +0200
+Subject: [PATCH] usb: typec: mux: don't swallow EPROBE_DEFER in the dedup check
+
+The 7.1 merge window added a "skip duplicates" filter to typec_mux_match()
+and typec_switch_match(), and started passing the output array in as the
+match data so it can be compared against. Both halves are broken for a
+connector whose mux is not registered yet.
+
+struct device is the FIRST member of struct typec_mux_dev and struct
+typec_switch_dev, so container_of() on a NULL device yields NULL. When
+class_find_device() finds nothing - the normal case while the mux driver
+has not probed yet, e.g. an i2c retimer such as wcd939x-usbss - the dedup
+loop compares that NULL against an array slot that is also NULL, matches,
+and returns NULL. The caller reads that as "no such connection" instead
+of the -EPROBE_DEFER it used to get, so the connector is created WITHOUT
+its mux, permanently: the DP lanes and the AUX/SBU pair are never routed.
+
+The arrays are also uninitialised stack (`struct typec_mux_dev
+*mux_devs[TYPEC_MUX_MAX_DEVS];`), yet the dedup loop reads every slot
+before fwnode_connection_find_matches() has filled them, so a valid mux
+can be dropped by a chance comparison against stack garbage.
+
+Bail out with -EPROBE_DEFER before the dedup loop when no device was
+found, and zero-initialise both arrays.
+
+Device-observed on an AYN Odin 3 (SM8750): dock DisplayPort output died
+with the 7.0.11 -> 7.1.3 bump. The firmware enters DP alt mode correctly
+(mux_ctrl=3, pin_assignment=4), raises HPD, and msm_dp powers up its
+clocks and PHY - then the very first DPCD read times out
+(drm_dp_dpcd_probe ... AUX -> (ret=-110)), link_ready stays false and the
+connector reports disconnected, because nothing ever routed the lanes.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+--- a/drivers/usb/typec/mux.c	2026-07-27 17:07:50.988901877 +0200
++++ b/drivers/usb/typec/mux.c	2026-07-27 17:07:51.010296597 +0200
+@@ -57,6 +57,8 @@
+ 	 */
+ 	dev = class_find_device(&typec_mux_class, NULL, fwnode,
+ 				switch_fwnode_match);
++	if (!dev)
++		return ERR_PTR(-EPROBE_DEFER);
+ 
+ 	/* Skip duplicates */
+ 	for (i = 0; i < TYPEC_MUX_MAX_DEVS; i++)
+@@ -65,7 +67,7 @@
+ 			return NULL;
+ 		}
+ 
+-	return dev ? to_typec_switch_dev(dev) : ERR_PTR(-EPROBE_DEFER);
++	return to_typec_switch_dev(dev);
+ }
+ 
+ /**
+@@ -79,7 +81,7 @@
+  */
+ struct typec_switch *fwnode_typec_switch_get(struct fwnode_handle *fwnode)
+ {
+-	struct typec_switch_dev *sw_devs[TYPEC_MUX_MAX_DEVS];
++	struct typec_switch_dev *sw_devs[TYPEC_MUX_MAX_DEVS] = {};
+ 	struct typec_switch *sw;
+ 	int count;
+ 	int err;
+@@ -292,6 +294,8 @@
+ 
+ 	dev = class_find_device(&typec_mux_class, NULL, fwnode,
+ 				mux_fwnode_match);
++	if (!dev)
++		return ERR_PTR(-EPROBE_DEFER);
+ 
+ 	/* Skip duplicates */
+ 	for (i = 0; i < TYPEC_MUX_MAX_DEVS; i++)
+@@ -300,8 +304,7 @@
+ 			return NULL;
+ 		}
+ 
+-
+-	return dev ? to_typec_mux_dev(dev) : ERR_PTR(-EPROBE_DEFER);
++	return to_typec_mux_dev(dev);
+ }
+ 
+ /**
+@@ -315,7 +318,7 @@
+  */
+ struct typec_mux *fwnode_typec_mux_get(struct fwnode_handle *fwnode)
+ {
+-	struct typec_mux_dev *mux_devs[TYPEC_MUX_MAX_DEVS];
++	struct typec_mux_dev *mux_devs[TYPEC_MUX_MAX_DEVS] = {};
+ 	struct typec_mux *mux;
+ 	int count;
+ 	int err;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Restore USB-C dock / KVM DisplayPort output on the AYN Odin 3 (SM8750), which has been dead since the `7.0.11 -> 7.1.3` kernel bump (6166516). Plugging a dock gives no video at all — the connector never leaves `disconnected` and the display shows no sign of detection.

The 7.1 merge window added a "skip duplicates" filter to `typec_mux_match()` / `typec_switch_match()` in `drivers/usb/typec/mux.c` and started passing the output array in as the match data. `struct device` is the **first** member of `struct typec_mux_dev` / `struct typec_switch_dev`, so `container_of()` on a NULL device yields NULL. When `class_find_device()` finds nothing — the normal case while the mux driver has not probed yet, here the `wcd939x-usbss` retimer on i2c — the dedup loop compares that NULL against an array slot that is also NULL, matches, and returns `NULL` instead of `ERR_PTR(-EPROBE_DEFER)`. The connector is then built **without its mux, permanently**, and the DP lanes and the AUX/SBU pair are never routed.

The two dedup arrays are also uninitialised stack, yet every slot is read before `fwnode_connection_find_matches()` has filled them, so a valid mux can be dropped by a chance comparison against stack garbage.

Kernel patch `0517` bails out with `-EPROBE_DEFER` before the dedup loop when no device was found, and zero-initialises both arrays. This is **not Odin 3 specific**: any platform whose Type-C mux probes after the connector is affected.

## Testing

* **How was this tested?** Built a ROCKNIX image for SM8750 and flashed an AYN Odin 3, with a USB-C KVM driving a DisplayPort monitor. A/B against release images on both sides of the bump (7.0.11 works, 7.1.3 does not), same dock and same instrumentation.
* **Test results:**

Before (7.1.3) — the firmware enters DP alt mode and raises HPD, the driver decodes it correctly and notifies DRM, then the very first DPCD read times out, so the link never trains:

```
pmic_glink_altmode: NOTIFY svid=0xff01 mux_ctrl=3 pin_assignment=4 hpd_state=1
aux_hpd_bridge:     HPD notify status=1          (connected)
[drm:msm_dp_display_host_phy_init] core_init=1 phy_init=0
[drm:drm_dp_dpcd_probe] dpu_dp_aux: 0x00102 AUX -> (ret=-110)
[drm:msm_dp_bridge_detect] link_ready = false
```

After (same image + this patch):

```
DP status : connected
DP enabled: enabled
EDID      : 256 bytes
modes     : 3840x2160  4096x2160
AUX -110  : 0
```

Picture on the external display, confirmed on device.

## Additional Context

* An `AUX -> (ret=-110)` timeout while every software layer reports success is the signature of the lanes never being routed — worth remembering for similar reports.
* Reached by elimination: every other file of the DP path is byte-identical between 7.0.11 and 7.1.3 (`dp_drm.c`, `dp_display.c`, `aux-hpd-bridge.c`, `pmic_glink_altmode.c`, `wcd939x-usbss.c`, `phy-qcom-qmp-combo.c`, `phy-core.c`, `dispcc-sm8750.c`, `drm_bridge.c`, `drm_bridge_connector.c`), as is the live device tree, so `mux.c` was the only behavioural change left.
* The fix belongs upstream in the kernel; carrying it here fixes ROCKNIX users now. Other users have reported no dock video on ROCKNIX, which this would explain.
* Freeze is active (last 7 days of the month) — this is a bugfix and needs the `bugfix` label, which I do not have permission to set.

---

### AI Usage

**Did you use AI tools to help write this code?** YES
