### PR TITLE
thor: add melonDS DS screen sizing option

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/setsettings.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/setsettings.sh
@@ -994,6 +994,18 @@ function set_dreamcastopts() {
     fi
 }
 
+function set_melondsds_opt() {
+    local OPT_FILE="${1}"
+    local OPT_KEY="${2}"
+    local OPT_VALUE="${3}"
+    if grep -q "^${OPT_KEY} = " "${OPT_FILE}"
+    then
+        sed -i "/^${OPT_KEY} = /c\\${OPT_KEY} = \"${OPT_VALUE}\"" "${OPT_FILE}"
+    else
+        echo "${OPT_KEY} = \"${OPT_VALUE}\"" >>"${OPT_FILE}"
+    fi
+}
+
 function set_melondsdsopts() {
     log "Set up melonDS DS..."
     if [ "${CORE}" = "melondsds" ]
@@ -1012,6 +1024,42 @@ melonds_console_mode = "ds"
 melonds_show_cursor = "timeout"
 melonds_touch_mode = "auto"
 EOF
+        fi
+
+        local FIT_SCALE="" FIT_GAP="" FIT_WIDTH="" FIT_HEIGHT=""
+        case "${QUIRK_DEVICE}" in
+            "AYN Thor"|"AYN Thor Lite"|"Retroid Pocket Mini V2")
+                ### 1240x1080 bottom panel
+                FIT_SCALE="85"
+                FIT_GAP="15"
+                FIT_WIDTH="1440"
+                FIT_HEIGHT="2079"
+                ;;
+            "Retroid Pocket Mini")
+                ### 1240x930 bottom panel, the secondary screen nearly fills it
+                FIT_SCALE="85"
+                FIT_GAP="1"
+                FIT_WIDTH="1440"
+                FIT_HEIGHT="2004"
+                ;;
+        esac
+
+        if [ -n "${FIT_SCALE}" ]
+        then
+            local SCREEN_SIZING="$(get_setting "screen_sizing" "${PLATFORM}" "${ROM}")"
+            if [ "${SCREEN_SIZING}" = "1" ]
+            then
+                set_melondsds_opt "${MELONDSDSDIR}/melonDS DS.opt" "melonds_secondary_screen_scale" "100"
+                set_melondsds_opt "${MELONDSDSDIR}/melonDS DS.opt" "melonds_screen_gap" "0"
+            else
+                set_melondsds_opt "${MELONDSDSDIR}/melonDS DS.opt" "melonds_secondary_screen_scale" "${FIT_SCALE}"
+                set_melondsds_opt "${MELONDSDSDIR}/melonDS DS.opt" "melonds_screen_gap" "${FIT_GAP}"
+                add_setting "none" "aspect_ratio_index" "23"
+                add_setting "none" "custom_viewport_height" "${FIT_HEIGHT}"
+                add_setting "none" "custom_viewport_width" "${FIT_WIDTH}"
+                add_setting "none" "video_viewport_bias_x" "0.500000"
+                add_setting "none" "video_viewport_bias_y" "-0.000000"
+            fi
         fi
 
         if [ "${PLATFORM}" = "ndsiware" ]
@@ -1291,11 +1339,11 @@ set_n64opts &
 set_saturnopts &
 set_snesopts &
 set_dreamcastopts &
-set_melondsdsopts &
 
 ### Sed operations are expensive, so they are staged and executed as
 ### a single process when all forks complete.
 wait
+set_melondsdsopts
 flush_settings
 
 cleanup

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/vertical-check
@@ -21,6 +21,7 @@ if [ -z "${CURRENT_CORE}" ] || [ -z "${ROM_PATH}" ]; then
     exit 0
 fi
 
+ROM=$(basename "${ROM_PATH}")
 ROM_NAME=$(basename "${ROM_PATH}" | sed 's/\.[^.]*$//')
 EXTERNAL_DISPLAY_CONNECTED=false
 if grep -q "^connected$" /sys/class/drm/card*-HDMI*/status 2>/dev/null || grep -q "^connected$" /sys/class/drm/card*-DP*/status 2>/dev/null; then
@@ -48,16 +49,33 @@ case "${ROM_NAME}" in
         ;;
 esac
 
+melondsds_fit_to_main_screen() {
+    [ "${CURRENT_CORE}" = "melondsds" ] || return 1
+    [ "$(get_setting "screen_sizing" "${PLATFORM}" "${ROM}")" != "1" ]
+}
+
 if [ "${IS_VERTICAL}" = "true" ]; then
     if [ "${QUIRK_DEVICE}" = "AYN Thor" ]; then
         # Needs two separate swaymsg calls. Screen cannot move and have windows moved to it in the same line.
         swaymsg '[title="RetroArch.*"] output DSI-2 pos 0 0, output DSI-1 power on pos 340 1080'
