### PR TITLE
thor: honour led.brightness in battery LED mode

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/battery_led_status
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/AYN Thor/bin/battery_led_status
@@ -10,6 +10,18 @@
 
 LED_PATH="/sys/devices/platform/"
 
+# Brightness for the status colours, taken from the led.brightness setting
+# (percent, 0-100) so the EmulationStation slider applies in battery mode too.
+# Previously this was hard-coded to 255.
+function led_bri() {
+  local pct
+  pct=$(get_setting led.brightness)
+  case "${pct}" in ''|*[!0-9]*) pct=100 ;; esac
+  [ "${pct}" -gt 100 ] && pct=100
+  BRI=$(( pct * 255 / 100 ))
+  [ "${pct}" -gt 0 ] && [ "${BRI}" -lt 1 ] && BRI=1
+}
+
 function bat_led_off() {
   n=1
   while [ "$n" -lt 5 ]; do
@@ -22,10 +34,11 @@ function bat_led_off() {
 }
 
 function bat_led_red() {
+  led_bri
   n=1
   while [ "$n" -lt 5 ]; do
-    echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
-    echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 0 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
     echo 0 0 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/multi_intensity
     n=$(( n + 1 ))
@@ -33,10 +46,11 @@ function bat_led_red() {
 }
 
 function bat_led_green() {
+  led_bri
   n=1
   while [ "$n" -lt 5 ]; do
-    echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
-    echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 255 0 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
     echo 0 255 0 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/multi_intensity
     n=$(( n + 1 ))
@@ -44,10 +58,11 @@ function bat_led_green() {
 }
 
 function bat_led_orange() {
+  led_bri
   n=1
   while [ "$n" -lt 5 ]; do
-    echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
-    echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 20 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
     echo 0 20 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/multi_intensity
     n=$(( n + 1 ))
@@ -55,10 +70,11 @@ function bat_led_orange() {
 }
 
 function bat_led_yellow() {
+  led_bri
   n=1
   while [ "$n" -lt 5 ]; do
-    echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
-    echo 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
+    echo ${BRI} >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/brightness
     echo 0 125 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/multi_intensity
     echo 0 125 255 >  ${LED_PATH}/multi-ledr${n}/leds/rgb:r${n}/multi_intensity
     n=$(( n + 1 ))


### PR DESCRIPTION
### Problem

On the AYN Thor the analogue-stick LEDs stay at full brightness in battery mode, no matter what the EmulationStation brightness setting is.

`led.brightness` is stored correctly (`/storage/.config/system/configs/system.cfg`), but `quirks/devices/AYN Thor/bin/battery_led_status` never reads it — every state function writes a literal `255`:

```sh
function bat_led_green() {
  ...
    echo 255 >  ${LED_PATH}/multi-ledl${n}/leds/rgb:l${n}/brightness
```

So the setting has no effect whenever `led.color=battery`, which is the default.

### Fix

Add a small `led_bri()` helper that converts `led.brightness` (percent) to 0-255, and use it for the brightness writes.

Colour values and `bat_led_off` are untouched, so battery status indication behaves exactly as before — only the intensity changes. It falls back to 100% when the setting is unset or non-numeric, and clamps to a minimum of 1 so a non-zero percentage never reads as "off".

### Testing

AYN Thor, ROCKNIX 20260701 + this change:

| `led.brightness` | resulting `rgb:l1..l4` / `rgb:r1..r4` brightness |
|---|---|
| 100 | 255 |
| 10  | 25  |
| 0   | 0   |

Battery colour transitions (green / yellow / orange / red, charging and discharging) are unchanged, and the setting is picked up on the next state change.

### Notes

`Anbernic RG DS` already reads `led.brightness` (#2533) — this brings the Thor in line with that.

The same hard-coded `255` appears in six other scripts: `AYN Odin 2 Portal`, `Powkiddy RGB20 Pro`, `Retroid Pocket 6`, `Retroid Pocket Nova`, and platforms `SM6115` and `SM8250`. I've left those alone since the Thor is the only device I can test on — happy to extend this PR if you'd like them included.
