### PR TITLE
SM8750: fix the Odin 3 headphone jack

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0603-ASoC-codecs-wcd939x-keep-the-codec-resumed-while-a-ja.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0603-ASoC-codecs-wcd939x-keep-the-codec-resumed-while-a-ja.patch
@@ -1,0 +1,62 @@
+From: Anze <aanzdev@gmail.com>
+Subject: [PATCH] ASoC: codecs: wcd939x: keep the codec resumed while a jack is set
+
+Headset detection reports nothing at all on an AYN Odin 3. MBHC is armed
+correctly - ANA_MBHC_MECH reads 0xbd with L_DET_EN set and the plug-type
+polarity matching the vendor DT - the interrupts are mapped, and yet
+plugging headphones produces no interrupt whatsoever and "Headphone
+Jack" stays off.
+
+The codec is runtime suspended essentially all the time: nothing
+streams, so it autosuspends a second after probe and stays there.
+Suspending puts its regmap in cache-only mode and lets the SoundWire
+link stop its clock, and the codec then has no way to signal anything.
+MBHC is powered and watching; its interrupt has nowhere to go.
+
+Resuming both SoundWire devices makes detection work immediately and
+completely:
+
+  wcd939x_wcd_mbhc_calc_impedance: impedance on HPH_L = 41(ohms)
+  wcd939x_wcd_mbhc_calc_impedance: impedance on HPH_R = 43(ohms)
+  wcd939x_wcd_mbhc_calc_impedance: stereo plug type detected
+
+with SW_HEADPHONE_INSERT set on the jack input device and the mechanical
+interrupt firing on every plug and unplug.
+
+Keep them resumed for as long as a jack is registered. pm_runtime_forbid()
+rather than a get/put pair: a plain reference is not enough here, the
+bus suspends the devices again anyway, and forbid is exactly what
+writing "on" to power/control does - which is what was verified on the
+device.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+--- a/sound/soc/codecs/wcd939x.c
++++ b/sound/soc/codecs/wcd939x.c
+@@ -3396,11 +3396,25 @@ static int wcd939x_codec_set_jack(struct snd_soc_component *comp,
+ {
+ 	struct wcd939x_priv *wcd = dev_get_drvdata(comp->dev);
+ 
+-	if (jack)
++	if (jack) {
++		/*
++		 * MBHC can only report while the SoundWire devices stay
++		 * resumed: suspending them lets the link stop its clock, and
++		 * the codec's interrupt then has nowhere to go - detection
++		 * goes completely silent even though MBHC itself is armed and
++		 * powered. Hold them up for as long as a jack is registered.
++		 */
++		pm_runtime_forbid(wcd->rxdev);
++		pm_runtime_forbid(wcd->txdev);
++
+ 		return wcd_mbhc_start(wcd->wcd_mbhc, &wcd->mbhc_cfg, jack);
++	}
+ 
+ 	wcd_mbhc_stop(wcd->wcd_mbhc);
+ 
++	pm_runtime_allow(wcd->txdev);
++	pm_runtime_allow(wcd->rxdev);
++
+ 	return 0;
+ }
+ 

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
@@ -1,0 +1,32 @@
+From: Anze <aanzdev@gmail.com>
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: set swr1 PCM port mask
+
+The WCD939x HPH PCM ("HiFi") path carries the headphone stream as
+384 kHz PCM on SoundWire master port 9, and the qcom controller only
+enables the PCM data port format for the ports listed in
+qcom,pcm-ports-mask. Without it the codec waits for PCM on port 9 and
+nothing ever arrives: turning on the HPH PCM mode kcontrols gives
+complete silence on the jack instead of the PDM path's constant hiss.
+
+The AYN swr1 node is otherwise identical to the KONKR Pocket FIT
+Elite's, which carries this property, and the RX port mapping already
+ends on port 9. The property is inert unless the HPH PCM mode
+kcontrols are enabled, so it changes nothing on its own.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -1035,6 +1035,12 @@
+ &swr1 {
+ 	status = "okay";
+
++	/* Master port 9 carries the WCD939x HIFI_PCM headphone stream
++	 * (384 kHz PCM), so the controller needs its per-port PCM format
++	 * enable set for it. Inert unless the HPH PCM mode kcontrols are
++	 * enabled. */
++	qcom,pcm-ports-mask = <0x200>;
++
+ 	wcd_rx: codec@0,4 {
+ 		compatible = "sdw20217010e00";
+ 		reg = <0 4>;

--- a/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8750/0001_SM8750-AYN-Odin3.patch
+++ b/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8750/0001_SM8750-AYN-Odin3.patch
@@ -40,7 +40,7 @@ new file mode 100644
 index 0000000..dc5211e
 --- /dev/null	2026-04-26 12:20:14.913728837 +0800
 +++ b/ucm2/AYN/Odin3/HiFi.conf	2026-04-26 13:58:49.334297133 +0800
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,61 @@
 +# Use case configuration for AYN SM8750
 +# Author: Teguh Sobirin <teguh@sobir.in>
 +
@@ -72,10 +72,25 @@ index 0000000..dc5211e
 +SectionDevice."Headphones" {
 +	Comment "Headphones playback"
 +
-+	Include.wcdhpe.File "/codecs/wcd939x/HeadphoneEnableSeq.conf"
-+	Include.wcdhpd.File "/codecs/wcd939x/HeadphoneDisableSeq.conf"
++	# rx-macro routing first, then the PCM mode flags, then the wcd939x
++	# bring-up: the HPH and COMP switches connect their SoundWire ports
++	# when set, so the mode has to be in place before they come up.
 +	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
++
++	EnableSequence [
++		cset "name='HPH PCM Switch' 1"
++		cset "name='RX_HPH PCM Switch' 1"
++	]
++
++	Include.wcdhpe.File "/codecs/wcd939x/HeadphoneEnableSeq.conf"
++
++	Include.wcdhpd.File "/codecs/wcd939x/HeadphoneDisableSeq.conf"
 +	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
++
++	DisableSequence [
++		cset "name='HPH PCM Switch' 0"
++		cset "name='RX_HPH PCM Switch' 0"
++	]
 +
 +	Value {
 +		PlaybackChannels 2

--- a/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8750/0001_SM8750-AYN-Odin3.patch
+++ b/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/SM8750/0001_SM8750-AYN-Odin3.patch
@@ -40,7 +40,7 @@ new file mode 100644
 index 0000000..dc5211e
 --- /dev/null	2026-04-26 12:20:14.913728837 +0800
 +++ b/ucm2/AYN/Odin3/HiFi.conf	2026-04-26 13:58:49.334297133 +0800
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,46 @@
 +# Use case configuration for AYN SM8750
 +# Author: Teguh Sobirin <teguh@sobir.in>
 +
@@ -81,25 +81,6 @@ index 0000000..dc5211e
 +		PlaybackChannels 2
 +		PlaybackPriority 200
 +		PlaybackPCM "hw:${CardId},1"
-+		PlaybackMixer "default:${CardId}"
-+		PlaybackMixerElem "HP Digital"
-+		JackControl "Headphone Jack"
-+		JackHWMute "Speaker"
-+	}
-+}
-+
-+SectionDevice."Headphones" {
-+	Comment "Headphones playback"
-+
-+	Include.wcdhpe.File "/codecs/wcd939x/HeadphoneEnableSeq.conf"
-+	Include.wcdhpd.File "/codecs/wcd939x/HeadphoneDisableSeq.conf"
-+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
-+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
-+
-+	Value {
-+		PlaybackChannels 2
-+		PlaybackPriority 200
-+		PlaybackPCM "hw:${CardId},0"
 +		PlaybackMixer "default:${CardId}"
 +		PlaybackMixerElem "HP Digital"
 +		JackControl "Headphone Jack"


### PR DESCRIPTION
## Summary

The 3.5mm headphone jack has never worked on the AYN Odin 3: plugging headphones is not detected and the sound stays on the speaker. Three independent faults, one commit each:

* the UCM profile declares `SectionDevice."Headphones"` twice, the later block pointing at the speaker's PCM;
* the wcd939x autosuspends 1s after probe, so the SoundWire link clock-stops and MBHC can never signal an insertion;
* the legacy PDM output path hisses constantly and is unbalanced. The codec's HPH PCM ("HiFi") mode, added for the KONKR Pocket FIT Elite, fixes both, but needs `qcom,pcm-ports-mask` on `&swr1` plus the right UCM ordering.

## Testing

* Built and flashed on an AYN Odin 3.
* Headphones detected on insert: impedance read on both channels (41 / 43 ohms), stereo plug type resolved, `SW_HEADPHONE_INSERT` set.
* Clean stereo audio in Steam and in Kodi, no hiss, balanced channels.
* Speaker path unchanged.

## Additional Context

The kernel patch also covers the KONKR Pocket FIT Elite, whose `040-headphone-mbhc-wake` quirk pins the same two SoundWire devices from userspace; that quirk becomes redundant. Pinning the two SoundWire *controllers*, which the quirk also does, proved unnecessary on device — they stay runtime-managed and detection still works.

Everything is scoped to the Odin 3 except the wcd939x patch, which only takes effect while a jack is registered.

---

### AI Usage

**Did you use AI tools to help write this code?** YES
