### PR TITLE
usbgadget: make MTP file transfer enumerate on SuperSpeed hosts

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/usbgadget
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/usbgadget
@@ -15,6 +15,11 @@
 MACHINEIDFILE=/storage/.cache/systemd-machine-id
 SERIAL=$(cat ${MACHINEIDFILE})
 
+# QUIRK_DEVICE only exists in a login shell, and a zero length iProduct makes
+# Windows refuse to start the gadget, so resolve it again rather than trust it.
+PRODUCT="${QUIRK_DEVICE:-$(tr -d '\0' < /sys/firmware/devicetree/base/model 2>/dev/null)}"
+PRODUCT="${PRODUCT:-${OS_NAME}}"
+
 CACHEDIR=/storage/.cache/usbgadget
 GADGETCONF=${CACHEDIR}/usbgadget.conf
 GADGETNETCONF=${CACHEDIR}/network.conf
@@ -139,7 +144,7 @@ prepare_usb_network() {
     echo "${devversion}" > ${g_cdc}/bcdDevice
     mkdir ${g_cdc}/strings/0x409
     echo "${OS_NAME}" > ${g_cdc}/strings/0x409/manufacturer
-    echo "${QUIRK_DEVICE}" > ${g_cdc}/strings/0x409/product
+    echo "${PRODUCT}" > ${g_cdc}/strings/0x409/product
     echo "${SERIAL}" > ${g_cdc}/strings/0x409/serialnumber
 
     # config 1 is for CDC
@@ -263,19 +268,24 @@ g_mtp="/sys/kernel/config/usb_gadget/mtp"
 
 prepare_usb_mtp() {
     usb_ver="0x0200" # USB 2.0
-    dev_class="2" # Communications
+    dev_class="0" # Per interface, umtprd declares Still Imaging
     attr="0xC0" # Self powered
     pwr="0xfe" #
 
     mkdir ${g_mtp}
+    # umtprd is built without CONFIG_USB_SS_SUPPORT, so functionfs only hands the
+    # kernel full and high speed descriptors. On a SuperSpeed capable UDC the
+    # composite layer then finds no configuration valid for the negotiated speed
+    # and stalls GET_DESCRIPTOR(CONFIGURATION), leaving the host stuck at addressed.
+    [ -w ${g_mtp}/max_speed ] && echo "high-speed" > ${g_mtp}/max_speed
     echo "${usb_ver}" > ${g_mtp}/bcdUSB
     echo "${dev_class}" > ${g_mtp}/bDeviceClass
     echo "0x1d6b" > ${g_mtp}/idVendor
-    echo "0x0104" > ${g_mtp}/idProduct
+    echo "0x0100" > ${g_mtp}/idProduct
     echo "${devversion}" > ${g_mtp}/bcdDevice
     mkdir ${g_mtp}/strings/0x409
     echo "${OS_NAME}" > ${g_mtp}/strings/0x409/manufacturer
-    echo "${QUIRK_DEVICE}" > ${g_mtp}/strings/0x409/product
+    echo "${PRODUCT}" > ${g_mtp}/strings/0x409/product
     echo "${SERIAL}" > ${g_mtp}/strings/0x409/serialnumber
 
     # config 1 for MTP
@@ -396,8 +406,8 @@ usb_start() {
 			exit 3
 		fi
 
-		mkdir /dev/ffs-umtp
-		mount mtp -t functionfs /dev/ffs-umtp
+		mkdir -p /dev/ffs-umtp
+		mountpoint -q /dev/ffs-umtp || mount mtp -t functionfs /dev/ffs-umtp
 		/usr/sbin/umtprd &
 		sleep 1
 
@@ -425,6 +435,17 @@ usb_start() {
 	usb_trigger async
 }
 
+# umtprd keeps ep0 open, so it has to go before the umount can succeed
+umtp_teardown() {
+	killall umtprd 2>/dev/null
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		mountpoint -q /dev/ffs-umtp 2>/dev/null || break
+		umount /dev/ffs-umtp 2>/dev/null && break
+		sleep 0.1
+	done
+	rmdir /dev/ffs-umtp 2>/dev/null
+}
+
 usb_stop() {
 
 	(
@@ -435,10 +456,7 @@ usb_stop() {
 		usb_disable
 
 		if [ -d /dev/ffs-umtp ] ; then
-			umount /dev/ffs-umtp
-			rmdir /dev/ffs-umtp
-
-			killall umtprd
+			umtp_teardown
 		fi
 	) >/dev/null 2>&1
 }
@@ -461,11 +479,7 @@ usb_init_clean_state() {
 		[ -n "$(cat "$udc_link" 2>/dev/null)" ] && echo "" > "$udc_link" 2>/dev/null
 	done
 
-	if mountpoint -q /dev/ffs-umtp 2>/dev/null; then
-		umount /dev/ffs-umtp 2>/dev/null
-	fi
-	[ -d /dev/ffs-umtp ] && rmdir /dev/ffs-umtp 2>/dev/null
-	pkill -x umtprd 2>/dev/null
+	[ -d /dev/ffs-umtp ] && umtp_teardown
 	if [ -f "${UDHCPPIDFILE}" ]; then
 		cat "${UDHCPPIDFILE}" 2>/dev/null | xargs -r -n 1 kill 2>/dev/null
 		rm -f "${UDHCPPIDFILE}"


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

Fix file transfer mode. On devices with a USB 3 capable port it never works: the host starts to enumerate the device, gives up halfway, and no MTP device ever shows up. Windows calls it "Unknown USB Device (Configuration Descriptor Request Failed)".

The reason is a mismatch. The gadget told the host it could do USB 3, but umtprd is built without USB 3 support and only provides USB 2 descriptors. So the host connected at USB 3 speed, asked for a description that was never there, and stopped. Capping the MTP gadget at USB 2 high speed makes the two agree. Network mode was never affected and still runs at USB 3.

Three smaller things were wrong in the same code, all inherited from the network gadget it was copied from:

* The device class said "Communications", so Windows went looking for a network driver instead of an MTP one. MTP declares its class on the interface, so this needs to be 0.
* The USB product ID was the network gadget's, so both modes collided in the host's driver cache. It now uses the ID umtprd's own config already declares.
* The product name came from a variable that only exists in a login shell, so most callers set an empty one. That alone was enough to stop the device coming up. It now reads the model from the device tree.

One unrelated bug fixed on the way: stopping the gadget unmounted functionfs before killing umtprd, but umtprd holds it open, so the unmount always failed and left the mount behind for the next start to trip over.

## Testing

* **How was this tested?**

On an AYN Odin 2, against Windows 11 and Ubuntu 24.04. The Linux side used usbipd to bind the USB device into WSL. Both modes were tested, plus switching between them, since they share the same script.

* **Test results:**

Windows shows an MTP device with no error and the Roms storage in This PC. Browsing, creating folders, renaming, copying both ways and deleting all work.

Linux sees the right interface, `mtp-detect` opens a session and reports Roms as read/write, and a file sent and read back came out byte identical before being deleted again.

Network mode was re-tested after the change and behaves exactly as before: it connects at USB 3, Windows binds UsbNcm with no error, the link reports 3.8 Gbps, and DHCP serves the host. Switching from file transfer to network and back leaves no stale mounts or processes behind.

## Additional Context

* **Add any other information that might be helpful for the reviewer**

**Why cap the speed instead of building umtprd with USB 3 support?** Its USB 3 descriptors are broken upstream: it asks for 512 byte bulk packets where USB 3 requires 1024. And there is little to gain, since umtprd reads and writes in 8 KB chunks one at a time and is unlikely to saturate even USB 2. That second half is reasoning, not a benchmark.

**Does this put network mode at risk?** Almost every change is inside the MTP setup and cannot reach it. The only line both modes share is the product name, and network mode was re-tested after the change.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY
