### PR TITLE
armsx2-sa: fix build from fresh on runners

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/armsx2-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/armsx2-sa/package.mk
@@ -7,7 +7,7 @@ PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ARMSX2/ARMSX2"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="ARMSX2 is a native ARM64 PlayStation 2 (PS2) emulator, a fork of PCSX2 that ports the EE/IOP/VU JIT recompilers to ARM64."
-PKG_DEPENDS_TARGET="toolchain llvm:host SDL3 libpng zlib libjpeg-turbo zstd lz4 libwebp freetype plutosvg curl libpcap ffmpeg libX11 libXext qt6 shaderc"
+PKG_DEPENDS_TARGET="toolchain llvm:host SDL3 libpng zlib libjpeg-turbo zstd lz4 libwebp freetype plutosvg curl libpcap ffmpeg libX11 libXext qt6 shaderc ecm"
 PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="speed"
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )
Fix armsx2-sa package race which requires package ecm to be built/included before it can succeed.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
Failing GH runner: https://github.com/beebono/distribution/actions/runs/30922509829
```CMake Error at cmake/SearchForStuff.cmake:71 (find_package):
  Could not find a package configuration file provided by "ECM" with any of
  the following names:

    ECMConfig.cmake
    ecm-config.cmake

  Add the installation prefix of "ECM" to CMAKE_PREFIX_PATH or set "ECM_DIR"
  to a directory containing one of the above files.  If "ECM" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:39 (include)


-- Configuring incomplete, errors occurred!
FAILURE: scripts/build armsx2-sa:target during make_target (package.mk)
*********** FAILED COMMAND ***********
cmake "${tgt_opts[@]}"
**************************************
FAILURE: scripts/build armsx2-sa:target has failed!
```

* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)
Successful GH runner: https://github.com/beebono/distribution/actions/runs/30980294888

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
