### PR TITLE
haptics: drop the stale __assign_str argument in the tracepoint header

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/patches/linux/1000-add-qcom-haptics-driver.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/1000-add-qcom-haptics-driver.patch
@@ -6442,7 +6442,7 @@ diff -Naur a/include/trace/events/qcom_haptics.h b/include/trace/events/qcom_hap
 +	),
 +
 +	TP_fast_assign(
-+		__assign_str(id_name, name);
++		__assign_str(id_name);
 +		__entry->msb = msb;
 +		__entry->lsb = lsb;
 +	),

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/1000-input-misc-qcom-hv-haptics-sm8750.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/1000-input-misc-qcom-hv-haptics-sm8750.patch
@@ -7036,7 +7036,7 @@ diff -Naur a/include/trace/events/qcom_haptics.h b/include/trace/events/qcom_hap
 +	),
 +
 +	TP_fast_assign(
-+		__assign_str(id_name, name);
++		__assign_str(id_name);
 +		__entry->msb = msb;
 +		__entry->lsb = lsb;
 +	),


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 

`__assign_str()` lost its second parameter in 6.10; it now takes the string from the matching `__string()` entry, which sits right above it. Both vendored haptics patches still pass two arguments in `include/trace/events/qcom_haptics.h`, so the header does not compile once tracepoints are enabled:

```
include/trace/events/qcom_haptics.h:94:1: error: macro '__assign_str' passed 2 arguments, but takes just 1
```

This is invisible in the shipping config: `CONFIG_FTRACE` is off, so the `TP_fast_assign` body is never really compiled and the stale call is never checked. The fix is one line each in the SM8550 and SM8750 patches, which ship the same header.

## Testing

* **How was this tested?** 

Built the SM8550 aarch64 image with `CONFIG_FTRACE=y` and `CONFIG_ENABLE_DEFAULT_TRACERS=y`. SM8750 was not built; the change there is textually identical and the header is the same file.

* **Test results:** 

Without this change the build fails at `drivers/input/misc/qcom-hv-haptics.o`. With it the kernel builds clean and exposes working `ufs:` tracepoints. Nothing exercised the haptics tracepoint at runtime, and with `CONFIG_FTRACE=n` this is a no-op in the shipping config anyway.

## Additional Context

Spotted while working on the SM8550 deep suspend/resume PR (#3126): enabling tracepoints there to investigate UFS clock gating is what made the build fail. The fix itself is unrelated to that work, hence a separate PR.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES 

Yes. AI was used to find the bug and write the change.
