### PR TITLE
SM8750: SteamOS-parity vm.max_map_count via kernel cmdline

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/steam/config/50-max-map-count.conf
+++ b/projects/ROCKNIX/packages/emulators/standalone/steam/config/50-max-map-count.conf
@@ -1,0 +1,3 @@
+# SteamOS-parity mmap limit: big Wine/FEX games exhaust the 65530 default
+# (HZD Remastered deadlocks at exactly 65531 maps).
+vm.max_map_count = 2147483642

--- a/projects/ROCKNIX/packages/emulators/standalone/steam/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/steam/package.mk
@@ -31,4 +31,6 @@ makeinstall_target() {
   cp -rf ${PKG_DIR}/resources/compatibilitytool.vdf ${INSTALL}/usr/share/steam
   cp -rf ${PKG_DIR}/resources/toolmanifest.vdf ${INSTALL}/usr/share/steam
   cp -rf ${PKG_DIR}/resources/registry.vdf ${INSTALL}/usr/share/steam
+  mkdir -p ${INSTALL}/usr/lib/sysctl.d
+  install -m 0644 ${PKG_DIR}/config/50-max-map-count.conf ${INSTALL}/usr/lib/sysctl.d/
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

increase vm max_map_count. the current limit is not high enough to run certain steam games.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

tested on my konkr pocket fit elite. horizon zero dawn remastered freezes during start with the default limit of 65k. this new limit allows it to run.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

the limit is only increased for the sm8750 platform. there could be reasons to not set the limit this high for some of the lower end platforms, so it's constrained. happy to amend if this should cover other platforms as well.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

yes
