### PR TITLE
SM8550: fix sn3112 probe crash and re-enable the Odin 2 stick LEDs

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-odin2.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayn-odin2.dts
@@ -197,7 +197,6 @@
 		sdb-gpios = <&tlmm 55 GPIO_ACTIVE_LOW>;
 		vdd-supply = <&vdd_mcu_3v3>;
 		#pwm-cells = <1>;
-		status = "disabled";
 	};
 };
 
@@ -244,7 +243,6 @@
 		sdb-gpios = <&tlmm 56 GPIO_ACTIVE_LOW>;
 		vdd-supply = <&vdd_mcu_3v3>;
 		#pwm-cells = <1>;
-		status = "disabled";
 	};
 };
 

--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0054_sn3112-pwm-driver.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0054_sn3112-pwm-driver.patch
@@ -9,8 +9,8 @@ Signed-off-by: BigfootACA <bigfoot@classfun.cn>
 ---
  drivers/pwm/Kconfig      |  10 ++
  drivers/pwm/Makefile     |   1 +
- drivers/pwm/pwm-sn3112.c | 351 +++++++++++++++++++++++++++++++++++++++
- 3 files changed, 362 insertions(+)
+ drivers/pwm/pwm-sn3112.c | 348 +++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 359 insertions(+)
  create mode 100644 drivers/pwm/pwm-sn3112.c
 
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
@@ -51,7 +51,7 @@ new file mode 100644
 index 0000000000000..38ef948602a3c
 --- /dev/null
 +++ b/drivers/pwm/pwm-sn3112.c
-@@ -0,0 +1,351 @@
+@@ -0,0 +1,348 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Driver for SN3112 12-channel 8-bit PWM LED controller
@@ -126,14 +126,11 @@ index 0000000000000..38ef948602a3c
 +	else
 +		return -EINVAL;
 +
-+	dev_dbg(priv->pdev, "channel %u enabled %u\n", channel, enabled);
-+	dev_dbg(priv->pdev, "reg %u bit %u\n", reg, bit);
++	/* not set_bit(): a u8 array is not aligned for the 64-bit atomic */
 +	if (enabled)
-+		set_bit(bit, (ulong *)&priv->pwm_en_reg[reg]);
++		priv->pwm_en_reg[reg] |= BIT(bit);
 +	else
-+		clear_bit(bit, (ulong *)&priv->pwm_en_reg[reg]);
-+	dev_dbg(priv->pdev, "set enable reg %u to %u\n", reg,
-+		priv->pwm_en_reg[reg]);
++		priv->pwm_en_reg[reg] &= ~BIT(bit);
 +
 +	if (!write)
 +		return 0;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the root cause of the AYN Odin 2 boot failure that #2981 worked around, and restore the analog stick and side LEDs that the workaround disabled.

`sn3112_set_en_reg()` calls `set_bit()` on a `uint8_t pwm_en_reg[3]` cast to `unsigned long *`. On arm64 that emits an LSE atomic (`stset`), which faults unless the address is 8-byte aligned. It is also an out-of-bounds access, since an 8-byte atomic on a 3-byte array runs past the end.

The bug has always been there, but the offset of `pwm_en_reg` inside `struct sn3112` depends on the members ahead of it. The 7.1.2 bump moved it to offset 60, which is 4-byte aligned, so probe started faulting on the very first channel:

```
sn3112-pwm 2-0054: supply vdd not found, using dummy regulator
Unable to handle kernel paging request at virtual address ffff000815169abc
  ESR = 0x0000000096000021
  FSC = 0x21: alignment fault
Internal error: Oops: 0000000096000021 [#1] SMP
Hardware name: AYN Odin 2 (DT)
pc : sn3112_set_en_reg+0x128/0x1b0
lr : sn3112_pwm_probe+0x144/0x35c
Call trace:
 sn3112_set_en_reg+0x128/0x1b0 (P)
 sn3112_pwm_probe+0x144/0x35c
 i2c_device_probe+0x194/0x420
```

`x19` is `priv` at `ffff000815169a80`, the faulting `x0` is `priv + 0x3c` (60), and `x4` is `BIT(3)`, so it dies on channel 0 before touching i2c.

The fix uses plain bitwise ops. No atomic is needed: `pwm_en_reg` is only touched under `priv->lock` in `sn3112_pwm_apply()`, and during `probe()` before the chip is registered.

With the driver fixed, the `status = "disabled"` workaround on both `sn3112@54` nodes is no longer needed and is dropped, which brings the LEDs back.

## Testing

* **How was this tested?** Built `ROCKNIX-SM8550.aarch64-20260804` from `next` plus this commit and flashed it on an AYN Odin 2.

* **Test results:**

Before, on stock 20260801, all four LED zones were stuck forever:

```
# cat /sys/kernel/debug/devices_deferred
led-controller-1	leds_pwm_multicolor: unable to request PWM
led-controller-2	leds_pwm_multicolor: unable to request PWM
led-controller-3	leds_pwm_multicolor: unable to request PWM
led-controller-4	leds_pwm_multicolor: unable to request PWM
```

After this change, both controllers probe and the zones appear:

```
[    0.829280] sn3112-pwm 2-0054: Found SI-EN SN3112 12-channel 8-bit PWM LED controller
[    0.855567] sn3112-pwm 3-0054: Found SI-EN SN3112 12-channel 8-bit PWM LED controller

# ls /sys/class/leds/
left-joystick  left-side  power-led  right-joystick  right-side  ...

# cat /sys/kernel/debug/devices_deferred
(empty)
```

Verified on the flashed device:

* boots normally, so the workaround is no longer required
* no alignment fault or oops anywhere in dmesg
* `2-0054` and `3-0054` bound to `sn3112-pwm`
* the ROCKNIX LED service drives the zones at boot again
* stick and side LEDs confirmed visually, including a red/green/blue/white cycle written through `/sys/class/leds/*/multi_intensity`

The crash can be reproduced on a stock image without reflashing, since the DT nodes are disabled but the buses are live (DT `&i2c0` is Linux `i2c-2`, `&i2c12` is `i2c-3`):

```
echo sn3112 0x54 > /sys/bus/i2c/devices/i2c-2/new_device
```

## Additional Context

* Scope is limited to the Odin 2: it is the only device with `si-en,sn3112-pwm` nodes, and the driver patch is SM8550 only.
* This effectively reverts the DT half of commit `b03cdb9` ("odin2: fix boot", #2981). The probe hardening from that same commit (SDB settle delay, retry loop, regulator unwind on error) is kept as is.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
