### PR TITLE
melonds-sa: vsync remains on even when disabled in emulationstation

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/melonds-sa/scripts/start_melonds.sh
@@ -147,7 +147,7 @@ fi
 if [ "$VSYNC" = "1" ]; then
 	sed -i '/^ScreenVSync=/c\ScreenVSync=1' "${CONF_DIR}/${MELONDS_INI}"
 else
-	sed -i '/^ScreenVSync=/c\ScreenVSync=1' "${CONF_DIR}/${MELONDS_INI}"
+	sed -i '/^ScreenVSync=/c\ScreenVSync=0' "${CONF_DIR}/${MELONDS_INI}"
 fi
 
 # Extract archive to /tmp/melonds


### PR DESCRIPTION
## Summary

Small fix for melonds-sa start script
**Issue:** when disabling vsync in emulationstation it remains enabled

## Testing

Tested on Ayn thor in a personal build

## Additional Context

No mayor risks, is a very small fix

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

AI was not used for this change
