### PR TITLE
SM8250: add 'gpt' to EXTRA_CMDLINE

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/options
+++ b/projects/ROCKNIX/devices/SM8250/options
@@ -28,7 +28,7 @@
     KERNEL_MAKE_EXTRACMD=" $(get_kernel_make_extracmd)"
 
   # Kernel cmdline
-    EXTRA_CMDLINE="quiet rootwait console=tty0 video=efifb:off"
+    EXTRA_CMDLINE="quiet rootwait console=tty0 video=efifb:off gpt"
 
   # Bootloader to use (syslinux / u-boot)
     BOOTLOADER="arm-efi"


### PR DESCRIPTION
## Summary

SM8250: add 'gpt' to EXTRA_CMDLINE

## Testing

Tested on my RP Mini V2

## Additional Context

Parameter doco, from: https://www.kernel.org/doc/html/v7.1/admin-guide/kernel-parameters.html

> gpt: [EFI] Forces disk with valid GPT signature but invalid Protective MBR to be treated as GPT. If the primary GPT is corrupted, it enables the backup/alternate GPT to be used instead.

This works around a situation discovered after flashing Retroid recovery images for the Retroid Pocket Mini V2 and then attempting to install the ROCKNIX ABL. The primary GPT partition table for the block device containing the ABL partitions is corrupt, and so they cannot be found. Adding 'gpt' to the kernel cmdline resolves this since the backup GPT partition table is fine. After flashing the ROCKNIX ABL the primary partition table is no longer corrupt.

Details of Retroid recovery image flashing and partition table corruption can be found on this PR: https://github.com/ROCKNIX/distribution/pull/3127

---

### AI Usage

**Did you use AI tools to help write this code?** NO
