### PR TITLE
SM8550: unlock 3.36 GHz prime-core boost

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0102-arm64-dts-qcom-sm8550-add-3.36GHz-prime-core-boost-opp.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0102-arm64-dts-qcom-sm8550-add-3.36GHz-prime-core-boost-opp.patch
@@ -1,0 +1,46 @@
+From a4975ce7c8eec079bd0cf7ec3890e100e016813f Mon Sep 17 00:00:00 2001
+From: azkali <a.ffcc7@gmail.com>
+Date: Fri, 31 Jul 2026 00:26:41 +0700
+Subject: [PATCH] arm64: dts: qcom: sm8550: add 3.36 GHz prime-core boost OPP
+
+The prime (X3) domain's EPSS LUT ends in a turbo row at 3.3600 GHz
+(core_count == LUT_TURBO_IND). qcom-cpufreq-hw only registers such a
+row as a CPUFREQ_BOOST_FREQ when qcom_cpufreq_update_opp() can enable
+a matching OPP from the DT table; with no opp-3360000000 entry the row
+is dropped ("failed to update OPP") and cpu7 tops out at the last
+regular LUT row, 2.9568 GHz.
+
+Interconnect votes are copied from opp-3187200000, the highest regular
+OPP: the LUT row carries no bandwidth data of its own and the DDR/LLCC
+votes already peak there.
+
+Verified on the AYANEO Pocket DS (QCS8550): with cpufreq boost enabled
+(/sys/devices/system/cpu/cpufreq/boost), policy7 exposes 3360000 kHz,
+reaches it under the performance governor, and LMH throttles sustained
+load as usual. Boost remains a runtime opt-in via sysfs.
+
+Signed-off-by: Alexandre Hamamdjian <azkali.limited@gmail.com>
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ arch/arm64/boot/dts/qcom/sm8550.dtsi | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8550.dtsi b/arch/arm64/boot/dts/qcom/sm8550.dtsi
+index 34e879ecf9fc..074a1e127de6 100644
+--- a/arch/arm64/boot/dts/qcom/sm8550.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8550.dtsi
+@@ -818,6 +818,11 @@ opp-3187200000 {
+ 			opp-hz = /bits/ 64 <3187200000>;
+ 			opp-peak-kBps = <(933000 * 16) (3686000 * 4) (1689600 * 32)>;
+ 		};
++
++		opp-3360000000 {
++			opp-hz = /bits/ 64 <3360000000>;
++			opp-peak-kBps = <(933000 * 16) (3686000 * 4) (1689600 * 32)>;
++		};
+ 	};
+ 
+ 
+-- 
+2.55.0
+

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8550/002-turbo-mode_config
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8550/002-turbo-mode_config
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+
+cat <<EOD >/storage/.config/profile.d/002-turbo-mode_config
+DEVICE_TURBO_MODE="true"
+EOD


### PR DESCRIPTION
The prime (X3) domain's EPSS LUT on SM8550 ends in a turbo row at 3.36 GHz. Mainline `qcom-cpufreq-hw` registers that row as a `CPUFREQ_BOOST_FREQ` **only if a matching OPP exists in the DT table** — the bandwidth-scaling tables added by `0101-v3_20260219_webgeek1234_...` stop at 3.1872 GHz, so the boost row is currently dropped (`failed to update OPP`) and cpu7 tops out at **2.9568 GHz** on SM8550 devices.

This PR:
- adds kernel patch `0102` with an `opp-3360000000` entry for cpu7 (interconnect votes copied from `opp-3187200000`, the highest regular OPP — the votes already peak there);
- enables the existing turbo-mode quirk for the SM8550 platform (`DEVICE_TURBO_MODE="true"`), so the boost knob (`/sys/devices/system/cpu/cpufreq/boost`) is exposed through the standard `turbomode` toggle.

Notes:
- Boost stays **off by default**, matching the other platforms' turbo-mode behaviour.
- Safe on lower-binned parts: DT OPPs are cross-validated against the LUT at probe, so an absent 3.36 GHz row just leaves the entry disabled.
- Only the *last* turbo row before the LUT terminator is resurrected by the driver, so 3.1872 GHz remains unreachable either way — this takes prime straight from 2.9568 to 3.36 GHz.
- Verified on hardware (AYANEO Pocket DS, QCS8550, mainline-based tree): with boost enabled, `policy7` exposes `3360000` in `scaling_boost_frequencies`/`cpuinfo_max_freq` and clocks there under the performance governor; LMH throttles sustained load as usual. EPSS LUT dump shows the turbo row at index 21 (1080 mV, core_count=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)