### PR TITLE
rpcs3-sa: update to 0.0.42-19677

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
@@ -7,8 +7,8 @@ PKG_SITE="https://github.com/RPCS3/rpcs3-binaries-linux"
 PKG_DEPENDS_TARGET="toolchain libevdev SDL2 qt6 mesa libcom-err"
 PKG_LONGDESC="PS3 Emulator appimage"
 PKG_TOOLCHAIN="manual"
-PKG_VERSION="7a90d09cfe3c31bf95c3cb63c6301c5c0824c531"
-PKG_REL_VERSION="0.0.41-19607-7a90d09c"
+PKG_VERSION="f113e7bbbc6b3c959416da324c0840bfe2269a8b"
+PKG_REL_VERSION="0.0.42-19677-f113e7bb"
 
 case ${TARGET_ARCH} in
   x86_64)


### PR DESCRIPTION
## Summary

Bump rpcs3-sa standalone emulator version to 0.0.42-19677.

## Testing

Verified package version bump compiles and formats correctly in package build variables.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

No just updated the version & package build 
