### PR TITLE
systemd: Only generate hwdb at first boot and after an update

### DIFF
--- a/projects/ROCKNIX/packages/sysutils/busybox/scripts/init
+++ b/projects/ROCKNIX/packages/sysutils/busybox/scripts/init
@@ -857,9 +857,9 @@ do_cleanup() {
   rm -rf ${UPDATE_ROOT}/* &>/dev/null
 
   # Remove hwdb so it's recreated next boot
-  if [ ! -d "/storage/.config/hwdb.bin" ]
+  if [ ! -d "/storage/.cache/hwdb.bin" ]
   then
-    rm /storage/.config/hwdb.bin &>/dev/null
+    rm /storage/.cache/hwdb.bin &>/dev/null
   fi
 
   # All previous unmounts were needed to safely unmount storage partition

--- a/projects/ROCKNIX/packages/sysutils/busybox/scripts/init
+++ b/projects/ROCKNIX/packages/sysutils/busybox/scripts/init
@@ -856,6 +856,12 @@ do_cleanup() {
   rm -rf ${UPDATE_ROOT}/.[0-9a-zA-Z]* &>/dev/null
   rm -rf ${UPDATE_ROOT}/* &>/dev/null
 
+  # Remove hwdb so it's recreated next boot
+  if [ ! -d "/storage/.config/hwdb.bin" ]
+  then
+    rm /storage/.config/hwdb.bin &>/dev/null
+  fi
+
   # All previous unmounts were needed to safely unmount storage partition
   if mountpoint -q /storage; then
     umount /storage &>/dev/null

--- a/projects/ROCKNIX/packages/sysutils/systemd/patches/systemd-0002-move-hwdb.bin-to-storage.patch
+++ b/projects/ROCKNIX/packages/sysutils/systemd/patches/systemd-0002-move-hwdb.bin-to-storage.patch
@@ -18,7 +18,7 @@ index 5302679a62..4afdd6e306 100644
  #define hwdb_bin_paths                          \
          "/etc/systemd/hwdb/hwdb.bin\0"          \
 -        "/etc/udev/hwdb.bin\0"                  \
-+        "/run/hwdb.bin\0"                       \
++        "/storage/.cache/hwdb.bin\0"            \
          "/usr/lib/systemd/hwdb/hwdb.bin\0"      \
          _CONF_PATHS_SPLIT_USR_NULSTR("systemd/hwdb/hwdb.bin") \
          UDEVLIBEXECDIR "/hwdb.bin\0"
@@ -31,7 +31,7 @@ index 12621b7f89..552b1dc008 100644
           * should set the argument false, and 'udevadm hwdb' command should set it true. */
  
 -        hwdb_bin = path_join(root, hwdb_bin_dir ?: "/etc/udev", "hwdb.bin");
-+        hwdb_bin = path_join(root, hwdb_bin_dir ?: "/run", "hwdb.bin");
++        hwdb_bin = path_join(root, hwdb_bin_dir ?: "/storage/.cache/", "hwdb.bin");
          if (!hwdb_bin)
                  return -ENOMEM;
  
@@ -44,7 +44,7 @@ index 4ba36d1fc6..4848ae9661 100644
  ConditionNeedsUpdate=/etc
  ConditionPathExists=|!{{UDEVLIBEXECDIR}}/hwdb.bin
 -ConditionPathExists=|/etc/udev/hwdb.bin
-+ConditionPathExists=|/run/hwdb.bin
++ConditionPathExists=!/storage/.cache/hwdb.bin
  ConditionDirectoryNotEmpty=|/etc/udev/hwdb.d/
  
  DefaultDependencies=no


### PR DESCRIPTION
## Summary

This change moves systemd hwdb to `/storage/.cache/` so it's generated only at first boot and after updating instead of every boot.

## Testing

Tested on a GKD Pixel 2 (rk3326), this shaves off ~3.5s from normal boot times (according to `systemd-analyze blame`)

## Additional Context

Please squash the commits, i messed the amend.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?**  NO
