### PR TITLE
steam: round the sway refresh to whole Hz for gamescope

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/steam/scripts/start_steam.sh
@@ -83,7 +83,9 @@ steam_read_sway_geometry() {
     .[] | select(.focused == true) |
     "W=\(.current_mode.width) H=\(.current_mode.height) TRANSFORM=\(.transform) REFRESH=\(.current_mode.refresh // 60000)"
   ')"
-  REFRESH_HZ=$((REFRESH / 1000))
+  # Round to nearest (119990 mHz -> 120) to match the mode's integer vrefresh,
+  # which gamescope's -r must hit exactly or it falls back to the preferred mode.
+  REFRESH_HZ=$(((REFRESH + 500) / 1000))
 }
 
 steam_setup_environment() {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

steam inside gamescope is currently using the incorrect display refresh rate, if sway reports a refresh rate that is not an integer.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

tested on the konkr pocket fit elite. ran vkcube inside gamescope with certain target refresh rates to see what is being reported.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

on the konkr, the display driver supports refresh rates such as 119.99hz (not exactly 120!). the script to start steam inside gamescope truncates the refresh rate though, so it receives 119, then tries to find a matching mode with vrefresh==119, doesnt find one (because the kernel reports vrefresh==120), fails to find it -> falls back to some other rate.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

yes