### PR TITLE
rpnova: fix nova left joystick axis and add trigger deadzone

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-retroidpocket-rpnova.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-retroidpocket-rpnova.dts
@@ -26,3 +26,10 @@
 		/delete-property/ touchscreen-inverted-y;
 	};
 };
+
+&gamepad {
+	invert-x;
+	invert-y;
+	trigger-left-deadzone = <100>;
+	trigger-right-deadzone = <100>;
+};

--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0031_input--Add-driver-for-RSInput-Gamepad.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0031_input--Add-driver-for-RSInput-Gamepad.patch
@@ -42,7 +42,7 @@ new file mode 100644
 index 000000000000..913c499ad30a
 --- /dev/null
 +++ b/drivers/input/joystick/rsinput.c
-@@ -0,0 +1,578 @@
+@@ -0,0 +1,592 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * RSInput Gamepad Driver
@@ -477,6 +477,20 @@ index 000000000000..913c499ad30a
 +            axis_righty_max =  range;
 +
 +            dev_info(&serdev->dev, "DT axis-range override applied: ±%u\n", range);
++        }
++    }
++
++    {
++        u32 deadzone;
++
++        if (!device_property_read_u32(&serdev->dev, "trigger-left-deadzone", &deadzone)) {
++            trigger_left_deadzone = deadzone;
++            dev_info(&serdev->dev, "DT trigger-left-deadzone override applied: %u\n", deadzone);
++        }
++
++        if (!device_property_read_u32(&serdev->dev, "trigger-right-deadzone", &deadzone)) {
++            trigger_right_deadzone = deadzone;
++            dev_info(&serdev->dev, "DT trigger-right-deadzone override applied: %u\n", deadzone);
 +        }
 +    }
 +


### PR DESCRIPTION
## Summary

Fixes Nova left joystick axis so up is up, left is left, etc. 
Adds a deadzone to L2 and R2 so false inputs dont register. 

## Testing

Tested on RP Nova. 