### PR TITLE
SM8750 konkr pocket fit elite add joystick stick led support

### DIFF
--- a/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/010-analog_sticks_led_control
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/010-analog_sticks_led_control
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+cat <<EOF >/storage/.config/profile.d/010-analog_sticks_led_control
+DEVICE_ANALOG_STICKS_LED_CONTROL="true"
+EOF

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/bin/analog_sticks_ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/bin/analog_sticks_ledcontrol
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+# Simple script to set led brightness and rgb color based on
+# brightness and rgb values from emulation station
+#
+# The MCU lighting frame carries a single rgb triple that reaches both rings, so
+# the konkr_sysbtn serdev driver registers them as one multicolor LED. Combine
+# the per-stick colors emulation station sends channel-wise: equal colors pass
+# through, and a color set on one stick alone still lights both rings.
+#
+# Brightness scales the channel intensities in the LED core, so a brightness of
+# 0 turns the rings off.
+
+LED_PATH="/sys/class/leds/konkr:rgb:joysticks"
+
+max() {
+  if [ ${1} -gt ${2} ]; then
+    echo ${1}
+  else
+    echo ${2}
+  fi
+}
+
+# Display usage if no parameters are provided
+if [ $# -ne 7 ]; then
+  echo "Usage: $0 <brightness> <right_red> <right_green> <right_blue> <left_red> <left_green> <left_blue>"
+  echo "Example: $0 255 255 0 0 255 0 0"
+  exit 1
+fi
+
+BRIGHTNESS=$1
+RED=$(max ${2} ${5})
+GREEN=$(max ${3} ${6})
+BLUE=$(max ${4} ${7})
+
+echo ${RED} ${GREEN} ${BLUE} >${LED_PATH}/multi_intensity
+echo ${BRIGHTNESS} >${LED_PATH}/brightness

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/bin/battery_led_status
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/bin/battery_led_status
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+# Color the analogue-stick rings by battery state while led.color is battery:
+# discharging is green >40%, yellow >30%, orange >20%, red >10% and blinking red
+# below that; charging is orange until 95%, then green.
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+BATTERY="/sys/class/power_supply/battery"
+
+function bat_led() {
+  /usr/bin/analog_sticks_ledcontrol 255 ${1} ${2} ${3} ${1} ${2} ${3}
+}
+
+function bat_led_off()    { /usr/bin/analog_sticks_ledcontrol 0 0 0 0 0 0 0; }
+function bat_led_red()    { bat_led 255 0 0; }
+function bat_led_orange() { bat_led 255 20 0; }
+function bat_led_yellow() { bat_led 255 125 0; }
+function bat_led_green()  { bat_led 0 255 0; }
+
+PREV_BATCAP="null"
+while true
+do
+  if [ ! "$(get_setting led.color)" == "battery" ]; then
+    break
+  fi
+
+  CAP=$(cat ${BATTERY}/capacity 2>/dev/null)
+  STAT=$(cat ${BATTERY}/status 2>/dev/null)
+
+  # qcom-battmgr answers with EAGAIN until the ADSP link is up, so wait for a
+  # usable reading instead of comparing empty values
+  case ${CAP} in
+    ''|*[!0-9]*)
+      sleep 5
+      continue
+    ;;
+  esac
+
+  if [ -z "${STAT}" ]; then
+    sleep 5
+    continue
+  fi
+
+  if [ "${STAT}" == "Discharging" ]; then
+    if (( ${CAP} <= 10 )); then
+      for ctr in $(seq 1 1 5)
+      do
+        bat_led_red
+        sleep .5
+        bat_led_off
+        sleep .5
+      done
+      continue
+    elif (( ${CAP} <= 20 )); then
+      BATCAP="D_RED"
+      if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+        bat_led_red
+      fi
+    elif (( ${CAP} <= 30 )); then
+      BATCAP="D_ORANGE"
+      if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+        bat_led_orange
+      fi
+    elif (( ${CAP} <= 40 )); then
+      BATCAP="D_YELLOW"
+      if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+        bat_led_yellow
+      fi
+    else
+      BATCAP="D_GREEN"
+      if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+        bat_led_green
+      fi
+    fi
+  elif (( ${CAP} <= 94 )); then
+    BATCAP="C_ORANGE"
+    if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+      bat_led_orange
+    fi
+  else
+    BATCAP="C_GREEN"
+    if [ ! ${BATCAP} = ${PREV_BATCAP} ]; then
+      bat_led_green
+    fi
+  fi
+
+  PREV_BATCAP=${BATCAP}
+  sleep 15
+done

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/bin/ledcontrol
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/KONKR Pocket FIT Elite/bin/ledcontrol
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
+
+# The analogue-stick rings are this device's only LEDs, so the LED color modes
+# drive them: off, the color picked in the analog sticks LED menu, or battery
+# status.
+
+# Minimal OS variable loading for performance
+. /etc/profile.d/001-functions
+
+function led_off() {
+  /usr/bin/analog_sticks_ledcontrol 0 0 0 0 0 0 0
+}
+
+function led_rgb() {
+  LEDS_CONFIG=$(get_setting analogsticks.led)
+
+  if [ -n "${LEDS_CONFIG}" ]; then
+    /usr/bin/analog_sticks_ledcontrol ${LEDS_CONFIG}
+  fi
+}
+
+case ${1} in
+  off)
+    led_off
+    set_setting led.color ${1}
+  ;;
+  rgb)
+    led_rgb
+    set_setting led.color ${1}
+  ;;
+  battery)
+    set_setting led.color ${1}
+    systemctl restart batteryledstatus.service
+  ;;
+  poweroff)
+    led_off
+  ;;
+  list)
+cat <<EOF
+off
+rgb
+battery
+EOF
+  ;;
+esac


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

implement support to control the joystick leds on the konkr pocket fit elite

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

tested on the device via the es joystick led controls. all 3 modes (off/battery/rgb) work fine.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

the hardware only supports setting the color for both joysticks at once, not individually, and i didnt find a way to tell es that, so the actual rgb color that ends up in the hardware is.. well, see the code. the idea is that you set the color of one joystick to 0/0/0, then the color of the other will control both directly.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

yes, heavy use of claude