### PR TITLE
S922X: add energy-full-design-microwatt-hours to DTS

### DIFF
--- a/projects/ROCKNIX/devices/S922X/patches/linux/S922X/0022-arm64-meson-odroid-go-ultra-add-battery-and-charger.patch
+++ b/projects/ROCKNIX/devices/S922X/patches/linux/S922X/0022-arm64-meson-odroid-go-ultra-add-battery-and-charger.patch
@@ -1,17 +1,17 @@
-From f10269b43d8b6800b6e98de8a462d32555462603 Mon Sep 17 00:00:00 2001
+From 7cada7bbd36237682e0be0d8c9bb7101e7c0c9e0 Mon Sep 17 00:00:00 2001
 From: John Williams <porschemad911@gmail.com>
-Date: Thu, 9 Jul 2026 12:48:25 +1000
+Date: Thu, 20 Aug 2026 12:26:30 +1000
 Subject: [PATCH 22/34] arm64: meson: odroid-go-ultra: add battery and charger
 
 ---
- .../amlogic/meson-g12b-odroid-go-ultra.dts    | 24 +++++++++++++++++++
- 1 file changed, 24 insertions(+)
+ .../amlogic/meson-g12b-odroid-go-ultra.dts    | 25 +++++++++++++++++++
+ 1 file changed, 25 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-go-ultra.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-go-ultra.dts
-index b5fe30860d8c..80dfe331cc8f 100644
+index b5fe30860d8c..98df0e75305f 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-go-ultra.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-go-ultra.dts
-@@ -25,6 +25,25 @@ chosen {
+@@ -25,6 +25,26 @@ chosen {
  		stdout-path = "serial0:115200n8";
  	};
  
@@ -19,6 +19,7 @@ index b5fe30860d8c..80dfe331cc8f 100644
 +		compatible = "simple-battery";
 +		voltage-max-design-microvolt = <4200000>;
 +		voltage-min-design-microvolt = <3500000>;
++		energy-full-design-microwatt-hours = <14800000>;
 +		charge-full-design-microamp-hours = <4000000>;
 +		charge-term-current-microamp = <200000>;
 +		constant-charge-current-max-microamp = <1500000>;
@@ -37,7 +38,7 @@ index b5fe30860d8c..80dfe331cc8f 100644
  	codec_clk: codec-clk {
  		compatible = "fixed-clock";
  		clock-frequency = <12288000>;
-@@ -397,6 +416,11 @@ rk818: pmic@1c {
+@@ -397,6 +417,11 @@ rk818: pmic@1c {
  		vcc9-supply = <&vddao_3v3>;
  		boost-supply = <&vdd_sys>;
  


### PR DESCRIPTION
## Summary

S922X: add energy-full-design-microwatt-hours to DTS

## Testing

Tested on my OGU

---

### AI Usage

**Did you use AI tools to help write this code?** NO
