### PR TITLE
config/functions: hash the global recipe a project package sources

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1088,12 +1088,34 @@ get_all_package_names() {
   sed -e 's#@?+?@##g; s#.*/##g' ${_CACHE_PACKAGE_GLOBAL} ${_CACHE_PACKAGE_LOCAL} | sort --ignore-case --unique
 }
 
+# Return the global package directory for a package, ignoring any project
+# package of the same name. Used by calculate_stamp; get_pkg_directory
+# deliberately prefers the project package and so cannot answer this.
+get_global_pkg_directory() {
+  local _PKG_ROOT_NAME=${1%:*} _ANCHOR="@?+?@" _DIR
+
+  for _DIR in $(grep -F "/${_PKG_ROOT_NAME}${_ANCHOR}" "${_CACHE_PACKAGE_GLOBAL}"); do
+    echo "${_DIR%${_ANCHOR}}"
+    return
+  done
+}
+
 calculate_stamp() {
-  local stamp data
+  local stamp data global_dir
 
   stamp="$PKG_DIR $PROJECT_DIR/$PROJECT/patches/$PKG_NAME $PROJECT_DIR/$PROJECT/packages/$PKG_NAME"
   [ -n "$DEVICE" ] && stamp+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
   [ -n "$PKG_NEED_UNPACK" ] && stamp+=" $PKG_NEED_UNPACK"
+
+  # A project package.mk routinely sources the global one to inherit
+  # PKG_VERSION, PKG_URL and PKG_SHA256, adding only project-specific hooks.
+  # $PKG_DIR resolves to the project copy in that case, so without this the
+  # global recipe is never hashed and a version bump there does not invalidate
+  # the stamp - the previous version stays built and installed, silently. For
+  # a package with no project override this adds a path already in the list,
+  # which the sort -u below discards, so existing stamps do not change.
+  global_dir="$(get_global_pkg_directory "${PKG_NAME}")"
+  [ -n "${global_dir}" ] && stamp+=" ${global_dir}"
 
   data="$(find -L ${stamp} -type f -not -name '.*' -print0 2>/dev/null | sed -z "s|^${ROOT}/||" | LC_ALL=C sort -zu | xargs -0 sha256sum)"
   [ -n "${PKG_STAMP}" ] && data+=$'\n'"$(echo "${PKG_STAMP}" | sha256sum)"


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make a version bump in a global recipe actually rebuild the package when a project override exists.

A project `package.mk` routinely sources the global one to inherit `PKG_VERSION`, `PKG_URL` and `PKG_SHA256`, adding only project-specific hooks. `projects/ROCKNIX` has 53 such packages, e.g. `projects/ROCKNIX/packages/security/libgpg-error/package.mk`:

```sh
. ${ROOT}/packages/security/libgpg-error/package.mk

pre_configure_target() {
  ...
}
```

`get_pkg_directory()` prefers the project package — correctly, that is its purpose — so `PKG_DIR` points at the project copy, and `calculate_stamp()` hashes only that. **The file carrying the version is never hashed.** Bumping the global recipe does not change the stamp, so the previously built version stays built and installed, with no error and no rebuild.

It surfaces later somewhere else entirely:

```
checking for GPG Error - version >= 1.56... no
configure: error: libgpg-error is needed.
```

after `libgpg-error` went to 1.61 globally while a tree kept 1.55 built. The failing package names a dependency that looks correct in the tree.

The silent case is the concerning one. On one month-old build tree, **35 packages were stale this way** — openssl 3.5.1 vs 3.6.3, glib 2.85.1 vs 2.89.3, libfmt 9.1.0 vs 12.2.0, plus curl, expat, zlib and most of the X11 stack. Only the one with a hard version check failed loudly; the rest would have shipped in an image as older libraries than the tree specifies.

`get_global_pkg_directory()` is added because `get_pkg_directory()` cannot answer this question by design, and its result is included in the stamp.

## Testing

* **How was this tested?** Both directions, against a real `.cache_package_global` from a populated build root, comparing the stamp before and after appending a comment to the global recipe:

| Package | Override? | Old code sees change | New code sees change | Stamp changed by patch |
|---|---|---|---|---|
| `libgpg-error` | yes | **no** | yes | yes — one-time rebuild |
| `libtool` | no | yes | yes | **no** |

* **Test results:** The first row is the bug and the fix. The second row is the important safety property: for a package with no project override, the added path is already in the list and the existing `sort -u` discards it, so the stamp is byte-identical and nothing rebuilds spuriously.

  The originating failure was also confirmed end-to-end: after wiping the affected build roots, the same tree built `libgpg-error-1.61`, `openssl-3.6.3` and `libtool-2.6.2` — the versions the stamps had been ignoring — and produced working RK3566, H700 and RK3326 images.

## Additional Context

* **Blast radius:** only packages with a project override change stamp, and each rebuilds once. Everything else is unaffected. On the ROCKNIX project that is 53 packages on the first build after merge.
* **Why not fix the overrides instead:** sourcing the global recipe is a good pattern and widely used here; the stamp should reflect what the build actually reads.
* CI never sees this, because CI builds clean. It only affects trees that persist across a version bump — developer machines, and any incremental build setup.

---

### AI Usage

**Did you use AI tools to help write this code?** YES — the diagnosis, patch, test harness and this description were produced with Claude Code. The staleness figures and the table above are measured output from that harness against a real build root, not estimates.
