### PR TITLE
SM8750: bump kernel 7.1.3 → 7.1.7

### DIFF
--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0028-drm-panel-Add-panel-driver-for-Chipone-ICNA35XX-base.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0028-drm-panel-Add-panel-driver-for-Chipone-ICNA35XX-base.patch
@@ -12,12 +12,12 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  create mode 100644 drivers/gpu/drm/panel/panel-chipone-icna35xx.c
 
 diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
-index 3bcf710414dd..cc2b93322628 100644
+index adab94b3e..a30cd7840 100644
 --- a/drivers/gpu/drm/panel/Kconfig
 +++ b/drivers/gpu/drm/panel/Kconfig
-@@ -115,6 +115,17 @@ config DRM_PANEL_BOE_XM91080G
- 	  Say Y if you want to enable support for panels based on the
- 	  Xm-Plus XM91080G controller.
+@@ -105,6 +105,17 @@ config DRM_PANEL_BOE_TV101WUM_LL2
+ 	  Say Y here if you want to support for BOE TV101WUM-LL2
+ 	  WUXGA PANEL DSI Video Mode panel
  
 +config DRM_PANEL_CHIPONE_ICNA35XX
 +	tristate "Chipone ICNA35XX panel driver"
@@ -34,10 +34,10 @@ index 3bcf710414dd..cc2b93322628 100644
  	tristate "EBBG FT8719 panel driver"
  	depends on OF
 diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
-index 4b64459f88b5..339a5cb9f31b 100644
+index a4291dc39..e0c80cc65 100644
 --- a/drivers/gpu/drm/panel/Makefile
 +++ b/drivers/gpu/drm/panel/Makefile
-@@ -9,6 +9,7 @@
+@@ -9,6 +9,7 @@ obj-$(CONFIG_DRM_PANEL_BOE_TD4320) += panel-boe-td4320.o
  obj-$(CONFIG_DRM_PANEL_BOE_TH101MB31UIG002_28A) += panel-boe-th101mb31ig002-28a.o
  obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_LL2) += panel-boe-tv101wum-ll2.o
  obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_NL6) += panel-boe-tv101wum-nl6.o
@@ -47,7 +47,7 @@ index 4b64459f88b5..339a5cb9f31b 100644
  obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple.o
 diff --git a/drivers/gpu/drm/panel/panel-chipone-icna35xx.c b/drivers/gpu/drm/panel/panel-chipone-icna35xx.c
 new file mode 100644
-index 000000000000..fe4742678c00
+index 000000000..8abdd5111
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-chipone-icna35xx.c
 @@ -0,0 +1,572 @@
@@ -624,5 +624,3 @@ index 000000000000..fe4742678c00
 +MODULE_DESCRIPTION("DRM driver for Chipone ICNA35XX based MIPI DSI panels");
 +MODULE_LICENSE("GPL");
 \ No newline at end of file
--- 
-2.34.1

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0029-Input-edt-ft5x06-add-no_regmap_bulk_read-option.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0029-Input-edt-ft5x06-add-no_regmap_bulk_read-option.patch
@@ -11,7 +11,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 40 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/input/touchscreen/edt-ft5x06.c b/drivers/input/touchscreen/edt-ft5x06.c
-index d0ab644be006..6d745b564f7c 100644
+index d3b117718..d45076a0e 100644
 --- a/drivers/input/touchscreen/edt-ft5x06.c
 +++ b/drivers/input/touchscreen/edt-ft5x06.c
 @@ -146,6 +146,7 @@ struct edt_ft5x06_ts_data {
@@ -75,7 +75,7 @@ index d0ab644be006..6d745b564f7c 100644
  	if (error) {
  		dev_err_ratelimited(dev, "Unable to fetch data, error: %d\n",
  				    error);
-@@ -1232,6 +1268,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client)
+@@ -1210,6 +1246,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client)
  		return error;
  	}
  
