### PR TITLE
SM8550: fix slow WiFi reconnect, ath12k never sends its scan priority

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/patches/linux/1020-wifi-ath12k-send-the-computed-scan-priority-to-the-f.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/1020-wifi-ath12k-send-the-computed-scan-priority-to-the-f.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Edouard Durand <edouard.durand@gmail.com>
+Date: Fri, 15 Aug 2026 14:30:00 +0800
+Subject: [PATCH] wifi: ath12k: send the computed scan priority to the
+ firmware
+
+The firmware schedules every scan through one queue and runs its
+offloaded 11d country scan at MEDIUM priority. The driver knows this:
+ath12k_wmi_send_scan_start_cmd() computes a priority for each hardware
+scan, LOW as the baseline and MEDIUM while an 11d scan is about to run,
+precisely so host scans are not starved by the 11d service. But it only
+writes the result into arg->scan_priority; cmd->scan_priority is never
+assigned, so every hardware scan reaches the firmware as priority 0,
+WMI_SCAN_PRIORITY_VERY_LOW, one step below even the intended baseline.
+ath11k assigns the same computation to the command it sends; the copy
+was lost in the ath12k rework.
+
+On a WCN7850 station that blocks and unblocks rfkill on every resume,
+the consequence is a scan refusal storm at every bring-up. The first
+hardware scan arms and starts the 11d scan; every scan submitted while
+that MEDIUM scan is pending is refused with WMI_SCAN_EVENT_START_FAILED
+reason WMI_SCAN_REASON_INTERNAL_FAILURE. The driver reports the refused
+scan to mac80211 as an aborted scan, so iwd abandons its quick
+reconnect plan, falls back to full sweeps with growing backoff, and
+reassociation takes 4.4 to 8 seconds, degrading as refusals accumulate.
+Resending a refused start changes nothing, on the same vdev or a
+recycled one: the resend is still priority 0. A refused scan was
+observed to recover only once something else flushed the queue, which
+is why the failure looked timing-dependent and was misattributed to the
+11d start/stop churn.
+
+Measured on an AYN Odin 2 (WCN7850 hw2.0), rfkill block/unblock cycles
+against the same AP from a fresh boot, reconnect time from radio
+unblock to DHCP address. Before, five cycles: 4459, 4442, 5929, 5856,
+7962 ms, nine scan refusals, degrading as they accumulate. After, ten
+cycles: nine land between 1021 and 1041 ms and zero scan refusals over
+the whole boot; the one outlier (10.4 s) shows no refusal either and
+matches a connection-manager stall that predates this change.
+
+With the priority on the wire, the first scan after bring-up goes out
+at MEDIUM, coexists with the 11d scan instead of losing to it, and iwd
+connects from its first quick scan every time.
+
+Signed-off-by: Edouard Durand <edouard.durand@gmail.com>
+---
+ drivers/net/wireless/ath/ath12k/wmi.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/wireless/ath/ath12k/wmi.c b/drivers/net/wireless/ath/ath12k/wmi.c
+--- a/drivers/net/wireless/ath/ath12k/wmi.c
++++ b/drivers/net/wireless/ath/ath12k/wmi.c
+@@ -2626,6 +2626,7 @@
+ 		arg->scan_priority = WMI_SCAN_PRIORITY_MEDIUM;
+ 	else
+ 		arg->scan_priority = WMI_SCAN_PRIORITY_LOW;
++	cmd->scan_priority = cpu_to_le32(arg->scan_priority);
+ 	cmd->notify_scan_events = cpu_to_le32(arg->notify_scan_events);
+ 
+ 	ath12k_wmi_copy_scan_event_cntrl_flags(cmd, arg);


### PR DESCRIPTION
## Summary

WiFi reconnects slowly and erratically after the radio is taken down and brought back up on the Odin 2, which is what the suspend hooks do around every sleep cycle. On a stock image, five off/on cycles reconnect in 4.4 to 8 seconds, degrading as cycles accumulate, with bursts of firmware scan refusals along the way.

