### PR TITLE
ath12k: disable WiFi power save

### DIFF
--- a/projects/ROCKNIX/packages/network/iwd/sources/main.conf
+++ b/projects/ROCKNIX/packages/network/iwd/sources/main.conf
@@ -3,6 +3,14 @@
 EnableNetworkConfiguration=false
 ControlPortOverNL80211=true
 
+[DriverQuirks]
+# ath12k dynamic power save parks the radio between DTIM beacons and delays or
+# drops inbound packets, so an idle handheld stops answering until it transmits
+# something and SSH into it stalls. iwd applies this when it initialises the
+# netdev, so it also survives the interface being recreated. Awake-only:
+# suspend still powers the radio down.
+PowerSaveDisable=ath12k*
+
 [Network]
 RoutePriorityOffset=200
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

disable wifi powersave to avoid stalling inbound connections (like ssh) while idle

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

tested on my konkr pocket fit elite

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

unsure about which devices to constrain this to. just the konkr? all sm8750? all devices with same ath12k* driver (which is what this patch is currently doing)?

for reference, ath12k is used across sm8750,8650,8550

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

yes
