### PR TITLE
ci: extend release asset caching for toolchain/qt6/rust/mame-lr/emu-libretro/emu-standalone workflows

### DIFF
--- a/.github/actions/build-cache/compute-hash/action.yml
+++ b/.github/actions/build-cache/compute-hash/action.yml
@@ -1,0 +1,41 @@
+name: Compute build-tree dependency hash
+description: >
+  Resolves the full ROCKNIX/LibreELEC package dependency closure for the given
+  trigger packages (via tools/list_deps.sh) and hashes their package.mk/patch/conf
+  files plus stamp-watch paths. Requires the repo to already be checked out.
+inputs:
+  project:
+    required: true
+  device:
+    required: true
+  arch:
+    required: true
+    default: aarch64
+  package-list:
+    description: Space-separated trigger packages, e.g. "toolchain alsa-lib llvm:host"
+    required: true
+outputs:
+  hash:
+    description: sha256 content hash of the resolved package/watch-path closure
+    value: ${{ steps.hash.outputs.hash }}
+runs:
+  using: composite
+  steps:
+    - id: hash
+      shell: bash
+      run: |
+        export PROJECT="${{ inputs.project }}" DEVICE="${{ inputs.device }}" ARCH="${{ inputs.arch }}"
+        OUT=$(bash tools/list_deps.sh ${{ inputs.package-list }})
+        PKG_DIRS=$(echo "$OUT" | sed -n '1,/---WATCH---/p' | grep -v '^---WATCH---$')
+        WATCH_PATHS=$(echo "$OUT" | sed -n '/---WATCH---/,$p' | grep -v '^---WATCH---$')
+
+        HASH=$({
+          for d in $PKG_DIRS; do
+            find "$d" -type f \( -name 'package.mk' -o -name '*.patch' -o -name '*.conf' \)
+          done
+          for d in $WATCH_PATHS; do
+            find "$d" -type f
+          done
+        } | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+
+        echo "hash=$HASH" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-cache/download/action.yml
+++ b/.github/actions/build-cache/download/action.yml
@@ -1,0 +1,55 @@
+name: Restore build tree from cache
+description: >
+  Downloads all hash-keyed tar.zst parts (and their combined sha256 manifest)
+  for a given cache entry, verifies checksums, reassembles, and extracts.
+inputs:
+  hash:
+    required: true
+  device:
+    required: true
+  artifact-prefix:
+    required: true
+  tag-name:
+    required: true
+  cache-repo:
+    required: true
+outputs:
+  hit:
+    value: ${{ steps.restore.outputs.hit }}
+runs:
+  using: composite
+  steps:
+    - id: restore
+      shell: bash
+      run: |
+        BASE="${{ inputs.artifact-prefix }}-${{ inputs.device }}-${{ inputs.hash }}"
+
+        ASSETS_JSON=$(curl -s "https://api.github.com/repos/${{ inputs.cache-repo }}/releases/tags/${{ inputs.tag-name }}")
+        mapfile -t URLS < <(echo "$ASSETS_JSON" | jq -r --arg base "$BASE" '.assets[]? | select(.name | startswith($base)) | .browser_download_url')
+
+        if [ "${#URLS[@]}" -eq 0 ]; then
+          echo "No exact-match cache for ${{ inputs.hash }}"
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        for url in "${URLS[@]}"; do
+          curl -L --fail --silent -o "$(basename "$url")" "$url"
+        done
+
+        if [ ! -f "${BASE}.sha256" ]; then
+          echo "::warning::Manifest missing for $BASE, discarding"
+          rm -f "${BASE}.tar.zst.part."*
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if sha256sum -c "${BASE}.sha256"; then
+          cat $(ls "${BASE}.tar.zst.part."* | sort) | sudo tar --zstd -xf -
+          echo "hit=true" >> "$GITHUB_OUTPUT"
+          echo "Restored cache for hash ${{ inputs.hash }} — skipping build"
+        else
+          echo "::warning::Checksum mismatch on parts for $BASE, discarding"
+          rm -f "${BASE}.tar.zst.part."* "${BASE}.sha256"
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/build-cache/tar-checksum/action.yml
+++ b/.github/actions/build-cache/tar-checksum/action.yml
@@ -1,0 +1,50 @@
+name: Tar and checksum a build tree
+description: >
+  Compresses the given paths into a hash-named tar.zst, split into <2GB parts
+  (release assets cap at 2GB), with a sha256 manifest covering all parts.
+inputs:
+  hash:
+    required: true
+  device:
+    required: true
+  artifact-prefix:
+    required: true
+  paths:
+    required: true
+  exclude:
+    required: false
+    default: ""
+  split-size:
+    description: "Part size for splitting, e.g. '1900m'. Required — release assets cap at 2GB."
+    required: false
+    default: "1900m"
+outputs:
+  tar-glob:
+    description: Glob matching all tar parts, for passing to the upload action
+    value: ${{ steps.tar.outputs.tar-glob }}
+  checksum-path:
+    value: ${{ steps.tar.outputs.checksum-path }}
+runs:
+  using: composite
+  steps:
+    - id: tar
+      shell: bash
+      run: |
+        BASE="${{ inputs.artifact-prefix }}-${{ inputs.device }}-${{ inputs.hash }}"
+
+        PATHS=()
+        while IFS= read -r line; do
+          [ -n "$line" ] && PATHS+=("$line")
+        done <<< "${{ inputs.paths }}"
+
+        EXCLUDES=()
+        while IFS= read -r pattern; do
+          [ -n "$pattern" ] && EXCLUDES+=("--exclude=$pattern")
+        done <<< "${{ inputs.exclude }}"
+
+        rm -f "${BASE}.tar.zst.part."*
+        sudo tar --zstd "${EXCLUDES[@]}" -cf - ${PATHS[@]} | split -b "${{ inputs.split-size }}" - "${BASE}.tar.zst.part."
+        sha256sum "${BASE}.tar.zst.part."* > "${BASE}.sha256"
+
+        echo "tar-glob=${BASE}.tar.zst.part.*" >> "$GITHUB_OUTPUT"
+        echo "checksum-path=${BASE}.sha256" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-cache/upload/action.yml
+++ b/.github/actions/build-cache/upload/action.yml
@@ -1,0 +1,29 @@
+name: Upload build tree to cache
+description: Publishes tar.zst parts + sha256 manifest as release assets in the cache repo.
+inputs:
+  tar-glob:
+    required: true
+  checksum-path:
+    required: true
+  tag-name:
+    required: true
+  cache-repo:
+    description: "owner/repo of the cache repository"
+    required: true
+  token:
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: softprops/action-gh-release@v3
+      continue-on-error: true
+      with:
+        tag_name: ${{ inputs.tag-name }}
+        files: |
+          ${{ inputs.tar-glob }}
+          ${{ inputs.checksum-path }}
+        make_latest: true
+        prerelease: true
+        body: ${{ inputs.tag-name }}
+        token: ${{ inputs.token }}
+        repository: ${{ inputs.cache-repo }}

--- a/.github/workflows/build-aarch64-emu-libretro.yml
+++ b/.github/workflows/build-aarch64-emu-libretro.yml
@@ -12,6 +12,10 @@ on:
       OWNER_LC:
         required: true
         type: string
+    outputs:
+      cache-hit:
+        description: "Whether the emu-libretro build tree was restored from cache"
+        value: ${{ jobs.build-aarch64-emu-libretro.outputs.cache-hit }}
 
 jobs:
   build-aarch64-emu-libretro:
@@ -28,33 +32,61 @@ jobs:
       PROJECT: ${{ inputs.PROJECT }}
       DEVICE: ${{ inputs.DEVICE }}
       ARCH: aarch64
-      CACHE_KEY: ccache-aarch64-${{ inputs.DEVICE }}-emu-libretro-${{ github.sha }}
       DISABLE_COLORS: yes
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
+      PACKAGE_LIST: "emulators"
+      CACHE_REPO: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+    outputs:
+      cache-hit: ${{ steps.restore-emu-libretro.outputs.hit }}
     steps:
-      - name: Maximize build space
-        uses: justinthelaw/maximize-github-runner-space@v0.9.0
-        with:
-          skip-components: docker-engine
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Compute emu-libretro dependency hash
+        id: hash
+        uses: ./.github/actions/build-cache/compute-hash
+        with:
+          project: ${{ env.PROJECT }}
+          device: ${{ env.DEVICE }}
+          arch: ${{ env.ARCH }}
+          package-list: ${{ env.PACKAGE_LIST }}
+
+      # Try to restore the whole emu-libretro build tree from a previous run first.
+      # On a hit, Build and everything that only makes sense post-build is skipped.
+      - name: Retrieve emu-libretro build tree
+        id: restore-emu-libretro
+        uses: ./.github/actions/build-cache/download
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: emu-libretro-aarch64
+          tag-name: emu-libretro
+          cache-repo: ${{ env.CACHE_REPO }}
+
+      - name: Maximize build space
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
+        uses: justinthelaw/maximize-github-runner-space@v0.9.0
+        with:
+          skip-components: docker-engine
+
       - name: Retrieve ccache
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-emu-libretro.tar"
-          curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."  
+          URL="https://github.com/${{ env.CACHE_REPO }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-emu-libretro.tar"
+          curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."
 
       - name: Download aarch64 (${{ inputs.DEVICE }})
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64 (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -63,14 +95,17 @@ jobs:
           retry_interval: 10
 
       - name: Clean up compressed aarch64 file
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: rm build.aarch64.tar
 
       - name: Download build aarch64 (${{ inputs.DEVICE }})
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64 build (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64 build
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -79,16 +114,17 @@ jobs:
           retry_interval: 10
 
       - name: Clean up compressed aarch64 file
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: rm build.build.aarch64.tar
 
       - name: Download qt6 (${{ inputs.DEVICE }})
-        if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' }}
+        if: steps.restore-emu-libretro.outputs.hit != 'true' && (inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550')
         uses: actions/download-artifact@v8
         with:
           name: qt6 (${{ inputs.DEVICE }})
 
       - name: Extract artifact qt6
-        if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' }}
+        if: steps.restore-emu-libretro.outputs.hit != 'true' && (inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550')
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -97,29 +133,33 @@ jobs:
           retry_interval: 10
 
       - name: Clean up compressed qt6 file
-        if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' }}
+        if: steps.restore-emu-libretro.outputs.hit != 'true' && (inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550')
         run: rm build.qt6.tar.zst
 
       - name: Download mame-lr (${{ inputs.DEVICE }})
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: mame-lr (${{ inputs.DEVICE }})
 
       - name: Extract artifact mame-lr
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: |
           tar --zstd -xf build.mame-lr.tar.zst
 
       - name: Clean up compressed mame-lr file
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: rm build.mame-lr.tar.zst
 
       - name: Build
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
             ./scripts/get_env > .env
             set -e
             { docker run --init --env-file .env --rm --user $(id -u):$(id -g) -v ${PWD}:${PWD} -w ${PWD} "ghcr.io/${{ inputs.OWNER_LC }}/rocknix-build:latest" \
-              bash -c "./scripts/build_mt emulators"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
+              bash -c "./scripts/build_mt ${PACKAGE_LIST}"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
             exit_code=$(<docker_exit_code)
             exit $exit_code
           max_attempts: 6
@@ -135,6 +175,7 @@ jobs:
             ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.threads/logs/
 
       - name: Clean ccache
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
@@ -144,10 +185,12 @@ jobs:
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z
 
       - name: Tar ccache
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: |
-          tar -cf ccache-aarch64-${{ inputs.DEVICE }}-emu-libretro.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache 
+          tar -cf ccache-aarch64-${{ inputs.DEVICE }}-emu-libretro.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
 
       - name: Save ccache
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ccache
@@ -156,17 +199,44 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repository: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+          repository: ${{ env.CACHE_REPO }}
         continue-on-error: true
 
       - name: Print space
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
         run: df -h
 
-      - name: Compress directory
-        run: | 
-          sudo tar --remove-files -cf - \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_* \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps | split -b 2G -  build.emu-libretro.tar.part
+      - name: Tar and checksum emu-libretro build tree
+        id: tar-checksum
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/tar-checksum
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: emu-libretro-aarch64
+          paths: |
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_*
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
+
+      - name: Save emu-libretro build tree
+        if: steps.restore-emu-libretro.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/upload
+        with:
+          tar-glob: ${{ steps.tar-checksum.outputs.tar-glob }}
+          checksum-path: ${{ steps.tar-checksum.outputs.checksum-path }}
+          tag-name: emu-libretro
+          cache-repo: ${{ env.CACHE_REPO }}
+          token: ${{ secrets.GH_PAT }}
+
+      # Unconditional — runs whether we hit cache or built fresh, so downstream
+      # jobs in THIS workflow run always have something to download.
+      - name: Split emu-libretro artifact for same-run consumers
+        if: always()
+        run: |
+          rm -f build.emu-libretro.tar.part*
+          sudo tar -cf - \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_* \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps | split -b 2G - build.emu-libretro.tar.part
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build-aarch64-emu-standalone.yml
+++ b/.github/workflows/build-aarch64-emu-standalone.yml
@@ -12,10 +12,17 @@ on:
       OWNER_LC:
         required: true
         type: string
+    outputs:
+      cache-hit:
+        description: "Whether the emu-standalone build tree was restored from cache"
+        value: ${{ jobs.build-aarch64-emu-standalone.outputs.cache-hit }}
 
 jobs:
   build-aarch64-emu-standalone:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
     env:
       EMULATION_DEVICE: no
       ENABLE_32BIT: no
@@ -25,31 +32,57 @@ jobs:
       PROJECT: ${{ inputs.PROJECT }}
       DEVICE: ${{ inputs.DEVICE }}
       ARCH: aarch64
-      CACHE_KEY: ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone-${{ github.sha }}
       DISABLE_COLORS: yes
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
+      PACKAGE_LIST: "emulators"
+      CACHE_REPO: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+    outputs:
+      cache-hit: ${{ steps.restore-emu-standalone.outputs.hit }}
     steps:
-      - name: Maximize build space
-        uses: justinthelaw/maximize-github-runner-space@v0.9.0
-        with:
-          skip-components: docker-engine
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Compute emu-standalone dependency hash
+        id: hash
+        uses: ./.github/actions/build-cache/compute-hash
+        with:
+          project: ${{ env.PROJECT }}
+          device: ${{ env.DEVICE }}
+          arch: ${{ env.ARCH }}
+          package-list: ${{ env.PACKAGE_LIST }}
+
+      # Try to restore the whole emu-standalone build tree from a previous run first.
+      # On a hit, Build and everything that only makes sense post-build is skipped.
+      - name: Retrieve emu-standalone build tree
+        id: restore-emu-standalone
+        uses: ./.github/actions/build-cache/download
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: emu-standalone-aarch64
+          tag-name: emu-standalone
+          cache-repo: ${{ env.CACHE_REPO }}
+
+      - name: Maximize build space
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
+        uses: justinthelaw/maximize-github-runner-space@v0.9.0
+        with:
+          skip-components: docker-engine
+
       - name: Retrieve ccache
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: |
-          BASE="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache"
+          BASE="https://github.com/${{ env.CACHE_REPO }}/releases/download/ccache"
           PREFIX="ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar.part-"
           found_any=0
           for suffix in $(printf "%s\n" {a..z}{a..z}); do
             FILE="${PREFIX}${suffix}"
             URL="${BASE}/${FILE}"
-          
+
             echo "Trying $URL"
             if curl -L --fail --silent --show-error -o "$FILE" "$URL"; then
               echo "Downloaded $FILE"
@@ -68,23 +101,28 @@ jobs:
           rm -f ${PREFIX}* ccache.tar
 
       - name: Download aarch64-toolchain (${{ inputs.DEVICE }})
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64-toolchain (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64-toolchain
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: |
           tar --zstd -xf build.aarch64-toolchain.tar.zst
 
       - name: Clean up compressed aarch64-toolchain file
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: rm build.aarch64-toolchain.tar.zst
 
       - name: Download aarch64 (${{ inputs.DEVICE }})
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64 (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -93,14 +131,17 @@ jobs:
           retry_interval: 10
 
       - name: Clean up compressed aarch64 file
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: rm build.aarch64.tar
 
       - name: Download build aarch64 (${{ inputs.DEVICE }})
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64 build (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64 build
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -109,46 +150,54 @@ jobs:
           retry_interval: 10
 
       - name: Clean up compressed aarch64 file
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: rm build.build.aarch64.tar
 
       - name: Download aarch64-rust (${{ inputs.DEVICE }})
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64-rust (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64-rust
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: |
           tar --zstd -xf build.aarch64-rust.tar.zst
 
       - name: Clean up compressed aarch64-rust file
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: rm build.aarch64-rust.tar.zst
 
       - name: Download qt6 (${{ inputs.DEVICE }})
-        if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' ||
-          inputs.DEVICE == 'S922X'  || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115' }}
+        if:
+          steps.restore-emu-standalone.outputs.hit != 'true' && (inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' ||
+          inputs.DEVICE == 'S922X'  || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115')
         uses: actions/download-artifact@v8
         with:
           name: qt6 (${{ inputs.DEVICE }})
 
       - name: Extract artifact qt6
-        if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' ||
-          inputs.DEVICE == 'S922X'  || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115' }}
+        if:
+          steps.restore-emu-standalone.outputs.hit != 'true' && (inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' ||
+          inputs.DEVICE == 'S922X'  || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115')
         run: |
           sudo tar --zstd -xf build.qt6.tar.zst --same-owner
 
       - name: Clean up compressed qt6 file
-        if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' ||
-          inputs.DEVICE == 'S922X'  || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115' }}
+        if:
+          steps.restore-emu-standalone.outputs.hit != 'true' && (inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' ||
+          inputs.DEVICE == 'S922X'  || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115')
         run: rm build.qt6.tar.zst
 
       - name: Build
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
             ./scripts/get_env > .env
             set -e
             { docker run --init --env-file .env -e USER=docker --rm --user $(id -u):$(id -g) -v ${PWD}:${PWD} -w ${PWD} "ghcr.io/${{ inputs.OWNER_LC }}/rocknix-build:latest" \
-              bash -c "./scripts/build_mt emulators"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
+              bash -c "./scripts/build_mt ${PACKAGE_LIST}"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
             exit_code=$(<docker_exit_code)
             exit $exit_code
           max_attempts: 6
@@ -164,6 +213,7 @@ jobs:
             ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.threads/logs/
 
       - name: Clean ccache
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
@@ -174,12 +224,14 @@ jobs:
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z
 
       - name: Tar ccache
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: |
           tar --remove-files -cf - ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache \
             | split -b 1900m - ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar.part-
 
       - name: Save ccache
-        uses: softprops/action-gh-release@v3 
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ccache
           files: "ccache-aarch64-${{ inputs.DEVICE }}-emu-standalone.tar.part-*"
@@ -187,18 +239,46 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repository: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+          repository: ${{ env.CACHE_REPO }}
         continue-on-error: true
 
       - name: Print space
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
         run: df -h
 
-      - name: Compress directory
+      - name: Tar and checksum emu-standalone build tree
+        id: tar-checksum
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/tar-checksum
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: emu-standalone-aarch64
+          paths: |
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_*
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain
+
+      - name: Save emu-standalone build tree
+        if: steps.restore-emu-standalone.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/upload
+        with:
+          tar-glob: ${{ steps.tar-checksum.outputs.tar-glob }}
+          checksum-path: ${{ steps.tar-checksum.outputs.checksum-path }}
+          tag-name: emu-standalone
+          cache-repo: ${{ env.CACHE_REPO }}
+          token: ${{ secrets.GH_PAT }}
+
+      # Unconditional — runs whether we hit cache or built fresh, so downstream
+      # jobs in THIS workflow run always have something to download.
+      - name: Split emu-standalone artifact for same-run consumers
+        if: always()
         run: |
-          sudo tar --remove-files -cf - \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_* \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain  | split -b 2G -  build.emu-standalone.tar.part
+          rm -f build.emu-standalone.tar.part*
+          sudo tar -cf - \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_* \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain | split -b 2G - build.emu-standalone.tar.part
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build-aarch64-mame-lr.yml
+++ b/.github/workflows/build-aarch64-mame-lr.yml
@@ -12,43 +12,78 @@ on:
       OWNER_LC:
         required: true
         type: string
+    outputs:
+      cache-hit:
+        description: "Whether the mame-lr build tree was restored from cache"
+        value: ${{ jobs.build-aarch64-mame-lr.outputs.cache-hit }}
 
 jobs:
   build-aarch64-mame-lr:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
     env:
       JAVA_HOME: /usr
       AUTOREMOVE: "yes"
       PROJECT: ${{ inputs.PROJECT }}
       DEVICE: ${{ inputs.DEVICE }}
       ARCH: aarch64
-      CACHE_KEY: ccache-aarch64-${{ inputs.DEVICE }}-mame-${{ github.sha }}
       DISABLE_COLORS: yes
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
+      PACKAGE_LIST: "mame-lr"
+      CACHE_REPO: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+    outputs:
+      cache-hit: ${{ steps.restore-mame-lr.outputs.hit }}
     steps:
-      - name: Maximize build space
-        uses: justinthelaw/maximize-github-runner-space@v0.9.0
-        with:
-          skip-components: docker-engine
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Compute mame-lr dependency hash
+        id: hash
+        uses: ./.github/actions/build-cache/compute-hash
+        with:
+          project: ${{ env.PROJECT }}
+          device: ${{ env.DEVICE }}
+          arch: ${{ env.ARCH }}
+          package-list: ${{ env.PACKAGE_LIST }}
+
+      # Try to restore the whole mame-lr build tree from a previous run first.
+      # On a hit, Build and everything that only makes sense post-build is skipped.
+      - name: Retrieve mame-lr build tree
+        id: restore-mame-lr
+        uses: ./.github/actions/build-cache/download
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: mame-lr-aarch64
+          tag-name: mame-lr
+          cache-repo: ${{ env.CACHE_REPO }}
+
+      - name: Maximize build space
+        if: steps.restore-mame-lr.outputs.hit != 'true'
+        uses: justinthelaw/maximize-github-runner-space@v0.9.0
+        with:
+          skip-components: docker-engine
+
       - name: Retrieve ccache
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-mame.tar"
+          URL="https://github.com/${{ env.CACHE_REPO }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-mame.tar"
           curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."
 
       - name: Download aarch64-toolchain (${{ inputs.DEVICE }})
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64-toolchain (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64-toolchain
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -57,23 +92,24 @@ jobs:
           retry_interval: 10
 
       - name: Clean up compressed aarch64 file
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         run: rm build.aarch64-toolchain.tar.zst
 
-
       - name: Build
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
             ./scripts/get_env > .env
             set -e
             { docker run --init --env-file .env --rm --user $(id -u):$(id -g) -v ${PWD}:${PWD} -w ${PWD} "ghcr.io/${{ inputs.OWNER_LC }}/rocknix-build:latest" \
-              bash -c "./scripts/build_mt mame-lr"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
+              bash -c "./scripts/build_mt ${PACKAGE_LIST}"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
             exit_code=$(<docker_exit_code)
             exit $exit_code
           max_attempts: 6
           retry_interval: 10
 
-      - name: Archive output.logs (${{ inputs.DEVICE }}-aarch64-mame-lr
+      - name: Archive output.logs (${{ inputs.DEVICE }}-aarch64-mame-lr)
         if: failure()
         uses: actions/upload-artifact@v7
         with:
@@ -83,6 +119,7 @@ jobs:
             ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.threads/logs/
 
       - name: Clean ccache
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
@@ -92,10 +129,12 @@ jobs:
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z
 
       - name: Tar ccache
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         run: |
-           tar -cf ccache-aarch64-${{ inputs.DEVICE }}-mame.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache  
+          tar -cf ccache-aarch64-${{ inputs.DEVICE }}-mame.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
 
       - name: Save ccache
+        if: steps.restore-mame-lr.outputs.hit != 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ccache
@@ -104,14 +143,39 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repository: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+          repository: ${{ env.CACHE_REPO }}
         continue-on-error: true
 
-      - name: Compress directory
+      - name: Tar and checksum mame-lr build tree
+        id: tar-checksum
+        if: steps.restore-mame-lr.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/tar-checksum
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: mame-lr-aarch64
+          paths: |
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_pkg/mame-lr-*
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
+
+      - name: Save mame-lr build tree
+        if: steps.restore-mame-lr.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/upload
+        with:
+          tar-glob: ${{ steps.tar-checksum.outputs.tar-glob }}
+          checksum-path: ${{ steps.tar-checksum.outputs.checksum-path }}
+          tag-name: mame-lr
+          cache-repo: ${{ env.CACHE_REPO }}
+          token: ${{ secrets.GH_PAT }}
+
+      # Unconditional — runs whether we hit cache or built fresh, so downstream
+      # jobs in THIS workflow run always have something to download.
+      - name: Tar mame-lr artifact for same-run consumers
+        if: always()
         run: |
           tar --zstd -cf build.mame-lr.tar.zst \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_pkg/mame-lr-* \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_pkg/mame-lr-* \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build-aarch64-qt6.yml
+++ b/.github/workflows/build-aarch64-qt6.yml
@@ -12,12 +12,20 @@ on:
       OWNER_LC:
         required: true
         type: string
+    outputs:
+      cache-hit:
+        description: "Whether the qt6 build tree was restored from cache"
+        value: ${{ jobs.build-aarch64-qt6.outputs.cache-hit }}
 
 jobs:
   build-aarch64-qt6:
-    if: ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X' 
+    if:
+      ${{ inputs.DEVICE == 'RK3399' || inputs.DEVICE == 'RK3566' || inputs.DEVICE == 'RK3576' || inputs.DEVICE == 'RK3588' || inputs.DEVICE == 'S922X'
       || inputs.DEVICE == 'SM8250' || inputs.DEVICE == 'SM8550' || inputs.DEVICE == 'SM8650' || inputs.DEVICE == 'SM8750' || inputs.DEVICE == 'SM6115' }}
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
     env:
       EMULATION_DEVICE: no
       ENABLE_32BIT: no
@@ -27,34 +35,55 @@ jobs:
       PROJECT: ${{ inputs.PROJECT }}
       DEVICE: ${{ inputs.DEVICE }}
       ARCH: aarch64
-      CACHE_KEY: ccache-aarch64-${{ inputs.DEVICE }}-qt6-${{ github.sha }}
       DISABLE_COLORS: yes
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
-
+      PACKAGE_LIST: "qt6 modules"
+      CACHE_REPO: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+    outputs:
+      cache-hit: ${{ steps.restore-qt6.outputs.hit }}
     steps:
-      - name: Maximize build space
-        uses: justinthelaw/maximize-github-runner-space@v0.9.0
-        with:
-          skip-components: docker-engine
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Compute qt6 dependency hash
+        id: hash
+        uses: ./.github/actions/build-cache/compute-hash
+        with:
+          project: ${{ env.PROJECT }}
+          device: ${{ env.DEVICE }}
+          arch: ${{ env.ARCH }}
+          package-list: ${{ env.PACKAGE_LIST }}
+
+      # Try to restore the whole qt6 build tree from a previous run first.
+      # On a hit, Build and everything that only makes sense post-build is skipped.
+      - name: Retrieve qt6 build tree
+        id: restore-qt6
+        uses: ./.github/actions/build-cache/download
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: qt6-aarch64
+          tag-name: qt6
+          cache-repo: ${{ env.CACHE_REPO }}
+
       - name: Retrieve ccache
+        if: steps.restore-qt6.outputs.hit != 'true'
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-qt6.tar"
-          curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping." 
+          URL="https://github.com/${{ env.CACHE_REPO }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-qt6.tar"
+          curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."
 
       - name: Download aarch64 (${{ inputs.DEVICE }})
+        if: steps.restore-qt6.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64 (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64
+        if: steps.restore-qt6.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -63,9 +92,11 @@ jobs:
           retry_interval: 10
 
       - name: Clean up compressed aarch64 file
+        if: steps.restore-qt6.outputs.hit != 'true'
         run: rm build.aarch64.tar
 
       - name: Build
+        if: steps.restore-qt6.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
@@ -73,7 +104,7 @@ jobs:
             touch timestamp_before
             set -e
             { docker run --init --env-file .env --rm --user $(id -u):$(id -g) -v ${PWD}:${PWD} -w ${PWD} "ghcr.io/${{ inputs.OWNER_LC }}/rocknix-build:latest" \
-              bash -c "./scripts/build_mt qt6 modules"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
+              bash -c "./scripts/build_mt ${PACKAGE_LIST}"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
             exit_code=$(<docker_exit_code)
             exit $exit_code
           max_attempts: 6
@@ -89,6 +120,7 @@ jobs:
             ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.threads/logs/
 
       - name: Clean ccache
+        if: steps.restore-qt6.outputs.hit != 'true'
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
@@ -98,10 +130,12 @@ jobs:
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z
 
       - name: Tar ccache
+        if: steps.restore-qt6.outputs.hit != 'true'
         run: |
-          tar --remove-files -cf ccache-aarch64-${{ inputs.DEVICE }}-qt6.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache 
+          tar --remove-files -cf ccache-aarch64-${{ inputs.DEVICE }}-qt6.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
 
       - name: Save ccache
+        if: steps.restore-qt6.outputs.hit != 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ccache
@@ -110,13 +144,39 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repository: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+          repository: ${{ env.CACHE_REPO }}
         continue-on-error: true
 
-      - name: Compress directory
+      - name: Tar and checksum qt6 build tree
+        id: tar-checksum
+        if: steps.restore-qt6.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/tar-checksum
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: qt6-aarch64
+          paths: |
+            build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/
+          exclude: |
+            build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/build
+
+      - name: Save qt6 build tree
+        if: steps.restore-qt6.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/upload
+        with:
+          tar-glob: ${{ steps.tar-checksum.outputs.tar-glob }}
+          checksum-path: ${{ steps.tar-checksum.outputs.checksum-path }}
+          tag-name: qt6
+          cache-repo: ${{ env.CACHE_REPO }}
+          token: ${{ secrets.GH_PAT }}
+
+      # Unconditional — runs whether we hit cache or built fresh, so downstream
+      # jobs in THIS workflow run always have something to download.
+      - name: Tar qt6 artifact for same-run consumers
+        if: always()
         run: |
           tar --zstd --exclude='build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/build' -cf build.qt6.tar.zst \
-          build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/          
+            build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build-aarch64-rust.yml
+++ b/.github/workflows/build-aarch64-rust.yml
@@ -12,10 +12,17 @@ on:
       OWNER_LC:
         required: true
         type: string
+    outputs:
+      cache-hit:
+        description: "Whether the rust build tree was restored from cache"
+        value: ${{ jobs.build-aarch64-rust.outputs.cache-hit }}
 
 jobs:
   build-aarch64-rust:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
     env:
       JAVA_HOME: /usr
       AUTOREMOVE: "yes"
@@ -23,36 +30,66 @@ jobs:
       DEVICE: ${{ inputs.DEVICE }}
       ARCH: aarch64
       DISABLE_COLORS: yes
+      PACKAGE_LIST: "cargo:host"
+      CACHE_REPO: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+    outputs:
+      cache-hit: ${{ steps.restore-rust.outputs.hit }}
     steps:
-      - name: Maximize build space
-        uses: justinthelaw/maximize-github-runner-space@v0.9.0
-        with:
-          skip-components: docker-engine
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Compute rust dependency hash
+        id: hash
+        uses: ./.github/actions/build-cache/compute-hash
+        with:
+          project: ${{ env.PROJECT }}
+          device: ${{ env.DEVICE }}
+          arch: ${{ env.ARCH }}
+          package-list: ${{ env.PACKAGE_LIST }}
+
+      # Try to restore the whole rust build tree from a previous run first.
+      # On a hit, Build and everything that only makes sense post-build is skipped.
+      - name: Retrieve rust build tree
+        id: restore-rust
+        uses: ./.github/actions/build-cache/download
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: rust-aarch64
+          tag-name: rust
+          cache-repo: ${{ env.CACHE_REPO }}
+
+      - name: Maximize build space
+        if: steps.restore-rust.outputs.hit != 'true'
+        uses: justinthelaw/maximize-github-runner-space@v0.9.0
+        with:
+          skip-components: docker-engine
+
       - name: Download aarch64-toolchain (${{ inputs.DEVICE }})
+        if: steps.restore-rust.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: aarch64-toolchain (${{ inputs.DEVICE }})
 
       - name: Extract artifact aarch64-toolchain
+        if: steps.restore-rust.outputs.hit != 'true'
         run: |
           tar --zstd -xf build.aarch64-toolchain.tar.zst
 
       - name: Clean up compressed aarch64-toolchain file
+        if: steps.restore-rust.outputs.hit != 'true'
         run: rm build.aarch64-toolchain.tar.zst
 
       - name: Build cargo:host
+        if: steps.restore-rust.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
             ./scripts/get_env > .env
             set -e
             { docker run --init --env-file .env --rm --user $(id -u):$(id -g) -v ${PWD}:${PWD} -w ${PWD} "ghcr.io/${{ inputs.OWNER_LC }}/rocknix-build:latest" \
-              bash -c "./scripts/build_mt cargo:host"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
+              bash -c "./scripts/build_mt ${PACKAGE_LIST}"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
             exit_code=$(<docker_exit_code)
             exit $exit_code
           max_attempts: 6
@@ -68,12 +105,36 @@ jobs:
             ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.threads/logs/
 
       - name: Print space
+        if: steps.restore-rust.outputs.hit != 'true'
         run: df -h
 
-      - name: Compress directory
+      - name: Tar and checksum rust build tree
+        id: tar-checksum
+        if: steps.restore-rust.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/tar-checksum
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: rust-aarch64
+          paths: |
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/
+
+      - name: Save rust build tree
+        if: steps.restore-rust.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/upload
+        with:
+          tar-glob: ${{ steps.tar-checksum.outputs.tar-glob }}
+          checksum-path: ${{ steps.tar-checksum.outputs.checksum-path }}
+          tag-name: rust
+          cache-repo: ${{ env.CACHE_REPO }}
+          token: ${{ secrets.GH_PAT }}
+
+      # Unconditional — runs whether we hit cache or built fresh, so downstream
+      # jobs in THIS workflow run always have something to download.
+      - name: Tar rust artifact for same-run consumers
+        if: always()
         run: |
-          tar --zstd --remove-files \
-          -cf build.aarch64-rust.tar.zst ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/
+          tar --zstd -cf build.aarch64-rust.tar.zst ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/
 
       - uses: actions/upload-artifact@v7
         with:
@@ -81,4 +142,3 @@ jobs:
           path: build.aarch64-rust.tar.zst
           compression-level: 0
           if-no-files-found: error
-

--- a/.github/workflows/build-aarch64-toolchain.yml
+++ b/.github/workflows/build-aarch64-toolchain.yml
@@ -12,6 +12,10 @@ on:
       OWNER_LC:
         required: true
         type: string
+    outputs:
+      cache-hit:
+        description: "Whether the aarch64 toolchain build tree was restored from cache"
+        value: ${{ jobs.build-aarch64-toolchain.outputs.cache-hit }}
 
 jobs:
   build-aarch64-toolchain:
@@ -26,35 +30,62 @@ jobs:
       PROJECT: ${{ inputs.PROJECT }}
       DEVICE: ${{ inputs.DEVICE }}
       ARCH: aarch64
-      CACHE_KEY: ccache-aarch64-${{ inputs.DEVICE }}-toolchain-${{ github.sha }}
       DISABLE_COLORS: yes
       CCACHE_COMPILERCHECK: content
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 6
       CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
+      PACKAGE_LIST: "toolchain alsa-lib llvm:host"
+      CACHE_REPO: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+    outputs:
+      cache-hit: ${{ steps.restore-toolchain.outputs.hit }}
     steps:
-      - name: Maximize build space
-        uses: justinthelaw/maximize-github-runner-space@v0.9.0
-        with:
-          skip-components: docker-engine
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Compute toolchain dependency hash
+        id: hash
+        uses: ./.github/actions/build-cache/compute-hash
+        with:
+          project: ${{ env.PROJECT }}
+          device: ${{ env.DEVICE }}
+          arch: ${{ env.ARCH }}
+          package-list: ${{ env.PACKAGE_LIST }}
+
+      # Try to restore the whole toolchain/build tree from a previous run first.
+      # On a hit, Build and everything that only makes sense post-build is skipped.
+      - name: Retrieve toolchain build tree
+        id: restore-toolchain
+        uses: ./.github/actions/build-cache/download
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: toolchain-aarch64
+          tag-name: toolchain
+          cache-repo: ${{ env.CACHE_REPO }}
+
+      - name: Maximize build space
+        if: steps.restore-toolchain.outputs.hit != 'true'
+        uses: justinthelaw/maximize-github-runner-space@v0.9.0
+        with:
+          skip-components: docker-engine
+
       - name: Retrieve ccache
+        if: steps.restore-toolchain.outputs.hit != 'true'
         run: |
-          URL="https://github.com/${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar"
-          curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."            
+          URL="https://github.com/${{ env.CACHE_REPO }}/releases/download/ccache/ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar"
+          curl -L --fail --silent --show-error "$URL" | tar -xvf - || echo "Cache archive not found, skipping."
 
       - name: Build
+        if: steps.restore-toolchain.outputs.hit != 'true'
         uses: corrupt952/actions-retry-command@v1.0.7
         with:
           command: |
             ./scripts/get_env > .env
             set -e
             { docker run --init --env-file .env --rm --user $(id -u):$(id -g) -v ${PWD}:${PWD} -w ${PWD} "ghcr.io/${{ inputs.OWNER_LC }}/rocknix-build:latest" \
-              bash -c "./scripts/build_mt toolchain alsa-lib llvm:host"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
+              bash -c "./scripts/build_mt ${PACKAGE_LIST}"; echo $? > docker_exit_code; } | tee output.log | grep -E  --color=never --line-buffered "^GET|^UNPACK|^BUILD|^INSTALL" || true
             exit_code=$(<docker_exit_code)
             exit $exit_code
           max_attempts: 6
@@ -93,6 +124,7 @@ jobs:
             ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.threads/logs/
 
       - name: Clean ccache
+        if: steps.restore-toolchain.outputs.hit != 'true'
         run: |
           export CCACHE_DIR=./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -s -v
@@ -102,10 +134,12 @@ jobs:
           ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain/bin/ccache -z
 
       - name: Tar ccache
+        if: steps.restore-toolchain.outputs.hit != 'true'
         run: |
-          tar --remove-files -cf ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache  
+          tar --remove-files -cf ccache-aarch64-${{ inputs.DEVICE }}-toolchain.tar ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.ccache
 
       - name: Save ccache
+        if: steps.restore-toolchain.outputs.hit != 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ccache
@@ -114,17 +148,47 @@ jobs:
           prerelease: true
           body: ccache
           token: ${{ secrets.GH_PAT }}
-          repository: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+          repository: ${{ env.CACHE_REPO }}
         continue-on-error: true
 
-      - name: Compress directory
+      - name: Tar and checksum toolchain build tree
+        id: tar-checksum
+        if: steps.restore-toolchain.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/tar-checksum
+        with:
+          hash: ${{ steps.hash.outputs.hash }}
+          device: ${{ env.DEVICE }}
+          artifact-prefix: toolchain-aarch64
+          paths: |
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/build
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_*
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
+
+      - name: Save toolchain build tree
+        if: steps.restore-toolchain.outputs.hit != 'true'
+        uses: ./.github/actions/build-cache/upload
+        with:
+          tar-glob: ${{ steps.tar-checksum.outputs.tar-glob }}
+          checksum-path: ${{ steps.tar-checksum.outputs.checksum-path }}
+          tag-name: toolchain
+          cache-repo: ${{ env.CACHE_REPO }}
+          token: ${{ secrets.GH_PAT }}
+
+      # Unconditional — runs whether we hit cache or built fresh, so downstream
+      # jobs in THIS workflow run always have something to download.
+      - name: Tar toolchain artifact for same-run consumers
+        if: always()
         run: |
           tar --zstd -cf build.aarch64-toolchain.tar.zst \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/build \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_* \
-          ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
-      - uses: actions/upload-artifact@v7
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/toolchain \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/build \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/install_* \
+            ./build.ROCKNIX-${{ inputs.DEVICE }}.aarch64/.stamps
+
+      - name: Upload toolchain artifact
+        if: always()
+        uses: actions/upload-artifact@v7
         with:
           name: aarch64-toolchain (${{ inputs.DEVICE }})
           path: build.aarch64-toolchain.tar.zst

--- a/.github/workflows/cleanup-old-release-assets.yml
+++ b/.github/workflows/cleanup-old-release-assets.yml
@@ -1,0 +1,59 @@
+name: Clean up old build-cache assets
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # daily at 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Delete assets older than this many days"
+        required: false
+        default: "30"
+      dry_run:
+        description: "List what would be deleted without deleting"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-24.04
+    env:
+      CACHE_REPO: ${{ github.repository_owner }}/${{ vars.CACHE_REPO || 'distribution-cache' }}
+      GH_TOKEN: ${{ secrets.GH_PAT }}
+      DAYS: ${{ inputs.days || '30' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+    steps:
+      - name: Delete stale build-cache assets
+        run: |
+          set -euo pipefail
+          CUTOFF=$(date -d "-${DAYS} days" +%s)
+          echo "Deleting assets older than ${DAYS} days (before $(date -d "@$CUTOFF"))"
+          [ "$DRY_RUN" = "true" ] && echo "DRY RUN — no deletions will be made"
+
+          TAGS=(toolchain qt6 rust mame-lr emu-libretro emu-standalone)
+
+          for TAG in "${TAGS[@]}"; do
+            echo "== $TAG =="
+
+            RELEASE_ID=$(gh api "repos/${CACHE_REPO}/releases/tags/${TAG}" --jq '.id' 2>/dev/null) || {
+              echo "  no release for tag $TAG, skipping"
+              continue
+            }
+
+            gh api --paginate "repos/${CACHE_REPO}/releases/${RELEASE_ID}/assets" \
+              --jq '.[] | [.id, .name, .created_at] | @tsv' | \
+            while IFS=$'\t' read -r ASSET_ID NAME CREATED_AT; do
+              CREATED_EPOCH=$(date -d "$CREATED_AT" +%s)
+              if [ "$CREATED_EPOCH" -lt "$CUTOFF" ]; then
+                AGE_DAYS=$(( (CUTOFF - CREATED_EPOCH) / 86400 + DAYS ))
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "  would delete: $NAME (created $CREATED_AT, ~${AGE_DAYS}d old)"
+                else
+                  echo "  deleting: $NAME (created $CREATED_AT, ~${AGE_DAYS}d old)"
+                  gh api -X DELETE "repos/${CACHE_REPO}/releases/assets/${ASSET_ID}"
+                fi
+              fi
+            done
+          done

--- a/tools/list_deps.sh
+++ b/tools/list_deps.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# usage: PROJECT=... DEVICE=... ARCH=... tools/list_deps.sh toolchain alsa-lib llvm:host
+
+declare -A SEEN
+QUEUE=()
+for a in "$@"; do QUEUE+=("${a}|walk"); done
+WALK_DIRS=()
+LEAF_DIRS=()
+WATCH_PATHS=()
+
+while [ ${#QUEUE[@]} -gt 0 ]; do
+  entry="${QUEUE[0]}"
+  QUEUE=("${QUEUE[@]:1}")
+  pkg="${entry%|*}"
+  mode="${entry#*|}"
+
+  base="${pkg%%:*}"
+  stage="target"
+  case "$pkg" in
+    *:host) stage="host" ;;
+    *:init) stage="init" ;;
+    *:bootstrap) stage="bootstrap" ;;
+  esac
+
+  key="${base}:${stage}"
+  [ -n "${SEEN[$key]:-}" ] && continue
+  SEEN[$key]=1
+
+  info=$(tools/pkginfo "${base}" 2>/dev/null) || continue
+
+  dir=$(echo "$info" | grep '^PKG_DIR=' | cut -d'"' -f2)
+  if [ -n "$dir" ]; then
+    if [ "$mode" = "leaf" ]; then
+      LEAF_DIRS+=("$dir")
+    else
+      WALK_DIRS+=("$dir")
+    fi
+  fi
+
+  need_unpack=$(echo "$info" | grep '^PKG_NEED_UNPACK=' | cut -d'"' -f2)
+  for p in $need_unpack; do
+    [ -d "$p" ] && WATCH_PATHS+=("$p")
+  done
+
+  [ "$mode" = "leaf" ] && continue
+
+  case "$stage" in
+    host)      deps=$(echo "$info" | grep '^PKG_DEPENDS_HOST=' | cut -d'"' -f2) ;;
+    init)      deps=$(echo "$info" | grep '^PKG_DEPENDS_INIT=' | cut -d'"' -f2) ;;
+    bootstrap) deps=$(echo "$info" | grep '^PKG_DEPENDS_BOOTSTRAP=' | cut -d'"' -f2) ;;
+    *)         deps=$(echo "$info" | grep '^PKG_DEPENDS_TARGET=' | cut -d'"' -f2) ;;
+  esac
+  unpack_deps=$(echo "$info" | grep '^PKG_DEPENDS_UNPACK=' | cut -d'"' -f2)
+
+  for d in $deps; do
+    [ "$d" = "$base" ] && continue
+    QUEUE+=("${d}|walk")
+  done
+  for d in $unpack_deps; do
+    [ "$d" = "$base" ] && continue
+    QUEUE+=("${d}|leaf")
+  done
+done
+
+WALK_NAMES=$(printf '%s\n' "${WALK_DIRS[@]}" | xargs -n1 basename | sort -u)
+LEAF_NAMES=$(printf '%s\n' "${LEAF_DIRS[@]}" | xargs -n1 basename | sort -u)
+ALL_NAMES=$(printf '%s\n%s\n' "$WALK_NAMES" "$LEAF_NAMES" | sort -u)
+WATCH_UNIQUE=$(printf '%s\n' "${WATCH_PATHS[@]}" | sort -u)
+
+{
+  echo "# Built packages (own BUILD step): $(echo "$WALK_NAMES" | grep -c .)"
+  echo "$WALK_NAMES"
+  echo
+  echo "# Unpack-only packages (PKG_DEPENDS_UNPACK, no own build step): $(echo "$LEAF_NAMES" | grep -c .)"
+  echo "$LEAF_NAMES"
+  echo
+  echo "# Total resolved packages: $(echo "$ALL_NAMES" | grep -c .)"
+  echo
+  echo "# Watch paths (PKG_NEED_UNPACK, project/device overlays etc.): $(echo "$WATCH_UNIQUE" | grep -c .)"
+  echo "$WATCH_UNIQUE"
+} >&2
+
+# stdout stays script-consumable: dirs to hash for package.mk/patch content,
+# then a marker, then watch-paths to hash as raw file content
+printf '%s\n' "${WALK_DIRS[@]}" "${LEAF_DIRS[@]}" | sort -u
+echo '---WATCH---'
+printf '%s\n' "$WATCH_UNIQUE"


### PR DESCRIPTION

**NOTE:** Created this mostly for my personal setup, as I'm more invested in GH action builds rather than using a local build environment. Due to the rapid development cycle of Rocknix, hash hits might not be high as expected but nonetheless it might benefit aarch64-toolchain build as its main dependencies are mostly provided in top level LibreELEC packages.

## Summary

Using the same pattern with ccache, adds content-hash based build-tree caching for CI, replacing the current "always rebuild" `toolchain`/`qt6`/`rust`/`mame-lr`/`emu-libretro`/`emu-standalone` jobs with a cache-first flow.

What changed
- Adds a new `tools/list_deps.sh` script; resolves the full transitive package dependency closure (via tools/pkginfo) for a given set of trigger packages, distinguishing packages that get built vs. unpack-only dependencies vs. stamp-watch paths.
- `.github/actions/build-cache/`; four composite actions used across all six build jobs:
  - `compute-hash`; hashes the resolved dependency closure's package.mk/patch/conf files
  - `download`; restores a matching cached build tree from the cache repo's releases, verified via checksum
  - `tar-checksum`; compresses + splits a build tree into <2GB parts (release asset limit) with a sha256 manifest
  - `upload`;  publishes parts to the cache repo

All six build workflows updated to: compute the hash → attempt cache restore → skip build/ccache/compress steps entirely on a hit → save to cache on a miss.
- `New scheduled cleanup workflow`;  deletes cache-repo release assets older than 30 days (configurable via manual dispatch, with a dry-run mode).

## Testing

Skipped aarch64-toolchain  build due to a cache hit:
https://github.com/edemirkan/rocknix-distribution/actions/runs/31957096522/job/95189476200#step:3:56
https://github.com/edemirkan/rocknix-distribution/actions/runs/31970676692/job/95223039715

Release asset storage:
https://github.com/edemirkan/rocknix-distribution-cache/releases

Clean up:
https://github.com/edemirkan/rocknix-distribution/actions/runs/31972259112/job/95226372823

## Additional Context

Per-package build steps were re-running in full on every CI run regardless of whether anything relevant had changed. This PR lets unchanged dependency subtrees (e.g. the aarch64 toolchain) skip straight to a cached artifact instead of rebuilding from source each time. Clean up job is set for 30 days, but can be updated as needed. GH has a 1000 files limit per release with no limit on the total combined size of a release.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** PARTIALLY
