### PR TITLE
iwd: drop the stale version pin that ships 3.9 as 3.10

### DIFF
--- a/projects/ROCKNIX/packages/network/iwd/package.mk
+++ b/projects/ROCKNIX/packages/network/iwd/package.mk
@@ -3,9 +3,6 @@
 
 . ${ROOT}/packages/network/iwd/package.mk
 
-PKG_VERSION="3.10"
-PKG_SHA256="0cd7dc9b32b9d6809a4a5e5d063b5c5fd279f5ad3a0bf03d7799da66df5cad45"
-
 pre_configure_target() {
   export LIBS="-lncurses -ltinfo"
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

Our iwd override pins `PKG_VERSION="3.10"` but carries the sha256 of `iwd-3.9.tar.xz`. The pin came in with #2079 and the checksum was copied from the base package, which was on 3.9 at the time. kernel.org's signed `sha256sums.asc` in `pub/linux/network/wireless/`:

```
0cd7dc9b32b9d6809a4a5e5d063b5c5fd279f5ad3a0bf03d7799da66df5cad45  iwd-3.9.tar.xz
640bff22540e1714f71772a83123aff6f810b7eb9d7d6df1e10fb2695beb5115  iwd-3.10.tar.xz
```

That mismatch does not fail the build, it downgrades it. `scripts/get_archive` tries `PKG_URL` first, gets the real 3.10 tarball from kernel.org, computes `640bff22...`, prints `WARNING Incorrect checksum calculated on downloaded file` and throws it away. It then falls back to `${DISTRO_MIRROR}/iwd-3.10.tar.xz`, and that file on distribution-sources is byte identical to `iwd-3.9.tar.xz`: same 1117304 bytes, same `0cd7dc9b...`, unpacks to `iwd-3.9/`. It matches the stale checksum, so it is accepted. `scripts/extract` then untars with `--strip-components=1` into a directory it names `iwd-3.10`, so the tarball's real version never surfaces anywhere.

The result is that the package metadata says 3.10, the base package says 3.12, and every shipping device is running iwd 3.9. `iwd --version` on an image confirms it. The only trace is that one warning line in the build log.

The pin has also outlived its purpose. It was added to get ahead of a base package that was on 3.9; the base is now on 3.12 with a checksum that does match kernel.org, so the override holds us two releases behind instead of ahead. Deleting the two lines restores what #2079 was after and removes the second copy of version and checksum that drifted in the first place.

## Testing

* **How was this tested?**

The checksum claims were verified against upstream rather than taken from either file: iwd 3.9, 3.10, 3.11 and 3.12 downloaded from `https://www.kernel.org/pub/linux/network/wireless/` and hashed locally, then cross-checked against the PGP-signed `sha256sums.asc` in the same directory. The mirror copy at `distribution-sources/releases/download/sources/iwd-3.10.tar.xz` was downloaded and confirmed to be the 3.9 tarball. The 3.9 and 3.12 trees were unpacked and diffed for anything that touches how we build or configure iwd.

* **Test results:**

Checksums line up as quoted above, and the base package's `d89a5e45...` is the genuine 3.12. The mirror's `iwd-3.10.tar.xz` hashes to `0cd7dc9b...` and unpacks to `iwd-3.9/`, which is what has been masking the mismatch.

3.9 to 3.12 is four bug fix releases with nothing else in them:

- 3.10: neighbor report on BSS TM request, deauth and FT association failure, roaming and old frequencies
- 3.11: interface registration before acquiring the name
- 3.12: PMKSA expiration, uninitialized buffer and PMKID, PKCS#8 key parser in unit tests, `-std=c23`

Diffing the two trees: `src/iwd.config.rst` is byte identical, so every key in our `main.conf` still applies; the `AC_ARG_ENABLE` set is unchanged, so our configure line still applies; ell is bundled in both with the same minimum version, so no dependency bump; `src/iwd.service.in` is unchanged, and we replace the unit anyway.

## Additional Context

* **Add any other information that might be helpful for the reviewer**

A few of those fixes land where our hardware hurts. FT association failure and roaming with stale frequencies are in the reassociation path, and PMKSA caching is what should let a wake skip the full handshake, which is relevant to the long reconnect after resume on the Qualcomm devices.

One thing this PR cannot fix: distribution-sources still hosts an `iwd-3.10.tar.xz` that is really 3.9. Nothing fetches it once this lands, but it is worth replacing or deleting so it cannot mask another checksum mismatch later.

If you would rather not move three releases at once, the conservative alternative is to keep the pin and correct it to `PKG_SHA256="640bff22540e1714f71772a83123aff6f810b7eb9d7d6df1e10fb2695beb5115"`. That still moves the devices off 3.9, since that is what they run today, and leaves the same drift in place for the next base bump.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES

Yes. AI was used to verify the checksums against kernel.org, trace the mirror fallback and write the change.
