### PR TITLE
S922X: linux 6.18.43

### DIFF
--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -47,7 +47,7 @@ case ${DEVICE} in
     PKG_PATCH_DIRS+=" 7.0"
     ;;
   S922X)
-    PKG_VERSION="6.18.38"
+    PKG_VERSION="6.18.43"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     ;;
   *)


### PR DESCRIPTION
## Summary

S922X: linux 6.18.43

## Testing

Tested ok on my OGU:
- display
- controls
- headphone audio
- bluetooth audio (hardkernel dongle)
- USB audio (Sennheiser BTD 600)
- USB ethernet
- wifi (hardkernel dongle)
- libmali / panfrost
- dmesg

## Additional Context

Keeping S922X on 6.18 LTS due to RK818 battery driver issues with newer kernels

---

### AI Usage

**Did you use AI tools to help write this code?** NO
