### PR TITLE
linux: build regulatory.db into the kernel

### DIFF
--- a/projects/ROCKNIX/packages/linux/package.mk
+++ b/projects/ROCKNIX/packages/linux/package.mk
@@ -95,6 +95,12 @@ if [ "${DEVICE}" = "SM8650" -o "${DEVICE}" = "SM8750" ]; then
   PKG_DEPENDS_UNPACK+=" extra-firmware"
 fi
 
+# A built-in cfg80211 needs regulatory.db inside the kernel image (see
+# pre_make_target), so unpack wireless-regdb before the kernel is built.
+if grep -q '^CONFIG_CFG80211=y' ${PKG_KERNEL_CFG_FILE}; then
+  PKG_DEPENDS_UNPACK+=" wireless-regdb"
+fi
+
 post_patch() {
   # linux was already built and its build dir autoremoved - prepare it again for kernel packages
   if [ -d ${PKG_INSTALL}/.image ]; then
@@ -278,6 +284,27 @@ pre_make_target() {
     FW_LIST="$(find ${PKG_BUILD}/external-firmware -type f | sed 's|.*external-firmware/||' | sort | xargs)"
 
     ${PKG_BUILD}/scripts/config --set-str CONFIG_EXTRA_FIRMWARE "${FW_LIST}"
+    ${PKG_BUILD}/scripts/config --set-str CONFIG_EXTRA_FIRMWARE_DIR "external-firmware"
+  fi
+
+  # cfg80211 requests regulatory.db as soon as it initialises. Built in (=y on
+  # every device but AMD64) that is during kernel init, while /usr/lib/firmware
+  # is still a dangling symlink to the kernel-overlay tmpfs that
+  # kernel-overlays-setup only populates later (scripts/image) - so the request
+  # fails with -ENOENT, the failure is cached, and the radio stays in domain 00
+  # with 5 GHz no-IR. Build the db into the kernel instead. The .p7s signature
+  # goes with it because CONFIG_CFG80211_REQUIRE_SIGNED_REGDB is set. Appends to
+  # whatever the per-device blocks above already listed (~7 KB in the image).
+  if grep -q '^CONFIG_CFG80211=y' ${PKG_BUILD}/.config; then
+    mkdir -p ${PKG_BUILD}/external-firmware
+      cp -Lv $(get_build_dir wireless-regdb)/regulatory.db ${PKG_BUILD}/external-firmware
+      cp -Lv $(get_build_dir wireless-regdb)/regulatory.db.p7s ${PKG_BUILD}/external-firmware
+
+    FW_LIST="$(${PKG_BUILD}/scripts/config --state CONFIG_EXTRA_FIRMWARE)"
+    [ "${FW_LIST}" = "undef" ] && FW_LIST=""
+
+    ${PKG_BUILD}/scripts/config --set-str CONFIG_EXTRA_FIRMWARE \
+      "$(echo ${FW_LIST} regulatory.db regulatory.db.p7s | xargs)"
     ${PKG_BUILD}/scripts/config --set-str CONFIG_EXTRA_FIRMWARE_DIR "external-firmware"
   fi
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

reluctantly build regulatory.db into the kernel, solution to reported cross-platform bug "regulatory.db does not load at boot for wifi, intermittently breaking 5GHz connections"

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

tested on my konkr pocket fit elite, unclear about other platforms.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

alternative solution is #3130 , which loki flagged as high regression risk, hence this pr instead.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

yes