### PR TITLE
network: add sing-box package (VLESS/Reality tun VPN)

### DIFF
--- a/distributions/ROCKNIX/options
+++ b/distributions/ROCKNIX/options
@@ -98,6 +98,9 @@
 # build and install WireGuard support (yes / no)
   WIREGUARD_SUPPORT="yes"
 
+# build and install sing-box support (yes / no)
+  SINGBOX_SUPPORT="yes"
+
 # build and install diskmounter support (udevil)
 # this service provide auto mounting support for external drives in the
 # mediacenter also automount internally drives at boottime via udev (yes / no)

--- a/projects/ROCKNIX/packages/network/sing-box/README.md
+++ b/projects/ROCKNIX/packages/network/sing-box/README.md
@@ -1,0 +1,31 @@
+# sing-box (ROCKNIX package)
+
+[sing-box](https://sing-box.sagernet.org/) — universal proxy platform. Provides an
+obfuscation-capable client (VLESS/Reality, AmneziaWG, WireGuard, Shadowsocks,
+Hysteria2, TUIC) with a `tun` transparent-routing mode, so the whole device can
+route through a censorship-resistant tunnel where plain WireGuard is DPI-blocked.
+
+Integrated like `tailscale`/`zerotier-one`:
+
+* binary installed to `/usr/sbin/sing-box`
+* started by the autostart daemon `004-sing-box` when the setting `singbox.up` is `1`
+* systemd unit `sing-box.service`
+
+## Configuration
+
+Place your config at:
+
+```
+/storage/.config/sing-box/config.json
+```
+
+A template ships at `/usr/config/sing-box/config.json.sample` (copied to
+`/storage/.config/sing-box/` on first boot). Fill in your provider's values
+(server, uuid, Reality public key / short id, SNI, gRPC service name), then
+enable the **sing-box** toggle in *Network Settings* (or `set_setting singbox.up 1`).
+
+Validate a config before enabling:
+
+```
+sing-box check -c /storage/.config/sing-box/config.json
+```

--- a/projects/ROCKNIX/packages/network/sing-box/config/config.json.sample
+++ b/projects/ROCKNIX/packages/network/sing-box/config/config.json.sample
@@ -1,0 +1,57 @@
+{
+  "log": { "level": "info", "timestamp": true },
+  "dns": {
+    "servers": [
+      { "type": "https", "tag": "proxy-dns", "server": "1.1.1.1", "detour": "proxy-out" },
+      { "type": "udp", "tag": "direct-dns", "server": "8.8.8.8", "detour": "direct" }
+    ],
+    "rules": [
+      { "domain_suffix": ["YOUR_VPN_SERVER_DOMAIN"], "server": "direct-dns" }
+    ],
+    "final": "proxy-dns"
+  },
+  "inbounds": [
+    {
+      "type": "tun",
+      "tag": "tun-in",
+      "interface_name": "singbox0",
+      "address": ["172.19.0.1/30"],
+      "auto_route": true,
+      "strict_route": true,
+      "stack": "system"
+    }
+  ],
+  "outbounds": [
+    {
+      "type": "vless",
+      "tag": "proxy-out",
+      "server": "SERVER_HOST",
+      "server_port": 443,
+      "uuid": "YOUR_UUID",
+      "packet_encoding": "xudp",
+      "tls": {
+        "enabled": true,
+        "server_name": "SNI_HOST",
+        "alpn": ["h2"],
+        "utls": { "enabled": true, "fingerprint": "firefox" },
+        "reality": {
+          "enabled": true,
+          "public_key": "REALITY_PUBLIC_KEY",
+          "short_id": "REALITY_SHORT_ID"
+        }
+      },
+      "transport": { "type": "grpc", "service_name": "GRPC_SERVICE_NAME" }
+    },
+    { "type": "direct", "tag": "direct" }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": { "server": "direct-dns" },
+    "rules": [
+      { "action": "sniff" },
+      { "protocol": "dns", "action": "hijack-dns" },
+      { "ip_is_private": true, "outbound": "direct" }
+    ],
+    "final": "proxy-out"
+  }
+}

--- a/projects/ROCKNIX/packages/network/sing-box/daemons/004-sing-box
+++ b/projects/ROCKNIX/packages/network/sing-box/daemons/004-sing-box
@@ -1,0 +1,3 @@
+STATE=$(get_setting singbox.up)
+SVC="sing-box"
+DAEMONS=("sing-box")

--- a/projects/ROCKNIX/packages/network/sing-box/package.mk
+++ b/projects/ROCKNIX/packages/network/sing-box/package.mk
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="sing-box"
+PKG_VERSION="1.13.15"
+PKG_SITE="https://sing-box.sagernet.org/"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Universal proxy platform (VLESS/Reality, WireGuard, AmneziaWG, Shadowsocks, Hysteria2) with a tun transparent-routing mode."
+PKG_TOOLCHAIN="manual"
+
+case ${TARGET_ARCH} in
+  aarch64)
+    SB_ARCH="linux-arm64"
+    PKG_SHA256="f0810bbb5722ae36635687c421019defcc8b328d31a0b3c287901f331747ca93"
+  ;;
+  x86_64)
+    SB_ARCH="linux-amd64"
+    PKG_SHA256="a3a3ff223b23c3f4731d0a17cb0ef94c97ce257c70721a5b07dc7ca079203c9f"
+  ;;
+esac
+
+PKG_URL="https://github.com/SagerNet/sing-box/releases/download/v${PKG_VERSION}/sing-box-${PKG_VERSION}-${SB_ARCH}.tar.gz"
+
+pre_unpack() {
+  mkdir -p ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz \
+      -C ${PKG_BUILD} sing-box-${PKG_VERSION}-${SB_ARCH}
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/sbin
+    cp ${PKG_BUILD}/sing-box ${INSTALL}/usr/sbin/
+
+  mkdir -p ${INSTALL}/usr/config/sing-box
+    cp ${PKG_DIR}/config/config.json.sample ${INSTALL}/usr/config/sing-box/
+}

