### PR TITLE
SM8550: mask the IPCC mailbox irq on suspend (parity with SM8750)

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0502-wakeup-qcom-ipcc-remove-IRQF-NO-SUSPEND.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0502-wakeup-qcom-ipcc-remove-IRQF-NO-SUSPEND.patch
@@ -1,0 +1,32 @@
+From: Ashketchup <ashley@shuuri.net>
+Subject: [PATCH] wakeup: qcom-ipcc: remove IRQF_NO_SUSPEND across system suspend
+
+The SM8550 deep-sleep self-wake (every few minutes) is the ADSP charger firmware
+pushing BATTMGR_NOTIFICATION over pmic_glink. Those notifications ring the IPCC
+mailbox IRQ, which is requested with IRQF_NO_SUSPEND and so is never masked across
+system suspend, pulling the SoC back out of deep sleep.
+
+Drop IRQF_NO_SUSPEND so the IPCC IRQ is masked during suspend like a normal IRQ.
+Co-processor doorbells (charger, sensors, modem) no longer wake the AP while it is
+asleep; pending signals are handled on resume instead. This mirrors the patch
+ROCKNIX already carries for SM8750, which uses the same battmgr/pmic_glink charger
+model and sleeps reliably with it.
+
+Verified on the Retroid Pocket 6: 30+ minute uninterrupted deep sleeps where
+the device previously could not stay asleep past 5 to 10 minutes.
+
+Signed-off-by: Ashketchup <ashley@shuuri.net>
+---
+diff --git a/drivers/mailbox/qcom-ipcc.c b/drivers/mailbox/qcom-ipcc.c
+index d957d989c..2e4bb5efb 100644
+--- a/drivers/mailbox/qcom-ipcc.c
++++ b/drivers/mailbox/qcom-ipcc.c
+@@ -321,7 +321,7 @@ static int qcom_ipcc_probe(struct platform_device *pdev)
+ 		goto err_mbox;
+ 
+ 	ret = devm_request_irq(&pdev->dev, ipcc->irq, qcom_ipcc_irq_fn,
+-			       IRQF_TRIGGER_HIGH | IRQF_NO_SUSPEND |
++			       IRQF_TRIGGER_HIGH |
+ 			       IRQF_NO_THREAD, name, ipcc);
+ 	if (ret < 0) {
+ 		dev_err(&pdev->dev, "Failed to register the irq: %d\n", ret);


### PR DESCRIPTION
## Summary

Suspend/resume groundwork for SM8550, split out from #2954. One patch, no behavior change on current builds (suspend remains disabled by the SM8550 quirk).

The ADSP charger firmware pushes an unsolicited BATTMGR_NOTIFICATION about 0.5s after suspend entry. The IPCC mailbox irq is IRQF_NO_SUSPEND upstream, so it is never masked across suspend and the notification wakes the device every few minutes, the single biggest blocker to SM8550 staying asleep. Dropping IRQF_NO_SUSPEND lets the PM core mask it like a normal irq; pending signals are handled on resume.

ROCKNIX already carries this patch verbatim for SM8750, so it shouldn't add much new maintenance surface. It is also needed by any future SM8550 suspend path - the charger chatter wakes both deep and s2idle - so whoever continues the suspend work builds on it either way. If a future kernel bump ever makes it fail to apply, dropping it is safe: the only consequence is the old self-wake behavior returning for suspend users.

## Testing

Verified on a Retroid Pocket 6 (details in the patch header): before, the device could not stay asleep past 5 to 10 minutes; after, clean RTC-bounded multi-hour deep sleeps with matching boottime drift. No effect on shipping builds, since the quirk keeps suspend off.

## AI Usage

**Did you use AI tools to help write this code?** Yes. AI tools were used for investigation tooling and log correlation; the fix itself is lifted from ROCKNIX's existing SM8750 patch and was validated by hardware testing.
