### PR TITLE
S922X: audio fixes

### DIFF
--- a/projects/ROCKNIX/packages/audio/wireplumber/config/S922X/051-internal-audio.conf
+++ b/projects/ROCKNIX/packages/audio/wireplumber/config/S922X/051-internal-audio.conf
@@ -1,0 +1,27 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        device.name = "~alsa_card._sys_devices_platform_sound_sound_card0*"
+      }
+    ]
+    actions = {
+      update-props = {
+        device.profile = "pro-audio"
+      }
+    }
+  },
+  {   
+    matches = [
+      {
+        node.name = "~alsa_output._sys_devices_platform_sound_sound_card0*"
+       }
+    ]
+    actions = {
+      update-props = {
+        priority.driver  = 1100
+        priority.session = 1100
+      }
+    }
+  }
+]

--- a/projects/ROCKNIX/packages/audio/wireplumber/package.mk
+++ b/projects/ROCKNIX/packages/audio/wireplumber/package.mk
@@ -93,6 +93,9 @@ monitor.bluez.rules = [
   }
 ]
 EOF
+
+# Platform-specific config files
+cp -f ${PKG_DIR}/config/${DEVICE}/*.conf ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/
 }
 
 post_install() {

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/050-audio_path
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Hardkernel ODROID-GO-Ultra/050-audio_path
@@ -6,7 +6,6 @@ cat <<EOF >/storage/.config/profile.d/002-audio_path
 DEVICE_PLAYBACK_PATH_SPK="SPK"
 DEVICE_PLAYBACK_PATH_HP="HP"
 DEVICE_PLAYBACK_PATH="Playback Mux"
-DEVICE_PIPEWIRE_PROFILE="pro-audio"
 EOF
 
 ### Set sound properties

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3 Pro/050-audio_path
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Powkiddy RGB10 MAX 3 Pro/050-audio_path
@@ -6,7 +6,6 @@ cat <<EOF >/storage/.config/profile.d/002-audio_path
 DEVICE_PLAYBACK_PATH_SPK="HP"
 DEVICE_PLAYBACK_PATH_HP="SPK"
 DEVICE_PLAYBACK_PATH="Playback Path"
-DEVICE_PIPEWIRE_PROFILE="pro-audio"
 EOF
 
 ### Set sound properties

--- a/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/hdmi_sense
+++ b/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/hdmi_sense
@@ -8,6 +8,9 @@
 TMP_STATUS="/run/hdmi-status.last"
 CURRENT_STATE=""
 
+# No action on S922X
+[ "${HW_DEVICE}" = "S922X" ] && exit 0
+
 for HDMI in /sys/class/drm/card*/card*-HDMI-A-[0-9]/status
 do
   HDMI_STATE=$(<${HDMI})


### PR DESCRIPTION
## Summary

Play nice with USB audio devices by not forcing `pro-audio` card profile across the board at boot

## Testing

Tested on my OGU with internal audio (headphones), USB bluetooth adapter and USB headphones

## Additional Context

Forcing `pro-audio` profile on all audio devices present at boot was breaking things. It is appropriate for the internal sound card, so move it to a card-specific wireplumber config.

---

### AI Usage

**Did you use AI tools to help write this code?** NO