@@ -84,6 +84,3 @@ index d0ab644be006..6d745b564f7c 100644
  	/*
  	 * Check which sleep modes we can support. Power-off requires the
  	 * reset-pin to ensure correct power-down/power-up behaviour. Start with
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0031_input--Add-driver-for-RSInput-Gamepad.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0031_input--Add-driver-for-RSInput-Gamepad.patch
@@ -11,10 +11,10 @@ Subject: [PATCH] input: Add driver for RSInput Gamepad
  create mode 100644 drivers/input/joystick/rsinput.c
 
 diff --git a/drivers/input/joystick/Kconfig b/drivers/input/joystick/Kconfig
-index 132a44428dcd..2a77296e1b85 100644
+index 7755e5b45..0da3c0f44 100644
 --- a/drivers/input/joystick/Kconfig
 +++ b/drivers/input/joystick/Kconfig
-@@ -387,6 +387,10 @@ config JOYSTICK_QWIIC
+@@ -383,6 +383,10 @@ config JOYSTICK_QWIIC
  	  To compile this driver as a module, choose M here: the
  	  module will be called qwiic-joystick.
  
@@ -26,10 +26,10 @@ index 132a44428dcd..2a77296e1b85 100644
  	tristate "FlySky FS-iA6B RC Receiver"
  	select SERIO
 diff --git a/drivers/input/joystick/Makefile b/drivers/input/joystick/Makefile
-index ccbed1bafbef..f848b82d99dc 100644
+index 9976f596a..3de503e29 100644
 --- a/drivers/input/joystick/Makefile
 +++ b/drivers/input/joystick/Makefile
-@@ -29,6 +29,7 @@ obj-$(CONFIG_JOYSTICK_RETROID)		+= retroid.o
+@@ -28,6 +28,7 @@ obj-$(CONFIG_JOYSTICK_N64)		+= n64joy.o
  obj-$(CONFIG_JOYSTICK_PSXPAD_SPI)	+= psxpad-spi.o
  obj-$(CONFIG_JOYSTICK_PXRC)		+= pxrc.o
  obj-$(CONFIG_JOYSTICK_QWIIC)		+= qwiic-joystick.o
@@ -39,7 +39,7 @@ index ccbed1bafbef..f848b82d99dc 100644
  obj-$(CONFIG_JOYSTICK_SIDEWINDER)	+= sidewinder.o
 diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
 new file mode 100644
-index 000000000000..913c499ad30a
+index 000000000..c9cbaf2cd
 --- /dev/null
 +++ b/drivers/input/joystick/rsinput.c
 @@ -0,0 +1,578 @@
@@ -621,7 +621,3 @@ index 000000000000..913c499ad30a
 +
 +MODULE_LICENSE("GPL");
 +MODULE_DESCRIPTION("RSInput Gamepad Driver");
-+MODULE_AUTHOR("Teguh Sobirin <teguh@sobir.in>");
--- 
-2.52.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0032-ASoC-codecs-aw88166-AYN-Products-Specific-modificati.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0032-ASoC-codecs-aw88166-AYN-Products-Specific-modificati.patch
@@ -15,7 +15,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 87 insertions(+), 8 deletions(-)
 
 diff --git a/sound/soc/codecs/aw88166.c b/sound/soc/codecs/aw88166.c
-index daee4de9e3b0..8c23c6db2547 100644
+index ea277a940..9db78a775 100644
 --- a/sound/soc/codecs/aw88166.c
 +++ b/sound/soc/codecs/aw88166.c
 @@ -12,7 +12,10 @@
@@ -138,7 +138,7 @@ index daee4de9e3b0..8c23c6db2547 100644
  	},
  };
  
-@@ -1802,9 +1874,16 @@ static const struct i2c_device_id aw88166_i2c_id[] = {
+@@ -1806,9 +1870,16 @@ static const struct i2c_device_id aw88166_i2c_id[] = {
  };
  MODULE_DEVICE_TABLE(i2c, aw88166_i2c_id);
  
@@ -155,6 +155,3 @@ index daee4de9e3b0..8c23c6db2547 100644
  	},
  	.probe = aw88166_i2c_probe,
  	.id_table = aw88166_i2c_id,
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0033-arm64-dts-qcom-sm8750-gpu-clock-controllers.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0033-arm64-dts-qcom-sm8750-gpu-clock-controllers.patch
@@ -12,7 +12,7 @@ of the old 0000_to_0025 enablement is now upstream).
  1 file changed, 68 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index 18fb52c..d5ed070 100644
+index 2d2f029c2..e971d8f7f 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
 @@ -6,7 +6,9 @@
@@ -25,7 +25,7 @@ index 18fb52c..d5ed070 100644
  #include <dt-bindings/clock/qcom,sm8750-tcsr.h>
  #include <dt-bindings/clock/qcom,sm8750-videocc.h>
  #include <dt-bindings/dma/qcom-gpi.h>
-@@ -3436,6 +3438,34 @@ dispcc: clock-controller@af00000 {
+@@ -3440,6 +3442,34 @@ dispcc: clock-controller@af00000 {
  			#power-domain-cells = <1>;
  		};
  
@@ -60,7 +60,7 @@ index 18fb52c..d5ed070 100644
  		pdc: interrupt-controller@b220000 {
  			compatible = "qcom,sm8750-pdc", "qcom,pdc";
  			reg = <0x0 0x0b220000 0x0 0x10000>, <0x0 0x164400f0 0x0 0x64>;
-@@ -4998,6 +5028,44 @@ tpdm_swao_out: endpoint {
+@@ -5002,6 +5032,44 @@ tpdm_swao_out: endpoint {
  			};
  		};
  

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0034-arm64-dts-qcom-sm8750-Add-UART15.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0034-arm64-dts-qcom-sm8750-Add-UART15.patch
@@ -9,10 +9,10 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 30 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index 0e7a343297e3..a453a350200c 100644
+index e971d8f7f..29df6a5aa 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-@@ -1207,6 +1207,28 @@ &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
+@@ -1210,6 +1210,28 @@ &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
  
  				status = "disabled";
  			};
@@ -41,7 +41,7 @@ index 0e7a343297e3..a453a350200c 100644
  		};
  
  		i2c_master_hub_0: geniqup@9c0000 {
-@@ -3553,6 +3575,14 @@ qup_uart14_cts_rts: qup-uart14-cts-rts-state {
+@@ -4040,6 +4062,14 @@ qup_uart14_cts_rts: qup-uart14-cts-rts-state {
  				bias-pull-down;
  			};
  
@@ -56,6 +56,3 @@ index 0e7a343297e3..a453a350200c 100644
  			sdc2_sleep: sdc2-sleep-state {
  				clk-pins {
  					pins = "sdc2_clk";
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0038-arm64-dts-qcom-sm8750-add-GPU-nodes.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0038-arm64-dts-qcom-sm8750-add-GPU-nodes.patch
@@ -11,10 +11,10 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 182 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index c19912178fb8..1a713ef2e006 100644
+index 29df6a5aa..d3034bf6c 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-@@ -3028,6 +3028,188 @@ videocc: clock-controller@aaf0000 {
+@@ -3464,6 +3464,188 @@ dispcc: clock-controller@af00000 {
  			#power-domain-cells = <1>;
  		};
  
@@ -203,6 +203,3 @@ index c19912178fb8..1a713ef2e006 100644
  		gxclkctl: clock-controller@3d64000 {
  			compatible = "qcom,sm8750-gxclkctl";
  			reg = <0x0 0x03d64000 0x0 0x6000>;
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0039-wifi-ath12k-add-initial-hardware-definition-for-WCN7.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0039-wifi-ath12k-add-initial-hardware-definition-for-WCN7.patch
@@ -17,19 +17,19 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  4 files changed, 118 insertions(+)
 
 diff --git a/drivers/net/wireless/ath/ath12k/core.h b/drivers/net/wireless/ath/ath12k/core.h
-index 990934ec92fc..6583e0be5f66 100644
+index 8be435535..590438804 100644
 --- a/drivers/net/wireless/ath/ath12k/core.h
 +++ b/drivers/net/wireless/ath/ath12k/core.h
-@@ -155,6 +155,7 @@ enum ath12k_hw_rev {
+@@ -156,6 +156,7 @@ enum ath12k_hw_rev {
  	ATH12K_HW_QCN9274_HW20,
  	ATH12K_HW_WCN7850_HW20,
  	ATH12K_HW_IPQ5332_HW10,
 +	ATH12K_HW_WCN7860_HW20,
  	ATH12K_HW_QCC2072_HW10,
+ 	ATH12K_HW_IPQ5424_HW10,
  };
- 
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/hal.c b/drivers/net/wireless/ath/ath12k/wifi7/hal.c
-index bd1753ca0db6..7dc8c71d3057 100644
+index a0a1902fb..744ac7b06 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/hal.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/hal.c
 @@ -43,6 +43,13 @@ static const struct ath12k_hw_version_map ath12k_wifi7_hw_ver_map[] = {
@@ -47,10 +47,10 @@ index bd1753ca0db6..7dc8c71d3057 100644
  		.hal_ops = &hal_qcc2072_ops,
  		.hal_desc_sz = sizeof(struct hal_rx_desc_qcc2072),
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/hw.c b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-index df045ddf42da..1eebfbb5f7a7 100644
+index f687eb69e..9ac69f2fa 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/hw.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-@@ -666,6 +666,94 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
+@@ -681,6 +681,94 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
  
  		.dp_primary_link_only = true,
  	},
@@ -146,7 +146,7 @@ index df045ddf42da..1eebfbb5f7a7 100644
  		.name = "qcc2072 hw1.0",
  		.hw_rev = ATH12K_HW_QCC2072_HW10,
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/pci.c b/drivers/net/wireless/ath/ath12k/wifi7/pci.c
-index 6c96b52dec13..893474de488d 100644
+index 6c96b52de..893474de4 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/pci.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/pci.c
 @@ -19,6 +19,7 @@
@@ -192,6 +192,3 @@ index 6c96b52dec13..893474de488d 100644
  	case QCC2072_DEVICE_ID:
  		ab->id.bdf_search = ATH12K_BDF_SEARCH_BUS_AND_BOARD;
  		ab_pci->msi_config = &ath12k_wifi7_msi_config[0];
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0040-wifi-ath12k-send-QDSS-config-when-CNSS_QDSS_CFG_MISS.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0040-wifi-ath12k-send-QDSS-config-when-CNSS_QDSS_CFG_MISS.patch
@@ -19,10 +19,10 @@ Signed-off-by: Gianni Spadoni <me@gio.blue>
  3 files changed, 225 insertions(+)
 
 diff --git a/drivers/net/wireless/ath/ath12k/hw.h b/drivers/net/wireless/ath/ath12k/hw.h
-index a9888e0521a1..42999c1c8d84 100644
+index da75d19ae..717c2452a 100644
 --- a/drivers/net/wireless/ath/ath12k/hw.h
 +++ b/drivers/net/wireless/ath/ath12k/hw.h
-@@ -78,6 +78,7 @@
+@@ -82,6 +82,7 @@ struct ieee80211_rx_status;
  #define ATH12K_DEFAULT_CAL_FILE		"caldata.bin"
  #define ATH12K_AMSS_FILE		"amss.bin"
  #define ATH12K_M3_FILE			"m3.bin"
@@ -31,7 +31,7 @@ index a9888e0521a1..42999c1c8d84 100644
  #define ATH12K_REGDB_FILE_NAME		"regdb.bin"
  
 diff --git a/drivers/net/wireless/ath/ath12k/qmi.c b/drivers/net/wireless/ath/ath12k/qmi.c
-index c11b84b56f8f..1a7263e71aa6 100644
+index 8c5dacf22..b816b4c4b 100644
 --- a/drivers/net/wireless/ath/ath12k/qmi.c
 +++ b/drivers/net/wireless/ath/ath12k/qmi.c
 @@ -1582,6 +1582,113 @@ static const struct qmi_elem_info qmi_wlanfw_bdf_download_resp_msg_v01_ei[] = {
@@ -259,7 +259,7 @@ index c11b84b56f8f..1a7263e71aa6 100644
  }
  
 diff --git a/drivers/net/wireless/ath/ath12k/qmi.h b/drivers/net/wireless/ath/ath12k/qmi.h
-index b5a4a01391cb..dee0b8f4e719 100644
+index b5a4a0139..dee0b8f4e 100644
 --- a/drivers/net/wireless/ath/ath12k/qmi.h
 +++ b/drivers/net/wireless/ath/ath12k/qmi.h
 @@ -529,6 +529,27 @@ struct qmi_wlanfw_bdf_download_resp_msg_v01 {
@@ -290,6 +290,3 @@ index b5a4a01391cb..dee0b8f4e719 100644
  #define QMI_WLANFW_M3_INFO_REQ_MSG_V01_MAX_MSG_LEN	18
  #define QMI_WLANFW_M3_INFO_RESP_MSG_V01_MAX_MSG_LEN	7
  #define QMI_WLANFW_M3_INFO_RESP_V01		0x003C
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0041-wifi-ath12k-disable-CNSS_QDSS_CFG_MISS_V01-for-the-W.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0041-wifi-ath12k-disable-CNSS_QDSS_CFG_MISS_V01-for-the-W.patch
@@ -12,10 +12,10 @@ Signed-off-by: Gianni Spadoni <me@gio.blue>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/hw.c b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-index 1eebfbb5f7a7..89be65aa9d84 100644
+index 9ac69f2fa..4d1288f0b 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/hw.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-@@ -721,8 +721,7 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
+@@ -736,8 +736,7 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
  
  		.wmi_init = ath12k_wifi7_wmi_init_wcn7850,
  
@@ -25,6 +25,3 @@ index 1eebfbb5f7a7..89be65aa9d84 100644
  					   BIT(CNSS_AUX_UC_SUPPORT_V01),
  
  		.rfkill_pin = 0,
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0045-Bluetooth-qca-add-WCN7860-support.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0045-Bluetooth-qca-add-WCN7860-support.patch
@@ -6,7 +6,7 @@ Rebased onto Linux 7.1: hci_qca.c switches were restructured upstream
 WCN7860 case/function/struct insertions were re-derived against 7.1.
 ---
 diff --git a/drivers/bluetooth/btqca.c b/drivers/bluetooth/btqca.c
-index dda7636..350c470 100644
+index fff1dd643..49acf9695 100644
 --- a/drivers/bluetooth/btqca.c
 +++ b/drivers/bluetooth/btqca.c
 @@ -843,6 +843,11 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
@@ -58,7 +58,7 @@ index dda7636..350c470 100644
  		err = qca_read_fw_build_info(hdev);
  		if (err < 0)
 diff --git a/drivers/bluetooth/btqca.h b/drivers/bluetooth/btqca.h
-index 8f3c1b1..3fe1873 100644
+index 8f3c1b1c7..3fe18739e 100644
 --- a/drivers/bluetooth/btqca.h
 +++ b/drivers/bluetooth/btqca.h
 @@ -158,6 +158,7 @@ enum qca_btsoc_type {
@@ -70,10 +70,10 @@ index 8f3c1b1..3fe1873 100644
  
  #if IS_ENABLED(CONFIG_BT_QCA)
 diff --git a/drivers/bluetooth/hci_qca.c b/drivers/bluetooth/hci_qca.c
-index 3450013..9a29126 100644
+index bd29d422c..fae963168 100644
 --- a/drivers/bluetooth/hci_qca.c
 +++ b/drivers/bluetooth/hci_qca.c
-@@ -1380,6 +1380,7 @@ static int qca_set_baudrate(struct hci_dev *hdev, uint8_t baudrate)
+@@ -1384,6 +1384,7 @@ static int qca_set_baudrate(struct hci_dev *hdev, uint8_t baudrate)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -81,7 +81,7 @@ index 3450013..9a29126 100644
  		usleep_range(1000, 10000);
  		break;
  
-@@ -1398,6 +1399,36 @@ static inline void host_set_baudrate(struct hci_uart *hu, unsigned int speed)
+@@ -1402,6 +1403,36 @@ static inline void host_set_baudrate(struct hci_uart *hu, unsigned int speed)
  		hci_uart_set_baudrate(hu, speed);
  }
  
@@ -118,7 +118,7 @@ index 3450013..9a29126 100644
  static int qca_send_power_pulse(struct hci_uart *hu, bool on)
  {
  	int timeout = CMD_TRANS_TIMEOUT;
-@@ -1467,6 +1498,7 @@ static int qca_check_speeds(struct hci_uart *hu)
+@@ -1471,6 +1502,7 @@ static int qca_check_speeds(struct hci_uart *hu)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -126,7 +126,7 @@ index 3450013..9a29126 100644
  		if (!qca_get_speed(hu, QCA_INIT_SPEED) &&
  		    !qca_get_speed(hu, QCA_OPER_SPEED))
  			return -EINVAL;
-@@ -1510,6 +1542,7 @@ static int qca_set_speed(struct hci_uart *hu, enum qca_speed_type speed_type)
+@@ -1514,6 +1546,7 @@ static int qca_set_speed(struct hci_uart *hu, enum qca_speed_type speed_type)
  		case QCA_WCN6750:
  		case QCA_WCN6855:
  		case QCA_WCN7850:
@@ -134,7 +134,7 @@ index 3450013..9a29126 100644
  			hci_uart_set_flow_control(hu, true);
  			break;
  
-@@ -1545,6 +1578,7 @@ error:
+@@ -1549,6 +1582,7 @@ static int qca_set_speed(struct hci_uart *hu, enum qca_speed_type speed_type)
  		case QCA_WCN6750:
  		case QCA_WCN6855:
  		case QCA_WCN7850:
@@ -142,7 +142,7 @@ index 3450013..9a29126 100644
  			hci_uart_set_flow_control(hu, false);
  			break;
  
-@@ -1861,6 +1895,7 @@ static int qca_power_on(struct hci_dev *hdev)
+@@ -1865,6 +1899,7 @@ static int qca_power_on(struct hci_dev *hdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -150,7 +150,7 @@ index 3450013..9a29126 100644
  		ret = qca_regulator_init(hu);
  		break;
  
-@@ -1957,6 +1992,10 @@ static int qca_setup(struct hci_uart *hu)
+@@ -1964,6 +1999,10 @@ static int qca_setup(struct hci_uart *hu)
  		soc_name = "wcn7850";
  		break;
  
@@ -161,15 +161,15 @@ index 3450013..9a29126 100644
  	default:
  		soc_name = "ROME/QCA6390";
  	}
-@@ -1980,6 +2019,7 @@ retry:
+@@ -1987,6 +2026,7 @@ static int qca_setup(struct hci_uart *hu)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
 +	case QCA_WCN7860:
- 		if (qcadev->bdaddr_property_broken)
+ 		if (qcadev && qcadev->bdaddr_property_broken)
  			hci_set_quirk(hdev, HCI_QUIRK_BDADDR_PROPERTY_BROKEN);
  
-@@ -1994,6 +2034,12 @@ retry:
+@@ -2001,6 +2041,12 @@ static int qca_setup(struct hci_uart *hu)
  		qca_set_speed(hu, QCA_INIT_SPEED);
  	}
  
@@ -182,7 +182,7 @@ index 3450013..9a29126 100644
  	/* Setup user speed if needed */
  	speed = qca_get_speed(hu, QCA_OPER_SPEED);
  	if (speed) {
-@@ -2013,6 +2059,7 @@ retry:
+@@ -2020,6 +2066,7 @@ static int qca_setup(struct hci_uart *hu)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -190,7 +190,7 @@ index 3450013..9a29126 100644
  		break;
  
  	default:
-@@ -2213,6 +2260,21 @@ static const struct qca_device_data qca_soc_data_wcn7850 __maybe_unused = {
+@@ -2220,6 +2267,21 @@ static const struct qca_device_data qca_soc_data_wcn7850 __maybe_unused = {
  			QCA_CAP_HFP_HW_OFFLOAD,
  };
  
@@ -212,7 +212,7 @@ index 3450013..9a29126 100644
  static void qca_power_off(struct hci_uart *hu)
  {
  	struct qca_serdev *qcadev;
-@@ -2423,6 +2485,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
+@@ -2430,6 +2492,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -220,7 +220,7 @@ index 3450013..9a29126 100644
  		qcadev->bt_power = devm_kzalloc(&serdev->dev,
  						sizeof(struct qca_power),
  						GFP_KERNEL);
-@@ -2442,6 +2505,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
+@@ -2449,6 +2512,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -228,7 +228,7 @@ index 3450013..9a29126 100644
  		if (!device_property_present(&serdev->dev, "enable-gpios")) {
  			/*
  			 * Backward compatibility with old DT sources. If the
-@@ -2492,7 +2556,8 @@ static int qca_serdev_probe(struct serdev_device *serdev)
+@@ -2499,7 +2563,8 @@ static int qca_serdev_probe(struct serdev_device *serdev)
  		if (IS_ERR(qcadev->sw_ctrl) &&
  		    (data->soc_type == QCA_WCN6750 ||
  		     data->soc_type == QCA_WCN6855 ||
@@ -238,7 +238,7 @@ index 3450013..9a29126 100644
  			dev_err(&serdev->dev, "failed to acquire SW_CTRL gpio\n");
  			return PTR_ERR(qcadev->sw_ctrl);
  		}
-@@ -2577,6 +2642,7 @@ static void qca_serdev_remove(struct serdev_device *serdev)
+@@ -2584,6 +2649,7 @@ static void qca_serdev_remove(struct serdev_device *serdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -246,7 +246,7 @@ index 3450013..9a29126 100644
  		if (power->vregs_on)
  			qca_power_off(&qcadev->serdev_hu);
  		break;
-@@ -2779,6 +2845,7 @@ static const struct of_device_id qca_bluetooth_of_match[] = {
+@@ -2786,6 +2852,7 @@ static const struct of_device_id qca_bluetooth_of_match[] = {
  	{ .compatible = "qcom,wcn6750-bt", .data = &qca_soc_data_wcn6750},
  	{ .compatible = "qcom,wcn6855-bt", .data = &qca_soc_data_wcn6855},
  	{ .compatible = "qcom,wcn7850-bt", .data = &qca_soc_data_wcn7850},

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0049-drm-msm-a8xx-add-adreno-830-catalog.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0049-drm-msm-a8xx-add-adreno-830-catalog.patch
@@ -7,7 +7,7 @@ never binds -> no Vulkan -> sway can't render -> no GUI. Carry the
 a830 reglists + catalog entry on top of 7.1's a8xx support.
 ---
 diff --git a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
-index 550ff3a9b82e..a97bf2c0c89d 100644
+index 550ff3a9b..a97bf2c0c 100644
 --- a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
 +++ b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
 @@ -1799,6 +1799,272 @@ static const struct adreno_reglist_pipe x285_dyn_pwrup_reglist_regs[] = {
@@ -328,10 +328,10 @@ index 550ff3a9b82e..a97bf2c0c89d 100644
  		.chip_ids = ADRENO_CHIP_IDS(0x44050a01),
  		.family = ADRENO_8XX_GEN2,
 diff --git a/drivers/gpu/drm/msm/adreno/adreno_gpu.h b/drivers/gpu/drm/msm/adreno/adreno_gpu.h
-index c0ee544ce257..2dd009b1ced5 100644
+index ec643b846..c75a6772d 100644
 --- a/drivers/gpu/drm/msm/adreno/adreno_gpu.h
 +++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.h
-@@ -601,6 +601,11 @@ static inline int adreno_is_x285(struct adreno_gpu *gpu)
+@@ -597,6 +597,11 @@ static inline int adreno_is_x285(struct adreno_gpu *gpu)
  	return gpu->info->chip_ids[0] == 0x44070001;
  }
  
@@ -343,6 +343,3 @@ index c0ee544ce257..2dd009b1ced5 100644
  static inline int adreno_is_a840(struct adreno_gpu *gpu)
  {
  	return gpu->info->chip_ids[0] == 0x44050a01;
--- 
-2.43.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0052-arm64-dts-qcom-cq8725s-ayn-wire-ss-through-redriver.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0052-arm64-dts-qcom-cq8725s-ayn-wire-ss-through-redriver.patch
@@ -16,9 +16,11 @@ Signed-off-by: André Braga <code@andrebraga.com>
  arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 35 +++++++--
  1 file changed, 33 insertions(+), 2 deletions(-)
 
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 6090b5b3c..fc16d0432 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-@@ -215,7 +215,7 @@
+@@ -213,7 +213,7 @@ port@1 {
  					reg = <1>;
  
  					pmic_glink_ss_in: endpoint {
@@ -27,7 +29,7 @@ Signed-off-by: André Braga <code@andrebraga.com>
  					};
  				};
  
-@@ -890,6 +890,37 @@
+@@ -888,6 +888,37 @@ spk_amp_r: spk_amp_r@35 {
  		awinic,sync-flag;
  		sound-name-prefix = "SPK_R";
  	};
@@ -65,7 +67,7 @@ Signed-off-by: André Braga <code@andrebraga.com>
  };
  
  &iris {
-@@ -1222,7 +1253,7 @@
+@@ -1220,7 +1251,7 @@ &usb_dp_qmpphy {
  };
  
  &usb_dp_qmpphy_out {
@@ -74,6 +76,3 @@ Signed-off-by: André Braga <code@andrebraga.com>
  };
  
  &usb_dwc3_hs {
-
--- 
-2.43.0

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0054-regulator-add-sgm3804-i2c-regulator-for-panel-power-.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0054-regulator-add-sgm3804-i2c-regulator-for-panel-power-.patch
@@ -12,10 +12,10 @@ Subject: [PATCH] regulator: add sgm3804 i2c regulator for panel power
  create mode 100644 drivers/regulator/sgm3804-regulator.c
 
 diff --git a/drivers/regulator/Kconfig b/drivers/regulator/Kconfig
-index 05e32d764028..631a0ad98724 100644
+index 87554ab92..5b38f469f 100644
 --- a/drivers/regulator/Kconfig
 +++ b/drivers/regulator/Kconfig
-@@ -1353,6 +1353,12 @@ config REGULATOR_SC2731
+@@ -1491,6 +1491,12 @@ config REGULATOR_SC2731
  	  This driver provides support for the voltage regulators on the
  	  SC2731 PMIC.
  
@@ -29,20 +29,20 @@ index 05e32d764028..631a0ad98724 100644
  	tristate "Skyworks Solutions SKY81452 voltage regulator"
  	depends on MFD_SKY81452
 diff --git a/drivers/regulator/Makefile b/drivers/regulator/Makefile
-index 524e026c0273..8b6925a159a3 100644
+index 35639f311..98ecbbc3c 100644
 --- a/drivers/regulator/Makefile
 +++ b/drivers/regulator/Makefile
-@@ -158,6 +158,7 @@ obj-$(CONFIG_REGULATOR_S2MPA01) += s2mpa01.o
+@@ -172,6 +172,7 @@ obj-$(CONFIG_REGULATOR_S2MPA01) += s2mpa01.o
  obj-$(CONFIG_REGULATOR_S2MPS11) += s2mps11.o
  obj-$(CONFIG_REGULATOR_S5M8767) += s5m8767.o
  obj-$(CONFIG_REGULATOR_SC2731) += sc2731-regulator.o
 +obj-$(CONFIG_REGULATOR_SGM3804) += sgm3804-regulator.o
  obj-$(CONFIG_REGULATOR_SKY81452) += sky81452-regulator.o
  obj-$(CONFIG_REGULATOR_SLG51000) += slg51000-regulator.o
- obj-$(CONFIG_REGULATOR_STM32_BOOSTER) += stm32-booster.o
+ obj-$(CONFIG_REGULATOR_SPACEMIT_P1) += spacemit-p1.o
 diff --git a/drivers/regulator/sgm3804-regulator.c b/drivers/regulator/sgm3804-regulator.c
 new file mode 100644
-index 0000000..5e7eac930
+index 000000000..5e7eac930
 --- /dev/null
 +++ b/drivers/regulator/sgm3804-regulator.c
 @@ -0,0 +1,162 @@

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0066-scsi-ufs-ufs-qcom-add-sm8750-compatible.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0066-scsi-ufs-ufs-qcom-add-sm8750-compatible.patch
@@ -6,9 +6,11 @@ the generic "qcom,ufshc" match with no drvdata. Match
 "qcom,sm8750-ufshc" to ufs_qcom_sm8550_drvdata (as SM8650 does) so it
 picks up UFSHCD_QUIRK_BROKEN_LSDBS_CAP and no_phy_retention.
 ---
+diff --git a/drivers/ufs/host/ufs-qcom.c b/drivers/ufs/host/ufs-qcom.c
+index 9c0973a7f..86adb2980 100644
 --- a/drivers/ufs/host/ufs-qcom.c
 +++ b/drivers/ufs/host/ufs-qcom.c
-@@ -2426,6 +2426,7 @@ static const struct of_device_id ufs_qcom_of_match[] __maybe_unused = {
+@@ -2995,6 +2995,7 @@ static const struct of_device_id ufs_qcom_of_match[] __maybe_unused = {
  	{ .compatible = "qcom,ufshc" },
  	{ .compatible = "qcom,sm8550-ufshc", .data = &ufs_qcom_sm8550_drvdata },
  	{ .compatible = "qcom,sm8650-ufshc", .data = &ufs_qcom_sm8550_drvdata },

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0500-ROCKNIX-set-boot-fanspeed.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0500-ROCKNIX-set-boot-fanspeed.patch
@@ -1,7 +1,8 @@
-diff -rupbN linux.orig/drivers/hwmon/pwm-fan.c linux/drivers/hwmon/pwm-fan.c
---- linux.orig/drivers/hwmon/pwm-fan.c	2024-10-19 13:35:29.516991617 +0000
-+++ linux/drivers/hwmon/pwm-fan.c	2024-11-18 15:41:47.343729846 +0000
-@@ -530,7 +530,7 @@ static int pwm_fan_probe(struct platform
+diff --git a/drivers/hwmon/pwm-fan.c b/drivers/hwmon/pwm-fan.c
+index 37269db2d..c181a6886 100644
+--- a/drivers/hwmon/pwm-fan.c
++++ b/drivers/hwmon/pwm-fan.c
+@@ -566,7 +566,7 @@ static int pwm_fan_probe(struct platform_device *pdev)
  	 * Set duty cycle to maximum allowed and enable PWM output as well as
  	 * the regulator. In case of error nothing is changed
  	 */

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0501-ROCKNIX-fix-wifi-and-bt-mac.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0501-ROCKNIX-fix-wifi-and-bt-mac.patch
@@ -10,7 +10,7 @@ Subject: [PATCH] drivers: use soc serial for wifi and bluetooth
  3 files changed, 209 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/bluetooth/btqca.c b/drivers/bluetooth/btqca.c
-index dfbbac92242a..dbe838040a67 100644
+index 49acf9695..bb461e5e6 100644
 --- a/drivers/bluetooth/btqca.c
 +++ b/drivers/bluetooth/btqca.c
 @@ -13,6 +13,78 @@
@@ -92,7 +92,7 @@ index dfbbac92242a..dbe838040a67 100644
  int qca_read_soc_version(struct hci_dev *hdev, struct qca_btsoc_version *ver,
  			 enum qca_btsoc_type soc_type)
  {
-@@ -668,7 +740,7 @@ int qca_set_bdaddr_rome(struct hci_dev *hdev, const bdaddr_t *bdaddr)
+@@ -697,7 +769,7 @@ int qca_set_bdaddr_rome(struct hci_dev *hdev, const bdaddr_t *bdaddr)
  }
  EXPORT_SYMBOL_GPL(qca_set_bdaddr_rome);
  
@@ -101,7 +101,7 @@ index dfbbac92242a..dbe838040a67 100644
  {
  	struct hci_rp_read_bd_addr *bda;
  	struct sk_buff *skb;
-@@ -739,6 +811,7 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
+@@ -773,6 +845,7 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
  	u8 rom_ver = 0;
  	u32 soc_ver;
  	u16 boardid = 0;
@@ -109,7 +109,7 @@ index dfbbac92242a..dbe838040a67 100644
  
  	bt_dev_dbg(hdev, "QCA setup on UART");
  
-@@ -918,9 +991,30 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
+@@ -1019,9 +1092,30 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
  		break;
  	}
  
@@ -142,48 +142,13 @@ index dfbbac92242a..dbe838040a67 100644
  
  	bt_dev_info(hdev, "QCA setup on UART is completed");
  
-diff --git a/drivers/soc/qcom/socinfo.c b/drivers/soc/qcom/socinfo.c
-index ecfd3da9d5e8..238f804e7fe0 100644
---- a/drivers/soc/qcom/socinfo.c
-+++ b/drivers/soc/qcom/socinfo.c
-@@ -163,6 +163,10 @@ struct smem_image_version {
- };
- #endif /* CONFIG_DEBUG_FS */
- 
-+/* Global variable to hold the serial number */
-+const char *qcom_serial_number;
-+EXPORT_SYMBOL(qcom_serial_number);
-+
- struct qcom_socinfo {
- 	struct soc_device *soc_dev;
- 	struct soc_device_attribute attr;
-@@ -795,6 +799,9 @@ static int qcom_socinfo_probe(struct platform_device *pdev)
- 							le32_to_cpu(info->serial_num));
- 		if (!qs->attr.serial_number)
- 			return -ENOMEM;
-+
-+		/* Assign the serial number to the global variable */
-+		qcom_serial_number = qs->attr.serial_number;
- 	}
- 
- 	qs->soc_dev = soc_device_register(&qs->attr);
-@@ -818,6 +825,9 @@ static void qcom_socinfo_remove(struct platform_device *pdev)
- 	soc_device_unregister(qs->soc_dev);
- 
- 	socinfo_debugfs_exit(qs);
-+
-+	/* Clear the global serial number */
-+	qcom_serial_number = NULL;
- }
- 
- static struct platform_driver qcom_socinfo_driver = {
 diff --git a/drivers/net/wireless/ath/ath12k/mac.c b/drivers/net/wireless/ath/ath12k/mac.c
-index d493ec812055..0e535e96e27b 100644
+index 7408c2577..687179afe 100644
 --- a/drivers/net/wireless/ath/ath12k/mac.c
 +++ b/drivers/net/wireless/ath/ath12k/mac.c
-@@ -159,6 +159,91 @@ static const struct ieee80211_channel ath12k_6ghz_channels[] = {
- 	CHAN6G(233, 7115, 0),
- };
+@@ -172,6 +172,91 @@ static const struct ieee80211_channel ath12k_6ghz_channels[] = {
+ 	{ .bitrate = (bps), .hw_value = (code), .hw_value_short = (code_short),\
+ 	  .flags = IEEE80211_RATE_SHORT_PREAMBLE }
  
 +extern const char *qcom_serial_number;
 +
@@ -273,7 +238,7 @@ index d493ec812055..0e535e96e27b 100644
  static struct ieee80211_rate ath12k_legacy_rates[] = {
  	{ .bitrate = 10,
  	  .hw_value = ATH12K_HW_RATE_CCK_LP_1M },
-@@ -9533,6 +9618,7 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+@@ -14483,6 +14568,7 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
  	struct ath12k_base *ab = ar->ab;
  	struct ath12k_pdev *pdev;
  	struct ath12k_pdev_cap *cap;
@@ -281,7 +246,7 @@ index d493ec812055..0e535e96e27b 100644
  	static const u32 cipher_suites[] = {
  		WLAN_CIPHER_SUITE_TKIP,
  		WLAN_CIPHER_SUITE_CCMP,
-@@ -9556,11 +9642,17 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+@@ -14506,11 +14592,17 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
  		u32 ht_cap_info = 0;
  
  		pdev = ar->pdev;
@@ -303,3 +268,38 @@ index d493ec812055..0e535e96e27b 100644
  		}
  
  		ret = ath12k_mac_setup_register(ar, &ht_cap_info, hw->wiphy->bands);
+diff --git a/drivers/soc/qcom/socinfo.c b/drivers/soc/qcom/socinfo.c
+index b2a535727..6dd8afbb4 100644
+--- a/drivers/soc/qcom/socinfo.c
++++ b/drivers/soc/qcom/socinfo.c
+@@ -225,6 +225,10 @@ struct smem_image_version {
+ };
+ #endif /* CONFIG_DEBUG_FS */
+ 
++/* Global variable to hold the serial number */
++const char *qcom_serial_number;
++EXPORT_SYMBOL(qcom_serial_number);
++
+ struct qcom_socinfo {
+ 	struct soc_device *soc_dev;
+ 	struct soc_device_attribute attr;
+@@ -903,6 +907,9 @@ static int qcom_socinfo_probe(struct platform_device *pdev)
+ 							le32_to_cpu(info->serial_num));
+ 		if (!qs->attr.serial_number)
+ 			return -ENOMEM;
++
++		/* Assign the serial number to the global variable */
++		qcom_serial_number = qs->attr.serial_number;
+ 	}
+ 
+ 	qs->soc_dev = soc_device_register(&qs->attr);
+@@ -926,6 +933,9 @@ static void qcom_socinfo_remove(struct platform_device *pdev)
+ 	soc_device_unregister(qs->soc_dev);
+ 
+ 	socinfo_debugfs_exit(qs);
++
++	/* Clear the global serial number */
++	qcom_serial_number = NULL;
+ }
+ 
+ static struct platform_driver qcom_socinfo_driver = {

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0503-ROCKNIX-battery-name.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0503-ROCKNIX-battery-name.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] power:supply: rename qcom battmgr sysfs
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/power/supply/qcom_battmgr.c b/drivers/power/supply/qcom_battmgr.c
-index 3c2837ef3461..157c2d965931 100644
+index 490137a23..92a9729e9 100644
 --- a/drivers/power/supply/qcom_battmgr.c
 +++ b/drivers/power/supply/qcom_battmgr.c
-@@ -931,7 +931,7 @@ static const enum power_supply_property sm8550_bat_props[] = {
+@@ -921,7 +921,7 @@ static const enum power_supply_property sm8550_bat_props[] = {
  };
  
  static const struct power_supply_desc sm8550_bat_psy_desc = {
@@ -20,6 +20,3 @@ index 3c2837ef3461..157c2d965931 100644
  	.type = POWER_SUPPLY_TYPE_BATTERY,
  	.properties = sm8550_bat_props,
  	.num_properties = ARRAY_SIZE(sm8550_bat_props),
--- 
-2.52.0
-

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0504-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0504-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
@@ -20,10 +20,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  5 files changed, 29 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/input/input-compat.c b/drivers/input/input-compat.c
-index 2ccd3eedbd6733..abb8cfb99d6cf9 100644
+index a5043193e..a3c0c7012 100644
 --- a/drivers/input/input-compat.c
 +++ b/drivers/input/input-compat.c
-@@ -14,7 +14,7 @@
+@@ -15,7 +15,7 @@
  int input_event_from_user(const char __user *buffer,
  			  struct input_event *event)
  {
@@ -32,7 +32,7 @@ index 2ccd3eedbd6733..abb8cfb99d6cf9 100644
  		struct input_event_compat compat_event;
  
  		if (copy_from_user(&compat_event, buffer,
-@@ -38,7 +38,7 @@ int input_event_from_user(const char __user *buffer,
+@@ -39,7 +39,7 @@ int input_event_from_user(const char __user *buffer,
  int input_event_to_user(char __user *buffer,
  			const struct input_event *event)
  {
@@ -41,7 +41,7 @@ index 2ccd3eedbd6733..abb8cfb99d6cf9 100644
  		struct input_event_compat compat_event;
  
  		compat_event.sec = event->input_event_sec;
-@@ -62,7 +62,7 @@ int input_event_to_user(char __user *buffer,
+@@ -63,7 +63,7 @@ int input_event_to_user(char __user *buffer,
  int input_ff_effect_from_user(const char __user *buffer, size_t size,
  			      struct ff_effect *effect)
  {
@@ -51,7 +51,7 @@ index 2ccd3eedbd6733..abb8cfb99d6cf9 100644
  
  		if (size != sizeof(struct ff_effect_compat))
 diff --git a/drivers/input/input-compat.h b/drivers/input/input-compat.h
-index 3b7bb12b023bc6..e78c0492ce0d36 100644
+index 99c87ceb9..e0e078306 100644
 --- a/drivers/input/input-compat.h
 +++ b/drivers/input/input-compat.h
 @@ -53,7 +53,7 @@ struct ff_effect_compat {
@@ -64,12 +64,12 @@ index 3b7bb12b023bc6..e78c0492ce0d36 100644
  }
  
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 77f01ac385f7a5..01125573065ecd 100644
+index ee06cba5c..0d03bd4d6 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -1535,6 +1535,11 @@ struct task_struct {
- #ifdef CONFIG_USER_EVENTS
- 	struct user_event_mm		*user_event_mm;
+@@ -1530,6 +1530,11 @@ struct task_struct {
+ #ifdef CONFIG_MEMCG_V1
+ 	struct mem_cgroup		*memcg_in_oom;
  #endif
 +	/*
 +	 * Whether the task wants to use compat input syscalls even if it's
@@ -77,15 +77,15 @@ index 77f01ac385f7a5..01125573065ecd 100644
 +	 */
 +	bool compat_input;
  
- 	/*
- 	 * New fields for task_struct should be added above here, so that
+ #ifdef CONFIG_MEMCG
+ 	/* Number of pages to reclaim on returning to userland: */
 diff --git a/include/uapi/linux/prctl.h b/include/uapi/linux/prctl.h
-index 961216093f11ab..86fca7d168cc66 100644
+index b6ec6f693..55ca31b52 100644
 --- a/include/uapi/linux/prctl.h
 +++ b/include/uapi/linux/prctl.h
-@@ -311,4 +311,9 @@ struct prctl_mm_map {
- # define PR_SET_MEM_MODEL_DEFAULT	0
- # define PR_SET_MEM_MODEL_TSO		1
+@@ -416,4 +416,9 @@ struct prctl_mm_map {
+ # define PR_CFI_DISABLE		_BITUL(1)
+ # define PR_CFI_LOCK		_BITUL(2)
  
 +#define PR_GET_COMPAT_INPUT    0x63494e50
 +#define PR_SET_COMPAT_INPUT    0x43494e50
@@ -94,12 +94,12 @@ index 961216093f11ab..86fca7d168cc66 100644
 +
  #endif /* _LINUX_PRCTL_H */
 diff --git a/kernel/sys.c b/kernel/sys.c
-index 2db751ce25a260..1be74620b0b659 100644
+index 62e842055..6b2c92de2 100644
 --- a/kernel/sys.c
 +++ b/kernel/sys.c
-@@ -2768,6 +2768,21 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
- 			return -EINVAL;
- 		error = arch_prctl_mem_model_set(me, arg2);
+@@ -2907,6 +2907,21 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
+ 		if (arg3 & PR_CFI_LOCK && !(arg3 & PR_CFI_DISABLE))
+ 			error = arch_prctl_lock_branch_landing_pad_state(me);
  		break;
 +	case PR_GET_COMPAT_INPUT:
 +		if (arg2 || arg3 || arg4 || arg5)
@@ -117,5 +117,5 @@ index 2db751ce25a260..1be74620b0b659 100644
 +			return -EINVAL;
 +		break;
  	default:
+ 		trace_task_prctl_unknown(option, arg2, arg3, arg4, arg5);
  		error = -EINVAL;
- 		break;

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0505-msm_gem-lock-before-put_iova_spaces.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0505-msm_gem-lock-before-put_iova_spaces.patch
@@ -1,5 +1,5 @@
 diff --git a/drivers/gpu/drm/msm/msm_gem.c b/drivers/gpu/drm/msm/msm_gem.c
-index b27abaa13..982c96366 100644
+index efd3d3c9a..a0a71e11c 100644
 --- a/drivers/gpu/drm/msm/msm_gem.c
 +++ b/drivers/gpu/drm/msm/msm_gem.c
 @@ -53,25 +53,29 @@ static void msm_gem_close(struct drm_gem_object *obj, struct drm_file *file)
@@ -265,7 +265,7 @@ index b27abaa13..982c96366 100644
  }
  
  static struct drm_gpuva *get_vma_locked(struct drm_gem_object *obj,
-@@ -556,8 +730,10 @@ int msm_gem_get_and_pin_iova_range(struct drm_gem_object *obj,
+@@ -559,8 +733,10 @@ int msm_gem_get_and_pin_iova_range(struct drm_gem_object *obj,
  	struct drm_exec exec;
  	int ret;
  
@@ -278,7 +278,7 @@ index b27abaa13..982c96366 100644
  	drm_exec_fini(&exec);     /* drop locks */
  
  	return ret;
-@@ -579,14 +755,16 @@ int msm_gem_get_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm,
+@@ -582,14 +758,16 @@ int msm_gem_get_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm,
  {
  	struct drm_gpuva *vma;
  	struct drm_exec exec;
@@ -302,7 +302,7 @@ index b27abaa13..982c96366 100644
  	}
  	drm_exec_fini(&exec);     /* drop locks */
  
-@@ -620,17 +798,20 @@ int msm_gem_set_iova(struct drm_gem_object *obj,
+@@ -623,17 +801,20 @@ int msm_gem_set_iova(struct drm_gem_object *obj,
  	struct drm_exec exec;
  	int ret = 0;
  
@@ -334,7 +334,7 @@ index b27abaa13..982c96366 100644
  		}
  	}
  	drm_exec_fini(&exec);     /* drop locks */
-@@ -658,14 +839,18 @@ void msm_gem_unpin_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm)
+@@ -661,14 +842,18 @@ void msm_gem_unpin_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm)
  {
  	struct drm_gpuva *vma;
  	struct drm_exec exec;

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
@@ -25,6 +25,12 @@ can be dropped by a chance comparison against stack garbage.
 Bail out with -EPROBE_DEFER before the dedup loop when no device was
 found, and zero-initialise both arrays.
 
+[7.1.6: mux half dropped. typec_mux_match() lost its dedup loop and
+fwnode_typec_mux_get() was rewritten (kzalloc_obj + bounded for-loop
+that only reads populated slots) between 7.1.3 and 7.1.6, so that half
+of this bug no longer exists upstream. typec_switch_match() and
+fwnode_typec_switch_get() are unchanged and still carry it -- kept.]
+
 Device-observed on an AYN Odin 3 (SM8750): dock DisplayPort output died
 with the 7.0.11 -> 7.1.3 bump. The firmware enters DP alt mode correctly
 (mux_ctrl=3, pin_assignment=4), raises HPD, and msm_dp powers up its
@@ -61,33 +67,5 @@ Signed-off-by: Anze <aanzdev@gmail.com>
 -	struct typec_switch_dev *sw_devs[TYPEC_MUX_MAX_DEVS];
 +	struct typec_switch_dev *sw_devs[TYPEC_MUX_MAX_DEVS] = {};
  	struct typec_switch *sw;
- 	int count;
- 	int err;
-@@ -292,6 +294,8 @@
- 
- 	dev = class_find_device(&typec_mux_class, NULL, fwnode,
- 				mux_fwnode_match);
-+	if (!dev)
-+		return ERR_PTR(-EPROBE_DEFER);
- 
- 	/* Skip duplicates */
- 	for (i = 0; i < TYPEC_MUX_MAX_DEVS; i++)
-@@ -300,8 +304,7 @@
- 			return NULL;
- 		}
- 
--
--	return dev ? to_typec_mux_dev(dev) : ERR_PTR(-EPROBE_DEFER);
-+	return to_typec_mux_dev(dev);
- }
- 
- /**
-@@ -315,7 +318,7 @@
-  */
- struct typec_mux *fwnode_typec_mux_get(struct fwnode_handle *fwnode)
- {
--	struct typec_mux_dev *mux_devs[TYPEC_MUX_MAX_DEVS];
-+	struct typec_mux_dev *mux_devs[TYPEC_MUX_MAX_DEVS] = {};
- 	struct typec_mux *mux;
  	int count;
  	int err;

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0601-ROCKNIX-odin3-pwm-fan-sysfs.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0601-ROCKNIX-odin3-pwm-fan-sysfs.patch
@@ -6,12 +6,10 @@ is accessible to userspace fan control via sysfs.
 Cooling levels (8 states): 0=off, 1-7=30/45/60/70/90/120/150 PWM
 ---
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index fc16d0432..8f5247e12 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-@@ -91,10 +91,12 @@
- 	pwm_fan: pwm-fan {
- 		compatible = "pwm-fan";
- 
+@@ -94,6 +94,8 @@ pwm_fan: pwm-fan {
  		fan-supply = <&vdd_fan_5v0>;
  		pwms = <&pm8550_pwm 3 40000>;
  

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
@@ -15,12 +15,14 @@ kcontrols are enabled, so it changes nothing on its own.
 
 Signed-off-by: Anze <aanzdev@gmail.com>
 ---
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index f91e6db9b..8723da2c9 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-@@ -1035,6 +1035,12 @@
+@@ -1068,6 +1068,12 @@ &sdhc_2 {
  &swr1 {
  	status = "okay";
-
+ 
 +	/* Master port 9 carries the WCD939x HIFI_PCM headphone stream
 +	 * (384 kHz PCM), so the controller needs its per-port PCM format
 +	 * enable set for it. Inert unless the HPH PCM mode kcontrols are

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/1000-input-misc-qcom-hv-haptics-sm8750.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/1000-input-misc-qcom-hv-haptics-sm8750.patch
@@ -1,4 +1,43 @@
-diff -Naur a/drivers/input/misc/qcom-hv-haptics.c b/drivers/input/misc/qcom-hv-haptics.c
+diff --git a/drivers/input/misc/Kconfig b/drivers/input/misc/Kconfig
+index 398d4f657..66960e21b 100644
+--- a/drivers/input/misc/Kconfig
++++ b/drivers/input/misc/Kconfig
+@@ -236,6 +236,20 @@ config INPUT_PMIC8XXX_PWRKEY
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called pmic8xxx-pwrkey.
+ 
++config INPUT_QCOM_HV_HAPTICS
++	tristate "QTI High Voltage Haptics support"
++	depends on MFD_SPMI_PMIC
++   depends on ARCH_QCOM || COMPILE_TEST
++   depends on QCOM_SMEM
++   depends on QCOM_RPROC_COMMON
++	help
++	  This option enables device driver support for the high voltage haptics
++	  peripheral found on Qualcomm Technologies, Inc. PMICs.  The high voltage
++	  haptics peripheral is capable of driving either LRA or ERM vibrators with
++	  drive voltage up to 10 V, and its 5 integrated pattern sources can be used
++	  for playing different vibration effects. To compile this driver as a module,
++	  choose M here: the module will be called qcom-hv-haptics.
++
+ config INPUT_SPARCSPKR
+ 	tristate "SPARC Speaker support"
+ 	depends on PCI && SPARC64
+diff --git a/drivers/input/misc/Makefile b/drivers/input/misc/Makefile
+index 3ddc57e49..e5a6c7a45 100644
+--- a/drivers/input/misc/Makefile
++++ b/drivers/input/misc/Makefile
+@@ -68,6 +68,7 @@ obj-$(CONFIG_INPUT_PF1550_ONKEY)	+= pf1550-onkey.o
+ obj-$(CONFIG_INPUT_PM8941_PWRKEY)	+= pm8941-pwrkey.o
+ obj-$(CONFIG_INPUT_PM8XXX_VIBRATOR)	+= pm8xxx-vibrator.o
+ obj-$(CONFIG_INPUT_PMIC8XXX_PWRKEY)	+= pmic8xxx-pwrkey.o
++obj-$(CONFIG_INPUT_QCOM_HV_HAPTICS)	+= qcom-hv-haptics.o
+ obj-$(CONFIG_INPUT_POWERMATE)		+= powermate.o
+ obj-$(CONFIG_INPUT_PWM_BEEPER)		+= pwm-beeper.o
+ obj-$(CONFIG_INPUT_PWM_VIBRA)		+= pwm-vibra.o
+diff --git a/drivers/input/misc/qcom-hv-haptics.c b/drivers/input/misc/qcom-hv-haptics.c
+new file mode 100644
+index 000000000..729be26ac
 --- /dev/null
 +++ b/drivers/input/misc/qcom-hv-haptics.c
 @@ -0,0 +1,6736 @@
@@ -6738,90 +6777,11 @@ diff -Naur a/drivers/input/misc/qcom-hv-haptics.c b/drivers/input/misc/qcom-hv-h
 +
 +MODULE_DESCRIPTION("Qualcomm Technologies, Inc. High-Voltage Haptics driver");
 +MODULE_LICENSE("GPL");
-diff -Naur a/include/linux/soc/qcom/qcom_hv_haptics.h b/include/linux/soc/qcom/qcom_hv_haptics.h
+diff --git a/include/dt-bindings/input/qcom,hv-haptics.h b/include/dt-bindings/input/qcom,hv-haptics.h
+new file mode 100644
+index 000000000..8453d2ae9
 --- /dev/null
-+++ b/include/linux/soc/qcom/qcom_hv_haptics.h
-@@ -0,0 +1,41 @@
-+/* SPDX-License-Identifier: GPL-2.0-only */
-+/*
-+ * Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
-+ */
-+
-+#ifndef _QCOM_HV_HAPTICS_H
-+#define _QCOM_HV_HAPTICS_H
-+
-+#include <linux/input.h>
-+#include <linux/remoteproc/qcom_rproc.h>
-+#include <linux/platform_device.h>
-+
-+#if IS_ENABLED(CONFIG_INPUT_QCOM_HV_HAPTICS)
-+bool qcom_haptics_vi_sense_is_enabled(void);
-+
-+int qcom_spmi_haptics_global_upload(struct ff_effect *effect);
-+int qcom_spmi_haptics_global_playback(int effect_id, int val);
-+int qcom_spmi_haptics_global_set_gain(u16 gain);
-+#else
-+static inline bool qcom_haptics_vi_sense_is_enabled(void)
-+{
-+	return false;
-+}
-+
-+static inline int qcom_spmi_haptics_global_upload(struct ff_effect *effect)
-+{
-+    return 0;
-+}
-+
-+static inline int qcom_spmi_haptics_global_playback(int effect_id, int val)
-+{
-+    return 0;
-+}
-+
-+static inline int qcom_spmi_haptics_global_set_gain(u16 gain)
-+{
-+    return 0;
-+}
-+#endif
-+
-+#endif
-\ No newline at end of file
-diff -Naur a/drivers/input/misc/Kconfig b/drivers/input/misc/Kconfig
---- a/drivers/input/misc/Kconfig	2025-03-22 22:54:28.000000000 +0300
-+++ b/drivers/input/misc/Kconfig	2025-03-30 00:33:07.140188820 +0300
-@@ -214,6 +214,20 @@
- 	  To compile this driver as a module, choose M here: the
- 	  module will be called pmic8xxx-pwrkey.
- 
-+config INPUT_QCOM_HV_HAPTICS
-+	tristate "QTI High Voltage Haptics support"
-+	depends on MFD_SPMI_PMIC
-+   depends on ARCH_QCOM || COMPILE_TEST
-+   depends on QCOM_SMEM
-+   depends on QCOM_RPROC_COMMON
-+	help
-+	  This option enables device driver support for the high voltage haptics
-+	  peripheral found on Qualcomm Technologies, Inc. PMICs.  The high voltage
-+	  haptics peripheral is capable of driving either LRA or ERM vibrators with
-+	  drive voltage up to 10 V, and its 5 integrated pattern sources can be used
-+	  for playing different vibration effects. To compile this driver as a module,
-+	  choose M here: the module will be called qcom-hv-haptics.
-+
- config INPUT_SPARCSPKR
- 	tristate "SPARC Speaker support"
- 	depends on PCI && SPARC64
-diff -Naur a/drivers/input/misc/Makefile b/drivers/input/misc/Makefile
---- a/drivers/input/misc/Makefile	2025-03-22 22:54:28.000000000 +0300
-+++ b/drivers/input/misc/Makefile	2025-03-30 00:33:07.144188820 +0300
-@@ -65,6 +65,7 @@
- obj-$(CONFIG_INPUT_PM8941_PWRKEY)	+= pm8941-pwrkey.o
- obj-$(CONFIG_INPUT_PM8XXX_VIBRATOR)	+= pm8xxx-vibrator.o
- obj-$(CONFIG_INPUT_PMIC8XXX_PWRKEY)	+= pmic8xxx-pwrkey.o
-+obj-$(CONFIG_INPUT_QCOM_HV_HAPTICS)	+= qcom-hv-haptics.o
- obj-$(CONFIG_INPUT_POWERMATE)		+= powermate.o
- obj-$(CONFIG_INPUT_PWM_BEEPER)		+= pwm-beeper.o
- obj-$(CONFIG_INPUT_PWM_VIBRA)		+= pwm-vibra.o
-diff -Naur a/include/dt-bindings/input/qcom,hv-haptics.h b/include/dt-bindings/input/qcom,hv-haptics.h
---- a/include/dt-bindings/input/qcom,hv-haptics.h	1970-01-01 03:00:00.000000000 +0300
-+++ b/include/dt-bindings/input/qcom,hv-haptics.h	2025-03-30 00:33:40.960189233 +0300
++++ b/include/dt-bindings/input/qcom,hv-haptics.h
 @@ -0,0 +1,37 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +/*
@@ -6860,9 +6820,11 @@ diff -Naur a/include/dt-bindings/input/qcom,hv-haptics.h b/include/dt-bindings/i
 +#define S_PERIOD_F_32KHZ		11
 +#define S_PERIOD_F_44P1KHZ		12
 +#define S_PERIOD_F_48KHZ		13
-diff -Naur a/include/linux/qpnp/qpnp-pbs.h b/include/linux/qpnp/qpnp-pbs.h
---- a/include/linux/qpnp/qpnp-pbs.h	1970-01-01 03:00:00.000000000 +0300
-+++ b/include/linux/qpnp/qpnp-pbs.h	2025-03-30 00:47:04.476199042 +0300
+diff --git a/include/linux/qpnp/qpnp-pbs.h b/include/linux/qpnp/qpnp-pbs.h
+new file mode 100644
+index 000000000..1834381a2
+--- /dev/null
++++ b/include/linux/qpnp/qpnp-pbs.h
 @@ -0,0 +1,33 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +/*
@@ -6897,9 +6859,11 @@ diff -Naur a/include/linux/qpnp/qpnp-pbs.h b/include/linux/qpnp/qpnp-pbs.h
 +#endif
 +
 +#endif
-diff -Naur a/include/linux/soc/qcom/battery_charger.h b/include/linux/soc/qcom/battery_charger.h
---- a/include/linux/soc/qcom/battery_charger.h	1970-01-01 03:00:00.000000000 +0300
-+++ b/include/linux/soc/qcom/battery_charger.h	2025-03-30 00:48:07.628199813 +0300
+diff --git a/include/linux/soc/qcom/battery_charger.h b/include/linux/soc/qcom/battery_charger.h
+new file mode 100644
+index 000000000..47382d8e0
+--- /dev/null
++++ b/include/linux/soc/qcom/battery_charger.h
 @@ -0,0 +1,45 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +/*
@@ -6946,9 +6910,59 @@ diff -Naur a/include/linux/soc/qcom/battery_charger.h b/include/linux/soc/qcom/b
 +#endif
 +
 +#endif
-diff -Naur a/include/trace/events/qcom_haptics.h b/include/trace/events/qcom_haptics.h
---- a/include/trace/events/qcom_haptics.h	1970-01-01 03:00:00.000000000 +0300
-+++ b/include/trace/events/qcom_haptics.h	2025-03-30 00:49:12.224200601 +0300
+diff --git a/include/linux/soc/qcom/qcom_hv_haptics.h b/include/linux/soc/qcom/qcom_hv_haptics.h
+new file mode 100644
+index 000000000..e32deab3a
+--- /dev/null
++++ b/include/linux/soc/qcom/qcom_hv_haptics.h
+@@ -0,0 +1,41 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#ifndef _QCOM_HV_HAPTICS_H
++#define _QCOM_HV_HAPTICS_H
++
++#include <linux/input.h>
++#include <linux/remoteproc/qcom_rproc.h>
++#include <linux/platform_device.h>
++
++#if IS_ENABLED(CONFIG_INPUT_QCOM_HV_HAPTICS)
++bool qcom_haptics_vi_sense_is_enabled(void);
++
++int qcom_spmi_haptics_global_upload(struct ff_effect *effect);
++int qcom_spmi_haptics_global_playback(int effect_id, int val);
++int qcom_spmi_haptics_global_set_gain(u16 gain);
++#else
++static inline bool qcom_haptics_vi_sense_is_enabled(void)
++{
++	return false;
++}
++
++static inline int qcom_spmi_haptics_global_upload(struct ff_effect *effect)
++{
++    return 0;
++}
++
++static inline int qcom_spmi_haptics_global_playback(int effect_id, int val)
++{
++    return 0;
++}
++
++static inline int qcom_spmi_haptics_global_set_gain(u16 gain)
++{
++    return 0;
++}
++#endif
++
++#endif
+\ No newline at end of file
+diff --git a/include/trace/events/qcom_haptics.h b/include/trace/events/qcom_haptics.h
+new file mode 100644
+index 000000000..e7166dd03
+--- /dev/null
++++ b/include/trace/events/qcom_haptics.h
 @@ -0,0 +1,98 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +/*

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/1003-arm64-dts-qcom-ayn-cq8725s-common-hv-haptics.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/1003-arm64-dts-qcom-ayn-cq8725s-common-hv-haptics.patch
@@ -1,3 +1,5 @@
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 8723da2c9..33bbc27f9 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 @@ -8,6 +8,7 @@
@@ -8,7 +10,7 @@
  #include "sm8750.dtsi"
  #include "pm8550.dtsi"
  #define PMK8550VE_SID 8
-@@ -1001,6 +1002,185 @@
+@@ -1034,6 +1035,185 @@ &pon_resin {
  	status = "okay";
  };
  

--- a/projects/ROCKNIX/devices/SM8750/patches/linux/1300-input-rsinput-ranges.patch
+++ b/projects/ROCKNIX/devices/SM8750/patches/linux/1300-input-rsinput-ranges.patch
@@ -1,6 +1,8 @@
+diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
+index 382596595..4dbf8ae3c 100644
 --- a/drivers/input/joystick/rsinput.c
 +++ b/drivers/input/joystick/rsinput.c
-@@ -29,29 +29,29 @@
+@@ -30,29 +30,29 @@ static int trigger_right_max=0x610;
  static int trigger_right_deadzone=0x0;
  static int trigger_right_antideadzone=0x0;
  

--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -31,7 +31,7 @@ case ${DEVICE} in
     PKG_PATCH_DIRS+=" 7.0"
     ;;
   SM8750)
-    PKG_VERSION="7.1.3"
+    PKG_VERSION="7.1.7"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS+=" 7.0"
     ;;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

Bump SM8750 (in particular Odin 3) to kernel 7.1.7 (current stable).

Also refreshes all 25 SM8750 device patches that had picked up line-offset/fuzz against 7.1.7 during the version-skip (7.1.3 → 7.1.7). Every patch now applies at offset 0 with 0 fuzz. Purely mechanical — no logic changes:

- non-git-diff style patches (`diff -Naur` / `diff -rupbN`) regenerated as unified `diff --git` for consistency
- commit-message headers (`From:`/`Subject:`/rationale) preserved verbatim where they existed

## Testing

* Tested 7.1.7 for several days on my own Odin 3.
* All 63 SM8750 patches apply against pristine 7.1.7: 61 clean, 2 fuzzy (the 2 fuzzy ones are pre-existing from `origin/next`, out of scope here).

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
