### PR TITLE
wireplumber: check existence before copying device-specific config

### DIFF
--- a/projects/ROCKNIX/packages/audio/wireplumber/package.mk
+++ b/projects/ROCKNIX/packages/audio/wireplumber/package.mk
@@ -95,7 +95,9 @@ monitor.bluez.rules = [
 EOF
 
 # Platform-specific config files
-cp -f ${PKG_DIR}/config/${DEVICE}/*.conf ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/
+if [ -d "${PKG_DIR}/config/${DEVICE}" ]; then 
+  cp -f ${PKG_DIR}/config/${DEVICE}/*.conf ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/
+fi
 }
 
 post_install() {


### PR DESCRIPTION
## Summary

wireplumber: check existence before copying device-specific config

## Testing

Build tested SM8550 and S922X

---

### AI Usage

**Did you use AI tools to help write this code?** NO
