### PR TITLE
buildroot improvements

### DIFF
--- a/distributions/ROCKNIX/options
+++ b/distributions/ROCKNIX/options
@@ -69,7 +69,11 @@
   ENABLE_32BIT="${ENABLE_32BIT-true}"
 
 # build and install bluetooth support (yes / no)
+if [[ "${ARCH}" != "arm" ]]; then
   BLUETOOTH_SUPPORT="yes"
+else
+  BLUETOOTH_SUPPORT="no"
+fi
 
 # build and install Avahi (Zeroconf) daemon (yes / no)
   AVAHI_DAEMON="yes"

--- a/projects/ROCKNIX/packages/graphics/glew/package.mk
+++ b/projects/ROCKNIX/packages/graphics/glew/package.mk
@@ -13,7 +13,12 @@ PKG_TOOLCHAIN="cmake"
 PKG_CMAKE_OPTS_TARGET="-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 if [ "${DISPLAYSERVER}" = "wl" ]; then
-  PKG_DEPENDS_TARGET+=" wayland ${WINDOWMANAGER} xwayland xrandr libXi libX11"
+  PKG_DEPENDS_TARGET+=" wayland xrandr libXi libX11"
+
+  if [ "${ARCH}" != "arm" ]; then
+    PKG_DEPENDS_TARGET+=" ${WINDOWMANAGER} xwayland"
+  fi
+
   PKG_CMAKE_OPTS_TARGET+=" -DGLEW_X11=ON"
 fi
 


### PR DESCRIPTION
This PR reduces the build steps in the arm plan from 270 > 222, inviting the views of others for this change.

It is not necessary for us to be building the window manager for the arm plan, packages dropped by this change
```
sway
wlroots
swaybg
swayimg
swaywm-env
foot
bemenu
grim
jq
rocknix-screenshot
wlr-randr
oniguruma
jsoncpp
xwayland
libdatrie
libthai
xkbcomp
libICE
libSM
libXt
libXmu
libXpm
libXaw
xterm
xcb-util-wm
```

Dropping bluetooth from pipewire is safe as 32bit apps just send to socket, packages dropped by this change
```
bluez
sbc
ldacBT
libfreeaptx
fdk-aac
fcft
tllist
```