### PR TITLE
SM8750: enable boost and tweak capacity-dmips-mhz

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0076-arm64-dts-qcom-sm8750-set-CPU-capacity-dmips-mhz.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0076-arm64-dts-qcom-sm8750-set-CPU-capacity-dmips-mhz.patch
@@ -3,10 +3,12 @@ Subject: [PATCH] arm64: dts: qcom: sm8750: set CPU capacity-dmips-mhz
 
 Without capacity-dmips-mhz all eight cores report capacity 1024 and the
 scheduler cannot tell the clusters apart, even though the prime cluster
-clocks 16% higher (4.09 vs 3.53 GHz). Set an equal 1024 on every core
-(same Oryon uarch); arch_topology then scales each core's capacity by
-its cpufreq maximum, which differentiates the clusters and enables the
-asymmetric-capacity scheduler paths.
+clocks 16% higher (4.09 vs 3.53 GHz). Use the values the vendor Android
+DT ships (dumped from a KONKR Pocket FIT Elite; Qualcomm sun baseline):
+1792 on the six-core cluster, 1894 on the prime pair, giving the prime
+cores their ~6% per-MHz edge. arch_topology then scales each core's
+capacity by its cpufreq maximum, which differentiates the clusters and
+enables the asymmetric-capacity scheduler paths.
 ---
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
@@ -14,7 +16,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x0>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1792>;
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd0>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
@@ -22,7 +24,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x100>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1792>;
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd1>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
@@ -30,7 +32,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x200>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1792>;
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd2>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
@@ -38,7 +40,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x300>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1792>;
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd3>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
@@ -46,7 +48,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x400>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1792>;
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd4>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
@@ -54,7 +56,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x500>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1792>;
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd5>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
@@ -62,7 +64,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x10000>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1894>;
  			next-level-cache = <&l2_1>;
  			power-domains = <&cpu_pd6>, <&scmi_dvfs 1>;
  			power-domain-names = "psci", "perf";
@@ -70,7 +72,7 @@ asymmetric-capacity scheduler paths.
  			compatible = "qcom,oryon";
  			reg = <0x0 0x10100>;
  			enable-method = "psci";
-+			capacity-dmips-mhz = <1024>;
++			capacity-dmips-mhz = <1894>;
  			next-level-cache = <&l2_1>;
  			power-domains = <&cpu_pd7>, <&scmi_dvfs 1>;
  			power-domain-names = "psci", "perf";

--- a/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/002-turbo-mode_config
+++ b/projects/ROCKNIX/packages/hardware/quirks/platforms/SM8750/002-turbo-mode_config
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
+
+cat <<EOF >/storage/.config/profile.d/002-turbo-mode_config
+DEVICE_TURBO_MODE="true"
+EOF


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

minor performance improvements for SM8750. (1) enable boost and (2) tweak the capacity-dmips-mhz which differ slightly between the 2 cpu clusters.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

tested on my konkr pocket fit elite. boosting is exposed via the "cpu overclock" setting in es, and only with that on do the performance cores go up to its advertised max of about 4.3ghz. without, they cap out at about 4.1ghz.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

the capacity-dmips-mhz is hard to measure, but these values have been taken from a dump and so are more accurate on paper, and they have not introduced a performance regression at least. andrebraga on discord confirmed the ayn odin 3 uses the same numbers as well.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

yes