-        swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 1240 2160, move to output DSI-2, move absolute position 340 0'
+        RA_WIDTH="1240"
+        RA_X="340"
+        if melondsds_fit_to_main_screen; then
+            RA_WIDTH="1440"
+            RA_X="240"
+        fi
+        swaymsg "[title=\"RetroArch.*\"] floating enable, fullscreen disable, resize set ${RA_WIDTH} 2160, move to output DSI-2, move absolute position ${RA_X} 0"
         swaymsg 'input "0:0:bottom_touchscreen" events enabled'
     elif [ "${QUIRK_DEVICE}" = "AYN Thor Lite" ]; then
         # Same notes from above apply here.
         swaymsg '[title="RetroArch.*"] output DSI-1 pos 0 0, output DSI-2 power on pos 340 1080'
-        swaymsg '[title="RetroArch.*"] floating enable, fullscreen disable, resize set 1240 2160, move to output DSI-1, move absolute position 340 0'
+        RA_WIDTH="1240"
+        RA_X="340"
+        if melondsds_fit_to_main_screen; then
+            RA_WIDTH="1440"
+            RA_X="240"
+        fi
+        swaymsg "[title=\"RetroArch.*\"] floating enable, fullscreen disable, resize set ${RA_WIDTH} 2160, move to output DSI-1, move absolute position ${RA_X} 0"
         swaymsg 'input "0:0:bottom_touchscreen" events enabled'
     elif [ "${QUIRK_DEVICE}" = "Anbernic RG DS" ]; then
         # Same notes from above apply here.
@@ -88,9 +106,19 @@ if [ "${IS_VERTICAL}" = "true" ]; then
                 ;;
         esac
 
+        RA_X="${DSI_X}"
+        case "${QUIRK_DEVICE}" in
+            "Retroid Pocket Mini" | "Retroid Pocket Mini V2")
+                if melondsds_fit_to_main_screen; then
+                    RA_WIDTH="1440"
+                    RA_X="240"
+                fi
+                ;;
+        esac
+
         # Setup vertical stack using external DP-1 as the top screen.
         swaymsg "[title=\"RetroArch.*\"] output DP-1 pos 0 0, output DSI-1 pos ${DSI_X} 1080"
-        swaymsg "[title=\"RetroArch.*\"] floating enable, fullscreen disable, resize set ${RA_WIDTH} ${RA_HEIGHT}, move to output DP-1, move absolute position ${DSI_X} 0"
+        swaymsg "[title=\"RetroArch.*\"] floating enable, fullscreen disable, resize set ${RA_WIDTH} ${RA_HEIGHT}, move to output DP-1, move absolute position ${RA_X} 0"
 
         swaymsg input "0:0:generic_ft5x06_(a0)" map_to_output DSI-1
         swaymsg input "0:0:generic_ft5x06_(a0)" events enabled

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -1639,7 +1639,18 @@
       <core name="mame2010" features="netplay, rewind, autosave" />
       <core name="mame2016" features="netplay, rewind, autosave" />
       <core name="melonds" features="netplay, rewind, autosave, cheevos" />
-      <core name="melondsds" features="netplay, rewind, autosave, cheevos" />
+      <core name="melondsds" features="netplay, rewind, autosave, cheevos">
+        <features>
+          <feature name="netplay" />
+          <feature name="rewind" />
+          <feature name="autosave" />
+          <feature name="cheevos" />
+          <feature name="screen sizing">
+             <choice name="original ratio" value="1"/>
+             <choice name="fit to main screen" value="0"/>
+          </feature>
+        </features>
+      </core>
       <core name="play" features="netplay, rewind, autosave" />
       <core name="beetle_gba" features="decoration, netplay, rewind, autosave, cheevos" />
       <core name="beetle_lynx" features="netplay, rewind, autosave, cheevos" />


### PR DESCRIPTION
## Summary

<img width="1226" height="692" alt="image" src="https://github.com/user-attachments/assets/68f5df3b-8cd0-4564-adc3-ff2dabf617b8" />

* Adds a screen sizing option for melonds-ds-lr. The top display was left with empty space around the main screen. This option uses the newly added secondary screen scale option in melonds-ds-lr so that space can be filled.
* melonds-ds-lr has been bumped to pick up that option.

## Testing

* Tested on Thor(SM8550).

## Additional Context

* As I only have a Thor, changes were limited to that device.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** NO
