### PR TITLE
SM8550/SM8650: build the extra-firmware package

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/options
+++ b/projects/ROCKNIX/devices/SM8550/options
@@ -60,7 +60,7 @@
   # Additional Firmware to use ( )
   # Space separated list is supported,
   # e.g. FIRMWARE=""
-    FIRMWARE=""
+    FIRMWARE="extra-firmware"
 
   # Additional packages to install
     ADDITIONAL_PACKAGES="gamepadcalibration rocknix-abl inputplumber"

--- a/projects/ROCKNIX/devices/SM8650/options
+++ b/projects/ROCKNIX/devices/SM8650/options
@@ -50,7 +50,7 @@
   # Additional Firmware to use ( )
   # Space separated list is supported,
   # e.g. FIRMWARE=""
-    FIRMWARE=""
+    FIRMWARE="extra-firmware"
 
   # Additional packages to install
     ADDITIONAL_PACKAGES="rocknix-abl inputplumber"


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Restore the SM8550 and SM8650 firmware that stopped being installed after 14ab5da808f53de6a13bbff826582b213f2df860 ("extra-firmware: bump package and move sm8550/sm8650 firmware").

That commit moved both platforms' firmware out of `projects/ROCKNIX/devices/<DEVICE>/filesystem` and into the `extra-firmware` package, and added the matching `SM8550` and `SM8650` cases to its `makeinstall_target`. What is missing is the other half: neither device pulls the package in.

`packages/virtual/linux-firmware/package.mk` depends on it through:

```
PKG_DEPENDS_TARGET="toolchain ${FIRMWARE}"
```

and both devices still carry `FIRMWARE=""`, so `extra-firmware` is never built and the files it now owns are simply absent from the image. For comparison, SM8250 and SM6115 set `FIRMWARE="extra-firmware"`, and SM8750 lists it in `ADDITIONAL_PACKAGES`.

This sets `FIRMWARE="extra-firmware"` on SM8550 and SM8650, two lines total.

## Testing

Built `next` (833140ed91f) for SM8550 and flashed to an AYN Odin 2.

**Before (current next).** `extra-firmware` has no build dir, no `install_pkg`, zero installed files, and no mention anywhere in the build log. The image contains zero files matching `WCN7850` and zero under `qcom/sm8550/ayn/odin2`. On the device, `/usr/lib/firmware/ath12k/WCN7850/hw2.0/` does not exist, and dmesg shows:

```
mhi mhi0: Direct firmware load for ath12k/WCN7850/hw2.0/amss.bin failed with error -2
ath12k_wifi7_pci 0000:01:00.0: failed to set mhi state: POWER_ON(2)
ath12k_wifi7_pci 0000:01:00.0: failed to power up :-110
ath12k_wifi7_pci 0000:01:00.0: probe with driver ath12k_wifi7_pci failed with error -110

remoteproc remoteproc0: Direct firmware load for qcom/sm8550/ayn/odin2/adsp.mbn failed with error -2
remoteproc remoteproc0: request_firmware failed: -2
remoteproc remoteproc1: Direct firmware load for qcom/sm8550/ayn/cdsp.mbn failed with error -2
```

Symptoms: wifi is enabled but never associates and gets no address, and `/sys/class/power_supply/battery/capacity` is empty so the battery reads 0 percent in ES. `cdsp.mbn` is missing as well.

**After (this PR).** Same tree with the two lines changed:

```
extra-firmware install_pkg files:  123
ath12k WCN7850 files in image:       4   (amss.bin, board-2.bin, m3.bin, regdb.bin)
qcom/sm8550/ayn/odin2 files:        21   (includes adsp.mbn and battmgr.jsn)
```

Flashed to the Odin 2. `/usr/lib/firmware/ath12k/WCN7850/hw2.0/` now holds all four files, and the remoteproc failures are gone:

```
remoteproc remoteproc1: Booting fw image qcom/sm8550/ayn/cdsp.mbn, size 7086504
remoteproc remoteproc0: Booting fw image qcom/sm8550/ayn/odin2/adsp.mbn, size 28330328
remoteproc remoteproc1: remote processor cdsp is now up
remoteproc remoteproc0: remote processor adsp is now up
```

ath12k probes cleanly, wifi associates and holds a DHCP lease, and the battery reports again:

```
wlan0:wifi:connected
/sys/class/power_supply/battery/capacity -> 100
/sys/class/power_supply/battery/status   -> Charging
```

## Additional Context

* Every SM8550 device is affected (AYN Odin 2 and Odin 2 Portal, AYN Thor, Retroid Pocket 6, AYANEO SM8550 models), so nightlies built from `next` since 3 August ship with no wifi, no battery reporting and no audio.
* SM8650 has the same `FIRMWARE=""` and additionally loses the gen70900 GPU firmware (`gen70900_aqe.fw`, `gen70900_sqe.fw`, `gmu_gen70900.bin`, `gen70900_zap.mbn`), so it is included here. I do not have SM8650 hardware, so that half is verified by inspection only and would benefit from a second pair of eyes.
* No change to the `extra-firmware` package itself; the copy cases added in 14ab5da are correct and work as soon as the package is actually built.
* cc @spycat88 as the author of 14ab5da, which went straight to `next` so there is no merge PR to reference.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY
