### PR TITLE
SM8250: qcom-abl bootloader

### DIFF
--- a/projects/ROCKNIX/config.xml
+++ b/projects/ROCKNIX/config.xml
@@ -111,7 +111,7 @@
     <file short="airx-mq66b" full="MANGMI Air X MQ66B">sm6115-mangmi-air-x-mq66b</file>
     <file short="airx-mq65" full="MANGMI Air X MQ65">sm6115-mangmi-air-x-mq65</file>
   </SM6115>
-  <SM8250 mkimage_options="grub,dtb,abl" dtb_prefix="qcom">
+  <SM8250 mkimage_options="abl" dtb_prefix="qcom">
     <file short="rp5" full="Retroid Pocket 5" rotation="1">sm8250-retroidpocket-rp5</file>
     <file short="rpflip2" full="Retroid Pocket Flip2" rotation="1">sm8250-retroidpocket-flip2</file>
     <file short="rpmini" full="Retroid Pocket Mini" rotation="1">sm8250-retroidpocket-rpmini</file>

--- a/projects/ROCKNIX/devices/SM8250/bootloader/update.sh
+++ b/projects/ROCKNIX/devices/SM8250/bootloader/update.sh
@@ -22,43 +22,13 @@ if [ -d "$SYSTEM_ROOT/usr/share/bootloader/rocknix_abl" ]; then
   cp $SYSTEM_ROOT/usr/share/bootloader/rocknix_abl/* $BOOT_ROOT/rocknix_abl
 fi
 
-if [ -f "$SYSTEM_ROOT/usr/share/bootloader/EFI/BOOT/bootaa64.efi" ]; then
-  if [ ! -f "$BOOT_ROOT/EFI/BOOT/bootaa64.efi" ]; then
-    mkdir -p $BOOT_ROOT/EFI/BOOT
-    echo "Installing GRUB..."
-    cp $SYSTEM_ROOT/usr/share/bootloader/EFI/BOOT/bootaa64.efi $BOOT_ROOT/EFI/BOOT
-  fi
-fi
+$SYSTEM_ROOT/usr/bin/updateabl
 
-if [ -d "$SYSTEM_ROOT/usr/share/bootloader/boot/grub" ]; then
-  mkdir -p $BOOT_ROOT/boot/grub
-  echo "Updating grub dtbs..."
-  cp $SYSTEM_ROOT/usr/share/bootloader/boot/grub/*.dtb $BOOT_ROOT/boot/grub
-fi
-
-if [ -f "$SYSTEM_ROOT/usr/share/bootloader/boot/grub/grub.cfg" ]; then
-  mkdir -p $BOOT_ROOT/boot/grub
-  echo "Updating grub.cfg..."
-  cp $SYSTEM_ROOT/usr/share/bootloader/boot/grub/grub.cfg $BOOT_ROOT/boot/grub
-  # Old GRUB installations
-  if [ -f "$BOOT_ROOT/EFI/BOOT/grub.cfg" ]; then
-    cp $SYSTEM_ROOT/usr/share/bootloader/boot/grub/grub.cfg $BOOT_ROOT/EFI/BOOT
-  fi
-fi
-
-if [ -f "$SYSTEM_ROOT/usr/share/bootloader/boot/grub/dejavu-mono.pf2" ]; then
-  mkdir -p $BOOT_ROOT/boot/grub
-  echo "Updating dejavu-mono.pf2..."
-  cp $SYSTEM_ROOT/usr/share/bootloader/boot/grub/dejavu-mono.pf2 $BOOT_ROOT/boot/grub
-fi
-
-if [ -f "$SYSTEM_ROOT/usr/share/bootloader/boot/grub/grubenv" ]; then
-  if [ ! -f "$BOOT_ROOT/boot/grub/grubenv" ]; then
-    mkdir -p $BOOT_ROOT/boot/grub
-    echo "Installing grubenv..."
-    cp $SYSTEM_ROOT/usr/share/bootloader/boot/grub/grubenv $BOOT_ROOT/boot/grub
-  fi
-fi
+### REMOVE IN THE FUTURE ###
+# cleanup old boot files
+[ -d "$BOOT_ROOT/boot" ] && rm -rf "$BOOT_ROOT/boot"
+[ -d "$BOOT_ROOT/EFI" ] && rm -rf "$BOOT_ROOT/EFI"
+# end
 
 # mount $BOOT_ROOT ro
 sync

--- a/projects/ROCKNIX/devices/SM8250/options
+++ b/projects/ROCKNIX/devices/SM8250/options
@@ -31,7 +31,7 @@
     EXTRA_CMDLINE="quiet rootwait console=tty0 video=efifb:off gpt"
 
   # Bootloader to use (syslinux / u-boot)
-    BOOTLOADER="arm-efi"
+    BOOTLOADER="qcom-abl"
 
   # Adreno GPU family
     GRAPHIC_DRIVERS="freedreno"


### PR DESCRIPTION
## Summary

SM8250: qcom-abl bootloader

## Testing

### Clean flash

- Fresh flash tested on my RP Mini V2 with `rocknix-abl` v1.1.7 (since V1.1.5)
- Tested many `qcom-abl`-based OTA updates

### Update from stock abl / stable grub ROCKNIX build

**Update**: after merging PR https://github.com/ROCKNIX/distribution/pull/3217 the update process to a ROCKNIX ABL-based build from the stock bootloader and GRUB-based ROCKNIX build works fine.

<details>
<summary>Testing updates prior to merging PR: https://github.com/ROCKNIX/distribution/pull/3217</summary>

Flashed stock recovery package from https://drive.google.com/drive/folders/1mE2Fe_Nuek8XW9geciksXUZtoxV6m2yF with `qdl version 1.0+git20250319.30ac3a8-1`:
```
$ qdl --storage=ufs prog_firehose_ddr.elf rawprogram*.xml patch*.xml
waiting for programmer...
flashed "xbl_a" successfully at 3400kB/s                                                               
flashed "xbl_config_a" successfully
flashed "PrimaryGPT" successfully
flashed "BackupGPT" successfully
flashed "xbl_b" successfully                                                                           
flashed "xbl_config_b" successfully
flashed "PrimaryGPT" successfully
flashed "BackupGPT" successfully
flashed "ddr" successfully
flashed "PrimaryGPT" successfully
flashed "BackupGPT" successfully
flashed "modem_a" successfully at 59516kB/s                                                            
flashed "modem_b" successfully at 29758kB/s                                                            
flashed "aop_a" successfully
flashed "tz_a" successfully                                                                            
flashed "hyp_a" successfully
dsp_a                [#########################################################################] 100.00                                                                                                       flashed "dsp_a" successfully at 65536kB/s
flashed "keymaster_a" successfully
flashed "cmnlib_a" successfully
flashed "cmnlib64_a" successfully
flashed "devcfg_a" successfully
flashed "qupfw_a" successfully
flashed "uefisecapp_a" successfully
flashed "multiimgoem_a" successfully
flashed "featenabler_a" successfully
flashed "aop_b" successfully
flashed "tz_b" successfully                                                                            
flashed "hyp_b" successfully
flashed "dsp_b" successfully at 32768kB/s                                                              
flashed "keymaster_b" successfully
flashed "cmnlib_b" successfully
flashed "cmnlib64_b" successfully
flashed "devcfg_b" successfully
flashed "qupfw_b" successfully
flashed "uefisecapp_b" successfully
flashed "multiimgoem_b" successfully
flashed "featenabler_b" successfully
flashed "apdp" successfully
flashed "devinfo" successfully
flashed "logfs" successfully
flashed "spunvm" successfully
flashed "abl_a" successfully
abl_b                [#########################################################################] 100.00                                                                                                       flashed "abl_b" successfully
flashed "boot_a" successfully at 49152kB/s                                                             
flashed "boot_b" successfully at 32768kB/s                                                             
flashed "dtbo_a" successfully                                                                          
flashed "dtbo_b" successfully                                                                          
flashed "recovery_a" successfully at 34133kB/s                                                         
flashed "recovery_b" successfully at 51200kB/s                                                         
flashed "vbmeta_a" successfully
flashed "vbmeta_b" successfully
flashed "loader_a" successfully
flashed "loader_b" successfully
flashed "imagefv_a" successfully
flashed "imagefv_b" successfully
flashed "PrimaryGPT" successfully
flashed "BackupGPT" successfully
flashed "PrimaryGPT" successfully
flashed "BackupGPT" successfully
flashed "persist" successfully at 32768kB/s                                                            
flashed "bluetooth_a" successfully
flashed "bluetooth_b" successfully
metadata             [#########################################################################] 100.00                                                                                                       flashed "metadata" successfully
flashed "metadata" successfully
flashed "vbmeta_system_a" successfully
flashed "super" successfully
flashed "super" successfully
flashed "super" successfully at 41365kB/s                                                              
flashed "super" successfully at 40021kB/s                                                              
super                [#########################################################################] 100.00                                                                                                       flashed "super" successfully at 39839kB/s
flashed "super" successfully at 41242kB/s                                                              
flashed "vbmeta_system_b" successfully
flashed "userdata" successfully
flashed "userdata" successfully
flashed "userdata" successfully at 43017kB/s                                                           
flashed "userdata" successfully
flashed "userdata" successfully
flashed "userdata" successfully
flashed "userdata" successfully
flashed "userdata" successfully
flashed "userdata" successfully
flashed "userdata" successfully
PrimaryGPT           [#########################################################################] 100.00                                                                                                       flashed "PrimaryGPT" successfully
flashed "BackupGPT" successfully
78 patches applied
partition 1 is now bootable
```

Flashed fixed loader for RP Mini V2 here: https://rocknix.org/devices/retroid/retroid-pocket-mini/#retroid-pocket-mini-v2
```
$ fastboot flash loader_a u-boot-sm8250-retroidpocket-rpminiv2.img
Sending 'loader_a' (632 KB)                        OKAY [  0.019s]
Writing 'loader_a'                                 OKAY [  0.009s]
Finished. Total time: 0.046s
$ fastboot flash loader_b u-boot-sm8250-retroidpocket-rpminiv2.img
Sending 'loader_b' (632 KB)                        OKAY [  0.019s]
Writing 'loader_b'                                 OKAY [  0.009s]
Finished. Total time: 0.038s
```

Flashed 20260801 monthly release to an SD card:
```
$ gunzip -c ../ROCKNIX-SM8250.aarch64-20260801.img.gz | sudo dd of=/dev/sda bs=1M conv=fsync status=progress
2141814784 bytes (2.1 GB, 2.0 GiB) copied, 21 s, 102 MB/s2198863872 bytes (2.2 GB, 2.0 GiB) copied, 21.8835 s, 100 MB/s

0+66124 records in
0+66124 records out
2198863872 bytes (2.2 GB, 2.0 GiB) copied, 47.1047 s, 46.7 MB/s
```

Booted up fine, but block device with abl partitions had GPT partition table corruption:
```
ROCKNIX:~ # partprobe /dev/sde
Error: The primary GPT table is corrupt, but the backup appears OK, so that will be used.
ROCKNIX:~ #
```

After a couple of `partprobe` attempts, was able to run `updateabl` successfully:
```
ROCKNIX:~ # updateabl 
Error: The primary GPT table is corrupt, but the backup appears OK, so that will be used.
Reading 63 sectors from ABL_A...
Reading 63 sectors from ABL_B...
Checksum abl_a: a858784
Checksum abl_b: a858784
Checksum update: d115de9
Checksums differ — flashing ABL partitions...
ABL update completed successfully...
```

Booted via rocknix ABL fine, and after reboot, GPT table corruption is gone:
```
SM8250:~ # partprobe /dev/sde
SM8250:~ #
```

Was then able to update to a test `qcom-abl`-based SM8250 build fine, booted up fine. `installtointernal` worked fine.

</details>


## Additional Context

- FAT filesystem issues that were causing corruption have been fixed now

---

### AI Usage

**Did you use AI tools to help write this code?** NO
