### PR TITLE
AYANEO Pocket S2: add analogue-stick RGB control

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYANEO Pocket S2/010-analog_sticks_led_control
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYANEO Pocket S2/010-analog_sticks_led_control
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+cat <<EOF >/storage/.config/profile.d/010-analog_sticks_led_control
+DEVICE_ANALOG_STICKS_LED_CONTROL="true"
+EOF

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYANEO Pocket S2/bin/analog_sticks_ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYANEO Pocket S2/bin/analog_sticks_ledcontrol
@@ -1,0 +1,66 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+SERIAL_DEVICE="/dev/ttyHS0"
+
+if [ "$#" -ne 4 ] && [ "$#" -ne 7 ]; then
+  echo "Usage: $0 <BRIGHTNESS> <RIGHT_R> <RIGHT_G> <RIGHT_B> [<LEFT_R> <LEFT_G> <LEFT_B>]" >&2
+  echo "Example: $0 255 255 0 0 255 0 0" >&2
+  exit 1
+fi
+
+for value in "$@"; do
+  case ${value} in
+    ''|*[!0-9]*)
+      echo "Brightness and RGB values must be integers from 0 to 255" >&2
+      exit 1
+    ;;
+  esac
+
+  if [ "${value}" -gt 255 ]; then
+    echo "Brightness and RGB values must be integers from 0 to 255" >&2
+    exit 1
+  fi
+done
+
+BRIGHTNESS=${1}
+R=${2}
+G=${3}
+B=${4}
+
+# The S2 protocol applies one colour to both analogue-stick rings. ROCKNIX's
+# frontend supplies separate right and left colours, so use the right colour
+# for both rings while retaining four-argument compatibility for system hooks.
+
+# AYANEO Pocket S2 uses the verified 27-byte MCU packet family with selector
+# 0x08. The checksum is the low byte of the sum of bytes 1 through 24.
+CHECKSUM=$(((
+  0x00 + 0x1C + 0x20 + 0x01 +
+  0x80 + 0x00 + 0x81 + 0x00 +
+  0x8B + 0x0F + 0x88 + R +
+  0x89 + G + 0x8A + B +
+  0x86 + BRIGHTNESS + 0x87 + BRIGHTNESS +
+  0x58 + 0x08 + 0x45 + 0x00
+) & 0xFF))
+
+FRAME=$(printf '\\%03o' \
+  0xF7 0x00 0x1C 0x20 0x01 \
+  0x80 0x00 0x81 0x00 0x8B 0x0F \
+  0x88 "${R}" 0x89 "${G}" 0x8A "${B}" \
+  0x86 "${BRIGHTNESS}" 0x87 "${BRIGHTNESS}" \
+  0x58 0x08 0x45 0x00 "${CHECKSUM}" 0xED)
+
+if [ ! -c "${SERIAL_DEVICE}" ]; then
+  echo "Serial device ${SERIAL_DEVICE} is unavailable" >&2
+  exit 1
+fi
+
+stty -F "${SERIAL_DEVICE}" 115200 -clocal -opost -isig -icanon -echo
+
+# Stock S2 software repeats RGB writes with approximately 40 ms spacing.
+printf '%b' "${FRAME}" >"${SERIAL_DEVICE}"
+sleep 0.04
+printf '%b' "${FRAME}" >"${SERIAL_DEVICE}"
+sleep 0.04
+printf '%b' "${FRAME}" >"${SERIAL_DEVICE}"

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYANEO Pocket S2/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYANEO Pocket S2/bin/ledcontrol
@@ -20,6 +20,18 @@ function led_off() {
   led_rgb power-led 0 0 0
 }
 
+function analog_sticks_off() {
+  /usr/bin/analog_sticks_ledcontrol 0 0 0 0
+}
+
+function analog_sticks_restore() {
+  LEDS_CONFIG=$(get_setting analogsticks.led)
+
+  if [ -n "${LEDS_CONFIG}" ]; then
+    /usr/bin/analog_sticks_ledcontrol ${LEDS_CONFIG}
+  fi
+}
+
 function led_red() {
   led_brightness power-led 255
   led_rgb power-led 255 0 0
@@ -93,8 +105,12 @@ case ${1} in
     set_setting led.color ${1}
     systemctl restart batteryledstatus.service
   ;;
+  rgb)
+    set_setting led.color ${1}
+  ;;
   poweroff)
     led_off
+    analog_sticks_off
   ;;
   list)
 cat <<EOF
@@ -111,3 +127,8 @@ EOF
   ;;
 esac
 
+case ${1} in
+  red|green|blue|white|orange|yellow|purple|off|battery|rgb)
+    analog_sticks_restore
+  ;;
+esac


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Implement analogue-stick RGB control for the AYANEO Pocket S2 Pro using its MCU UART protocol. This enables static colour and brightness control through the existing EmulationStation settings, including LED off, reboot persistence, and fake-suspend restore.

## Testing

Hardware tested on an AYANEO Pocket S2 Pro:

- Static colour and brightness control through EmulationStation
- Both analogue-stick rings controlled together
- LED off
- Settings retained after reboot
- LEDs turn off and restore during fake suspend
- Complete SM8650 image built successfully and installed through the local ROCKNIX updater

## Additional Context

The Pocket S2 controls its analogue-stick rings through the MCU UART rather than the standard LED sysfs interface. It uses the hardware-verified 27-byte packet format with selector `0x08`.

The hardware applies one colour to both rings, so the right-stick colour supplied by EmulationStation is used for both. Animated lighting modes are outside the scope of this PR.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES 
