### PR TITLE
config/functions: do not reconfigure libtool with installed libtoolize

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -951,7 +951,13 @@ do_autoreconf() {
     export AUTOPOINT=$TOOLCHAIN/bin/autopoint
   fi
 
-  if [ -e "$TOOLCHAIN/bin/libtoolize" ]; then
+  # Never reconfigure libtool with a previously installed libtoolize: it runs
+  # as 'libtoolize --copy --force' and overwrites the package's own m4 macros
+  # with the installed - older - ones. A clean build tree has no libtoolize
+  # here at all, so this only ever bites an incremental build across a libtool
+  # version bump, and it fails inside the new macros rather than pointing at
+  # the stale tool.
+  if [ -e "$TOOLCHAIN/bin/libtoolize" -a "$PKG_NAME" != "libtool" ]; then
     export LIBTOOLIZE=$TOOLCHAIN/bin/libtoolize
   fi
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Let `libtool` be upgraded on a build tree that already has an older `libtool` installed.

`do_autoreconf()` points `LIBTOOLIZE` at the toolchain copy whenever one exists. When the package being reconfigured *is* libtool, that is the previously installed libtool preparing its own successor — `autoreconf` invokes it as `libtoolize --copy --force`, which overwrites the unpacked tarball's `m4/*.m4` with the installed, older macros.

Upgrading libtool 2.5.4 → 2.6.2 then fails on any tree that already has 2.5.4:

```
configure.ac:155: error: LT_LANG: unsupported language: "Objective-C"
m4/libtool.m4:824: LT_LANG is expanded from...
```

2.6.2's own macros (serial 67) support that language; 2.5.4's (serial 63), which overwrote them, do not. The message names the new source and the old macros, so it reads as a defect in the package rather than a stale tool.

A clean tree is unaffected: no `libtoolize` exists at that point in the build, and the build container ships none. That is why CI does not see this — it only affects incremental builds across a libtool bump, which is to say developer trees.

The fix skips the export for `libtool` alone, reproducing the clean-tree condition.

## Testing

* **How was this tested?** The bug was hit for real: an incremental RK3566 build on a tree predating the 2.6.2 bump failed exactly as above. Removing the stale libtool host install by hand (`toolchain/bin/libtool{,ize}`, `toolchain/share/libtool`, `toolchain/share/aclocal/lt*.m4`) let `libtool:host` build 2.6.2 and the build continued; RK3566, H700 and RK3326 images all completed afterwards. This patch performs that same exclusion automatically.

  The conditional itself was verified in isolation with a `libtoolize` present in a fake toolchain:

  ```
  libtool      LIBTOOLIZE=<unset>
  glib         LIBTOOLIZE=<toolchain>/bin/libtoolize
  libtool-bin  LIBTOOLIZE=<toolchain>/bin/libtoolize
  ```

  Only libtool is exempted; other packages, including similarly-named ones, are untouched.

* **Test results:** Worth stating plainly — I have **not** re-run a warm-tree 2.5.4 → 2.6.2 bump with this patch applied, because the affected build roots were wiped before the patch was written. The evidence is that the failure is real and reproducible, that clearing the same artifacts by hand resolves it, and that the patch removes the same input. A reviewer with a pre-2.6.2 tree could confirm end-to-end in one build.

## Additional Context

* Only `libtool` is exempted. Other self-hosting autotools packages could in principle need the same treatment, but libtool is the one known to overwrite its own build inputs, so the change is kept narrow.
* Risk is low and one-directional: the only behaviour change is that `libtool` no longer uses a previously installed `libtoolize`, which is already the case on every clean build.

---

### AI Usage

**Did you use AI tools to help write this code?** YES — the diagnosis, patch and this description were produced with Claude Code. The failure, the manual workaround and the isolated check of the conditional were all run and observed directly; the untested gap is called out above rather than glossed.