--- a/projects/ROCKNIX/packages/network/sing-box/system.d/sing-box.service
+++ b/projects/ROCKNIX/packages/network/sing-box/system.d/sing-box.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=sing-box universal proxy (VLESS tun)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStartPre=/usr/sbin/sing-box check -c /storage/.config/sing-box/config.json
+ExecStart=/usr/sbin/sing-box run -c /storage/.config/sing-box/config.json
+Restart=on-failure
+RestartSec=5
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
+
+[Install]
+WantedBy=multi-user.target

--- a/projects/ROCKNIX/packages/virtual/network/package.mk
+++ b/projects/ROCKNIX/packages/virtual/network/package.mk
@@ -35,6 +35,10 @@ if [ "${ZEROTIER_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} zerotier-one"
 fi
 
+if [ "${SINGBOX_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} sing-box"
+fi
+
 # nss needed by inputstream.adaptive, chromium etc.
 if [ "${TARGET_ARCH}" = "x86_64" ] || [ "${TARGET_ARCH}" = "arm" ]; then
   PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} nss"


### PR DESCRIPTION
## What
Adds `sing-box` as a ROCKNIX network package, wired in like `tailscale` / `zerotier`:
- Prebuilt upstream binary v1.13.15 to `/usr/sbin/sing-box` (aarch64 + x86_64, SHA256-pinned).
- Autostart daemon `daemons/004-sing-box`, gated by the `singbox.up` setting.
- `sing-box.service`: `sing-box check` pre-start, runs `-c /storage/.config/sing-box/config.json`, `Restart=on-failure`, `CAP_NET_ADMIN` / `CAP_NET_RAW` only.
- Sample config (placeholders only) + README.
- `SINGBOX_SUPPORT` distro-wide, pulled in by the `network` virtual package.

## Why
sing-box is an obfuscation-capable proxy client (VLESS/REALITY, AmneziaWG, WireGuard, Shadowsocks, Hysteria2) with TUN transparent routing. On links where plain WireGuard is DPI-blocked, and where the menu `wg-quick` path is not usable, it is a working way to route the device through a VPN (e.g. to reach Steam/FEX servers for Install Steam on restricted connections).

## Testing
Built for SM8750, flashed on a KONKR Pocket FIT Elite (AYANEO, `sun`):
- `/usr/sbin/sing-box` present; `sing-box check` passes a VLESS+REALITY+gRPC TUN config.
- `set_setting singbox.up 1` + `systemctl start sing-box` brings the service up; external IP resolves to the VPN exit, tunnel carries traffic and re-arms on boot via `singbox.up`.

## UI toggle
A matching switch in the VPN SERVICES menu: https://github.com/ROCKNIX/emulationstation-next/pull/25
