### PR TITLE
sleep: keep the same Wi-Fi network across suspend/resume

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/wifictl
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/wifictl
@@ -115,6 +115,35 @@ destroy_adhoc() {
   "${NMCLI}" device set "${WIFI_DEV}" managed yes >/dev/null 2>&1
 }
 
+# Prefer the network currently in use for the next automatic connection. On
+# resume the radio is only rfkill-unblocked, so NetworkManager autoconnect
+# chooses among every saved profile and can join a different access point than
+# the one in use -- often on another subnet, silently moving the device and
+# dropping whatever was connected. The same applies at boot. Raising the
+# priority of the active profile makes NM try that one first.
+#
+# Priority only, deliberately: every profile keeps autoconnect enabled, so a
+# preferred network that is out of range just loses to whatever is in range.
+# Turning autoconnect off on the others would pin harder but strand the device
+# on a network it can no longer see. With no active connection there is nothing
+# to prefer, and the priorities from the previous call still stand.
+pin_wifi() {
+  local active name
+
+  active=$("${NMCLI}" -t -f GENERAL.CONNECTION device show "${WIFI_DEV}" 2>/dev/null | cut -d: -f2-)
+  [ -z "${active}" ] && return 0
+
+  "${NMCLI}" -t -f NAME,TYPE connection show 2>/dev/null |
+    awk -F: '$2 ~ /wireless/ {print $1}' |
+    while IFS= read -r name; do
+      if [ "${name}" = "${active}" ]; then
+        "${NMCLI}" connection modify "${name}" connection.autoconnect-priority 100 >/dev/null 2>&1
+      else
+        "${NMCLI}" connection modify "${name}" connection.autoconnect-priority 0 >/dev/null 2>&1
+      fi
+    done
+}
+
 has_ap_mode() {
   wait_for_wifi
 
@@ -132,6 +161,9 @@ case "${1}" in
     ;;
   disable)
     rfkill block wifi
+    ;;
+  pin)
+    pin_wifi
     ;;
   connect)
     if [ "${WIFI_TYPE}" = "1" ] && \

--- a/projects/ROCKNIX/packages/sysutils/sleep/sources/sleep.sh
+++ b/projects/ROCKNIX/packages/sysutils/sleep/sources/sleep.sh
@@ -84,6 +84,11 @@ quirks() {
 case $1 in
   pre)
     if [ "$(get_setting wifi.enabled)" == "1" ]; then
+      # while still associated, so resume rejoins this network and not
+      # whichever saved profile NM happens to pick first
+      log $0 "Preferring the active WIFI network on reconnect."
+      wifictl pin >${EVENTLOG} 2>&1
+
       log $0 "Disabling WIFI."
       nohup wifictl disable >${EVENTLOG} 2>&1
     fi


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

when multiple wifi networks are saved and in range at the same time, after suspend/resume, the device will not reconnect to the same one, instead it will connect to whatever network it likes most. i believe it should reconnect to the network it was connected to before it entered sleep/reboot.

e.g. network A and B are saved. currently connected to A. you reboot, it auto connects to B, not A.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

tested in my konkr pocket fit elite. it's a bit difficult to test because es will not reflect the currently connected network in its settings, so you may connect to B, then to A (to have both saved), the ui will show A. then you suspend, resume, and see es show the ssid for A, even though its connected to B!

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

this came up in the my pr for konkr pocket fit elite support and i was told to make it available for all devices, so here we are. i only have the konkr, so i could not test this (bug or fix) anywhere else. i tried looking for existing reports of someone running into this, but couldn't find any.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

yes, heavy use of claude
