### PR TITLE
moonlight: fix touchscreen input on hosts without native touch

### DIFF
--- a/projects/ROCKNIX/packages/apps/moonlight/patches/moonlight-0001-fix-touchscreen-without-native-touch.patch
+++ b/projects/ROCKNIX/packages/apps/moonlight/patches/moonlight-0001-fix-touchscreen-without-native-touch.patch
@@ -1,0 +1,58 @@
+From 2ea4ce664afefbcad1a767a1b21e6836fafc8368 Mon Sep 17 00:00:00 2001
+From: Edouard Durand <edouard.durand@gmail.com>
+Date: Sat, 1 Aug 2026 10:10:59 +0800
+Subject: [PATCH] sdl: fix touchscreen input on hosts without native touch
+ support
+
+---
+ src/input/sdl.c | 30 ++++++++++++++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)
+
+diff --git a/src/input/sdl.c b/src/input/sdl.c
+index 72a2a3e..9ef8b18 100644
+--- a/src/input/sdl.c
++++ b/src/input/sdl.c
+@@ -432,6 +432,12 @@ static void remove_gamepad(SDL_JoystickID sdl_id) {
+ void sdlinput_init(char* mappings) {
+   memset(gamepads, 0, sizeof(gamepads));
+ 
++  // Touch is handled above, either natively or by emulating the mouse there.
++  // Letting SDL also synthesise mouse events from touch moves its internal
++  // cursor, and the compositor then re-reports the real pointer once the touch
++  // ends, which arrives as a large spurious motion.
++  SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
++
+   SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER);
+ #if !SDL_VERSION_ATLEAST(2, 0, 9)
+   SDL_InitSubSystem(SDL_INIT_HAPTIC);
+@@ -542,8 +548,28 @@ int sdlinput_handle_event(SDL_Window* window, SDL_Event* event) {
+     event->tfinger.x = SDL_max(SDL_min(1.0f, event->tfinger.x), 0.0f);
+     event->tfinger.y = SDL_max(SDL_min(1.0f, event->tfinger.y), 0.0f);
+ 
+-    LiSendTouchEvent(touchEventType, event->tfinger.fingerId, event->tfinger.x, event->tfinger.y,
+-                     event->tfinger.pressure, 0.0f, 0.0f, LI_ROT_UNKNOWN);
++    if (LiSendTouchEvent(touchEventType, event->tfinger.fingerId, event->tfinger.x, event->tfinger.y,
++                         event->tfinger.pressure, 0.0f, 0.0f, LI_ROT_UNKNOWN) == LI_ERR_UNSUPPORTED) {
++      // The host has no native touch support, so drive the mouse instead.
++      int w, h;
++      SDL_GetWindowSize(window, &w, &h);
++
++      // A touchscreen is absolute, so position the pointer where the finger is
++      // rather than following the mouse capture mode.
++      switch (event->type) {
++      case SDL_FINGERDOWN:
++        LiSendMousePositionEvent(event->tfinger.x * w, event->tfinger.y * h, w, h);
++        LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
++        break;
++      case SDL_FINGERMOTION:
++        LiSendMousePositionEvent(event->tfinger.x * w, event->tfinger.y * h, w, h);
++        break;
++      case SDL_FINGERUP:
++        // Deliberately no movement here: a release carries no new position.
++        LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
++        break;
++      }
++    }
+     break;
+   case SDL_CONTROLLERAXISMOTION:
+     gamepad = get_gamepad(event->caxis.which, false);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the touchscreen usable in Moonlight. Right now the pointer follows your finger while you drag, then jumps somewhere else the moment you lift it, and tapping does not move the pointer at all.

**This is meant as a temporary carry.** I have opened the same fix upstream at https://github.com/moonlight-stream/moonlight-embedded/pull/938. If you would rather wait for that to be merged than carry a patch, that is completely fair, and this can be closed. I am proposing it here because upstream can be slow to move on input changes, the equivalent X11 cursor-jump fix in moonlight-stream/moonlight-embedded#834 has been open since 2021, and the touchscreen is unusable in the meantime. Drop the patch once the pin in `package.mk` moves past the merge.

Moonlight calls `LiSendTouchEvent()` for every finger event and ignores the return value. On a host that does not support native touch it returns `LI_ERR_UNSUPPORTED` and nothing is sent, which is the case `Limelight.h` tells you to handle:

> If unsupported by the host, this will return LI_ERR_UNSUPPORTED and the caller should consider falling back to mouse emulation

There is no such fallback upstream. Touch only appears to work because SDL is separately turning it into mouse events, and that has a side effect: SDL drags its own cursor along with your finger, so when the touch ends the compositor re-reports the real pointer as one large motion event. Moonlight streams with relative mouse mode, so that goes out as a delta and throws the host pointer across the screen.

The patch adds the documented fallback and turns off SDL's synthesis, so touch has one path instead of two fighting each other. It also treats touch as absolute, since a touchscreen reports where your finger is rather than how far it moved.

`src/input/sdl.c` is identical between the pinned `a6bf715` and current upstream master, so the patch applies cleanly to what we build today and will keep applying if the pin moves before the upstream PR lands.

## Testing

* **How was this tested?** On an AYN Odin 2 (SM8550) running ROCKNIX 20260801, streaming to Sunshine.

  1. Reproduced the problem on the stock build first.
  2. Cross-compiled moonlight with the patch and ran it from `/storage` so the system binary stayed untouched.
  3. Compared against an unpatched build of the same upstream commit, so I could be sure the fix was doing the work and not something else.
  4. Tapped, dragged, and released, checking each time.

* **Test results:** Taps now land where you touch, drags track the finger, and letting go leaves the pointer alone.

  The host in question returns `LI_ERR_UNSUPPORTED` for every touch event, 2015 out of 2015 in a logged session, so this is the path being used. With SDL's touch synthesis left on, the spurious event after each release carried `xrel=-740 yrel=173`. With it off the same event still arrives but carries `xrel=0 yrel=0`, which is why it stops mattering.

  I only have the one device, and no host with native touch support to try the other path on.

## Additional Context

* **Add any other information that might be helpful for the reviewer**
  * Only affects hosts without native touch support. Where the host does support it, `LiSendTouchEvent()` succeeds and none of the patched code runs.
  * The patch lands in `projects/ROCKNIX/packages/apps/moonlight/patches/`, which `scripts/unpack` already applies, so no change to `package.mk` is needed.
  * Worth doing separately: the pinned moonlight is `a6bf715` from September 2024, and v2.7.1 since then brings a `moonlight-common-c` protocol update plus fixes for high latency connections. That will not affect this bug, but it is overdue.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES

Reviewed with Claude Code. I also used it to automate the local cross-build so I could test on device, and to look back over the change for anything worth improving.
