### PR TITLE
rpcs3-sa: update package to 0.0.42-19706

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="rpcs3-sa"
 PKG_LICENSE="GPLv2"
 PKG_LONGDESC="PS3 Emulator"
-PKG_VERSION="59e59c7de6e5595c7f9a795489b2570273aafb0d"
+PKG_VERSION="072c4cb71f76fc3ddba5bc781c00cb92eecaf260"
 PKG_SITE="https://github.com/RPCS3/rpcs3"
 PKG_URL="${PKG_SITE}.git"
 PKG_TOOLCHAIN="cmake"


### PR DESCRIPTION
## Summary

**Bump up the standalone RPCS3 emulator (rpcs3-sa) package version to upstream build 0.0.42-19706 (commit hash 072c4cb71f76fc3ddba5bc781c00cb92eecaf260)**

## Testing
**- Manually verified on-device by using a `mount --bind` to hot-swap the compiled upstream binary on the filesystem. 

- Able to load more titles smoothly & better fps, along with performance boost**

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)
**- Regular update to provide version bump & QoL improvements** 
---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code? **NO**