### PR TITLE
fonts: add Simplified Chinese font support

### DIFF
--- a/projects/ROCKNIX/packages/fonts/noto-sans-cjk/package.mk
+++ b/projects/ROCKNIX/packages/fonts/noto-sans-cjk/package.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="noto-sans-cjk"
+PKG_VERSION="2.004"
+PKG_LICENSE="OFL-1.1"
+PKG_SITE="https://github.com/notofonts/noto-cjk"
+PKG_URL="https://raw.githubusercontent.com/notofonts/noto-cjk/Sans${PKG_VERSION}/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"
+PKG_SOURCE_NAME="NotoSansCJKsc-Regular-${PKG_VERSION}.otf"
+PKG_SHA256="2c76254f6fc379fddfce0a7e84fb5385bb135d3e399294f6eeb6680d0365b74b"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Noto Sans CJK Simplified Chinese font"
+PKG_TOOLCHAIN="manual"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  cp -f ${SOURCES}/${PKG_NAME}/${PKG_SOURCE_NAME} ${PKG_BUILD}/NotoSansCJKsc-Regular.otf
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/share/fonts/truetype/noto-cjk
+  cp -f ${PKG_BUILD}/NotoSansCJKsc-Regular.otf \
+    ${INSTALL}/usr/share/fonts/truetype/noto-cjk/
+}

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION="9d664e2ffa75d0fcfd129c6598318c61b57ff8f7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="boost toolchain SDL2 freetype curl freeimage bash rapidjson SDL2_mixer fping p7zip alsa vlc drm_tool pugixml ${OPENGLES}"
+PKG_DEPENDS_TARGET="boost toolchain SDL2 freetype curl freeimage bash rapidjson SDL2_mixer fping p7zip alsa vlc drm_tool pugixml noto-sans-cjk ${OPENGLES}"
 PKG_NEED_UNPACK="busybox"
 PKG_LONGDESC="Emulationstation emulator frontend"
 PKG_BUILD_FLAGS="-gold"
@@ -52,6 +52,9 @@ makeinstall_target() {
 
   mkdir -p ${INSTALL}/usr/config/emulationstation/resources
     cp -a ${PKG_BUILD}/resources/* ${INSTALL}/usr/config/emulationstation/resources
+    rm -f ${INSTALL}/usr/config/emulationstation/resources/DroidSansFallbackFull.ttf
+    ln -sf /usr/share/fonts/truetype/noto-cjk/NotoSansCJKsc-Regular.otf \
+      ${INSTALL}/usr/config/emulationstation/resources/DroidSansFallbackFull.ttf
 
   mkdir -p ${INSTALL}/usr/bin
     cp -a ${PKG_BUILD}/es_settings ${INSTALL}/usr/bin

--- a/projects/ROCKNIX/packages/ui/themes/es-theme-art-book-next/package.mk
+++ b/projects/ROCKNIX/packages/ui/themes/es-theme-art-book-next/package.mk
@@ -6,6 +6,7 @@ PKG_VERSION="9a50ef366e750aabfab29e6915a2867607212971"
 PKG_LICENSE="CUSTOM"
 PKG_SITE="https://github.com/anthonycaccese/art-book-next-es"
 PKG_URL="https://github.com/anthonycaccese/art-book-next-es/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain noto-sans-cjk"
 PKG_LONGDESC="Art Book Next"
 PKG_TOOLCHAIN="manual"
 
@@ -14,4 +15,11 @@ makeinstall_target() {
     cp -rf * ${INSTALL}/usr/share/themes/${PKG_NAME}
     rm -rf ${INSTALL}/usr/share/themes/${PKG_NAME}/_inc/systems/{artwork-circuit,artwork-classic,artwork-nintendont,artwork-noir,artwork-outline}
     sed -i '/<include name="\(noir\|nintendont\|circuit\|outline\)"/d' ${INSTALL}/usr/share/themes/${PKG_NAME}/theme.xml
+    sed -i '/<\/theme>/i\
+   <variables lang="zh" ifSubset="fonts:default|custom">\
+      <fontBold>/usr/share/fonts/truetype/noto-cjk/NotoSansCJKsc-Regular.otf</fontBold>\
+      <fontRegular>/usr/share/fonts/truetype/noto-cjk/NotoSansCJKsc-Regular.otf</fontRegular>\
+      <fontLight>/usr/share/fonts/truetype/noto-cjk/NotoSansCJKsc-Regular.otf</fontLight>\
+      <fontLogo>/usr/share/fonts/truetype/noto-cjk/NotoSansCJKsc-Regular.otf</fontLogo>\
+   </variables>' ${INSTALL}/usr/share/themes/${PKG_NAME}/fonts.xml
 }

--- a/projects/ROCKNIX/packages/virtual/image/package.mk
+++ b/projects/ROCKNIX/packages/virtual/image/package.mk
@@ -21,7 +21,7 @@ PKG_UI_TOOLS="fbgrab grim"
 
 PKG_GRAPHICS="imagemagick"
 
-PKG_FONTS="corefonts"
+PKG_FONTS="corefonts noto-sans-cjk"
 
 PKG_MULTIMEDIA="ffmpeg vlc mpv gmu m8c"
 


### PR DESCRIPTION
## Summary

Add Noto Sans CJK SC to the ROCKNIX image so Simplified Chinese text is available to fontconfig applications such as Steam and to EmulationStation.

- package the upstream Noto Sans CJK SC 2.004 regular font
- install it in `/usr/share/fonts` for system-wide fontconfig discovery
- use it as EmulationStation's CJK fallback without storing a second copy
- select it for the default theme when the language is Chinese

## Testing

- all changed package scripts pass `bash -n`
- the upstream font matches the configured SHA256
- `fc-query` identifies the font as Noto Sans CJK SC with `zh-cn` support and CJK Unified Ideographs coverage
- the generated Chinese theme override parses as valid XML
- `git diff --check` passes
- a full image build and on-device test have not been run yet

## Additional Context

The source OTF is 16,437,364 bytes; compressed image impact has not been measured. The EmulationStation fallback is a symlink to avoid embedding the font twice.

This follows up ROCKNIX/distribution#3177 and ROCKNIX/emulationstation-next#28. Related earlier font proposals: #2875 and #2880.

@loki666 @spycat88

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY