### PR TITLE
rpcs3-sa: fix the quit hotkey kill target

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/scripts/start_rpcs3.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/scripts/start_rpcs3.sh
@@ -211,10 +211,10 @@ EOF
 # Run rpcs3
 if [ "$SUI" = "true" ]; then
   export QT_QPA_PLATFORM=wayland
-  set_kill set "-9 rpcs3"
+  set_kill set "-9 rpcs3-sa"
   ${EMUPERF} /usr/bin/rpcs3-sa
 else
   export QT_QPA_PLATFORM=xcb
-  set_kill set "-9 rpcs3"
+  set_kill set "-9 rpcs3-sa"
   ${EMUPERF} /usr/bin/rpcs3-sa --no-gui "$GAME_PATH"
 fi


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the quit hotkey combo for RPCS3. The launch script registers `killall -9 rpcs3` with input_sense via `set_kill`, but the binary it starts is `/usr/bin/rpcs3-sa`, so the killall never matches a process and the combo silently does nothing. Register the actual process name instead.

## Testing

* **How was this tested?** On an AYN Odin 2 (SM8550), by launching a PS3 game and pressing the quit combo, before and after the change (the fixed script was bind-mounted over /usr/bin/start_rpcs3.sh on a stock build to verify).
* **Test results:** Before: the combo does nothing and the game can only be left by killing rpcs3-sa manually. After: the combo kills the emulator and returns to EmulationStation.

## Additional Context

* input_sense reads the kill target from /tmp/.process-kill-data at combo time, so the fix is purely in what the launcher registers. Other emulator launch scripts register their real binary names already.

---

### AI Usage

**Did you use AI tools to help write this code?** YES