### PR TITLE
sleep: log the brightness value being restored

### DIFF
--- a/projects/ROCKNIX/packages/sysutils/sleep/sources/sleep.sh
+++ b/projects/ROCKNIX/packages/sysutils/sleep/sources/sleep.sh
@@ -119,7 +119,7 @@ case $1 in
     amixer -c 0 -M set "${DEVICE_AUDIO_MIXER}" ${DEVICE_VOLUME}% >${EVENTLOG} 2>&1
 
     BRIGHTNESS=$(get_setting display.brightness)
-    log $0 "Restoring brightness}."
+    log $0 "Restoring brightness to ${BRIGHTNESS}."
     brightness set ${BRIGHTNESS} >${EVENTLOG} 2>&1
 
     BRIGHTNESS_2=$(get_setting display.brightness2)


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a log message typo: every resume writes `Restoring brightness}.` to the sleep log. The stray brace is left over from 8ff25721ab, which moved the value into ${BRIGHTNESS} for the dual screen fix but did not carry it into the message, so the one number worth having in the log is the one it does not print. This matches the volume line above it and the display 2 line below it, both of which already log their value.

## Testing

* **How was this tested?** Seen live in the journal on an AYN Odin 2 while testing #3126; the fix is a one-line message change with no behavioral effect, verified with sh -n.
* **Test results:** With the change the line prints `Restoring brightness to 818.` (the value from my device) instead of `Restoring brightness}.`

## Additional Context

* Independent of #3126; upstream bug present on next since 8ff25721ab.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY

Spotted during AI-assisted log analysis; the one-line fix was reviewed by hand.