The cause is a one-line regression in ath12k. The driver computes a priority for every hardware scan and then never sends it: `ath12k_wmi_send_scan_start_cmd()` fills `arg->scan_priority` (LOW as the baseline, MEDIUM when its own 11d regulatory scan is about to run, precisely so host scans do not get starved by it) but `cmd->scan_priority` is never assigned, so every hardware scan reaches the firmware as priority 0, `WMI_SCAN_PRIORITY_VERY_LOW`. ath11k computes the same value and does send it; the copy was lost in the ath12k rework. The firmware schedules all scans through one queue and runs the 11d scan at MEDIUM, so after every bring-up the first hardware scan starts the 11d scan and every further scan submitted while it is pending is refused:

```
scan event start failed type 64 reason 4 freq 0 ... state starting (1)
received scan start failure event
```

Reason 4 is `WMI_SCAN_REASON_INTERNAL_FAILURE`. The driver reports each refused scan to iwd as an aborted scan, iwd abandons its quick reconnect plan and falls back to full sweeps with growing backoff, and that is the whole slowdown.

The fix sends the priority the driver already computes:

```c
	cmd->scan_priority = cpu_to_le32(arg->scan_priority);
```

## Testing

AYN Odin 2 (SM8550, WCN7850 hw2.0), linux 7.1.2, shipped c5 firmware, everything from a fresh boot, timing from radio unblock to carrier plus an IPv4 address.

Ten rfkill off/on cycles through the real resume path (`wifictl disable`, then `wifi-resume`):

| | before (5 cycles) | after (10 cycles) |
| --- | --- | --- |
| reconnected | 5/5 | 10/10 |
| cycle times | 4459, 4442, 5929, 5856, 7962 ms | 1030, 1024, 1025, 10414*, 1041, 1027, 1024, 1021, 1026, 1032 ms |
| scan refusals | 9, growing per cycle | 0 over the whole boot |

Nine of ten cycles land within 20 ms of each other. The starred outlier shows zero refusals and matches a NetworkManager-level stall that exists on stock as well (where it produces the 8 s cycles and occasional 40 s timeouts); the driver side stayed clean through it.

On top of the rfkill cycles, real suspend/resume endurance: deep suspend entered via `systemctl suspend` with an RTC wake, about 25 seconds asleep per cycle, WiFi remeasured after every wake. 36 consecutive cycles before the run was ended manually, every one a verified real suspend (`suspend_stats` incremented), every reconnect between 2.0 and 3.2 seconds, zero scan refusals across the entire run. The same pattern on the unfixed driver produces refusal bursts from the second or third cycle and degrades from there.

## Additional context

**How this was found.** The earlier version of this PR moved the 11d arming from the per-scan vdev to the interface, based on the observation that ath12k churns an 11d scan start/stop around every hardware scan. The churn is real, but an A/B on the real resume path measured identical refusal counts with and without that patch, which meant the refusals had another cause. Debug traces then showed refused scans staying refused when resent as-is (same vdev or a recycled one, up to 660 ms later) while any different scan submitted moments later sailed through; that ruled out timing and vdev state and left the request itself, and the missing priority assignment accounts for everything, including why a wedged 11d scan used to block every scan for minutes.

**This likely fixes the Pocket S Mini workaround target too.** #3177 carries `0507-wifi-ath12k-skip-11d-scan-on-ayaneo-pocket-s-mini.patch` for the same symptom on the same chip (scans permanently refused after 11d starts and stops, until power cycle). That is the priority starvation in its hardest form. With this fix, host scans coexist with the 11d scan instead of losing to it, so the per-device 11d amputation (and the regulatory blind spot it brings) should no longer be needed; worth a retest on that hardware.

**Upstream.** This is a mechanical divergence from ath11k and worth sending to linux-wireless. The ath12k 11d-offload commit message documents the MEDIUM/LOW queue model this restores. A related patch in review upstream ("wifi: ath12k: restore country code during resume") fixes country loss across a full firmware reload; complementary, no overlap.

---

### AI Usage

**Did you use AI tools to help write this code?** YES
