### PR TITLE
rocknix-fake-suspend: fix suspend actions when timed shutdown disabled

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-fake-suspend
@@ -51,7 +51,7 @@ check_es_running_game() {
   # Check whether ES API endpoint is up
   local endpoint_up=1 # default to endpoint down
   test "$(nc -vz -w5 localhost 1234 2>&1 | grep 'open')" && endpoint_up=0
-  
+
   if [[ $endpoint_up -eq 0 ]]; then
     ${DEBUG} && log $0 "ES API endpoint up - querying"
     local HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1234/runningGame")
@@ -314,17 +314,21 @@ suspend() {
   check_charging
   local CHARGING=$?
 
+  [[ ${TIMED_SHUTDOWN_ENABLED} == "1" ]] && ${DEBUG} && log $0 "Timed shutdown enabled ..."
+  [[ ${TIMED_SHUTDOWN_ENABLED} != "1" ]] && ${DEBUG} && log $0 "Timed shutdown disabled ..."
+
   # Determine shutdown delay
   local DELAY=${SHUTDOWN_DELAY}
   [[ $RUNNING_GAME -eq 0 ]] && DELAY=${SHUTDOWN_DELAY_RUNNING_GAME}
   ${DEBUG} && log $0 "Shutdown delay - ${DELAY} seconds"
   [[ ${CHARGING} -eq 0 ]] && ${DEBUG} && log $0 "Charging ..."
 
-  if [[ "${DELAY}" -gt 0 || ${CHARGING} -eq 0 ]]; then
+
+  if [[ "${DELAY}" -gt 0 || ${CHARGING} -eq 0 || ${TIMED_SHUTDOWN_ENABLED} != "1" ]]; then
     do_suspend_actions
   fi
 
-  if [[ $TIMED_SHUTDOWN_ENABLED == "1" ]]; then
+  if [[ ${TIMED_SHUTDOWN_ENABLED} == "1" ]]; then
     # Delay shutdown
     ${DEBUG} && log $0 "Timed shutdown (${DELAY} seconds) ..."
     sleep ${DELAY}


### PR DESCRIPTION
## Summary

rocknix-fake-suspend: fix suspend actions when timed shutdown disabled

## Testing

Tested on my OGU

## Additional Context

With the following combination of ES settings, suspend actions were not triggering:
- timed shutdown disabled
- 0 minutes shutdown delay

---

### AI Usage

**Did you use AI tools to help write this code?** NO
