### PR TITLE
SM8550: fix Pocket S Mini panel for Linux 7.2

### DIFF
--- a/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayaneo-pocketsmini.dts
+++ b/projects/ROCKNIX/devices/SM8550/linux/dts/qcom/qcs8550-ayaneo-pocketsmini.dts
@@ -99,17 +99,33 @@
 	clock-frequency = <400000>;
 	status = "okay";
 
-	sgm3804: regulator@3e {
+	/* Screen power */
+	regulator@3e {
 		compatible = "sgmicro,sgm3804";
 		reg = <0x3e>;
 		pinctrl-0 = <&panel_pwr_active>;
 		pinctrl-1 = <&panel_pwr_sleep>;
 		pinctrl-names = "default", "sleep";
-		regulator-name = "panel-avdd";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		reset-gpios = <&tlmm 152 GPIO_ACTIVE_HIGH>,
-			      <&tlmm 153 GPIO_ACTIVE_HIGH>;
+
+		vin-supply = <&vph_pwr>;
+
+		sgm3804_pos: pos {
+			regulator-name = "panel-avdd";
+			regulator-min-microvolt = <5200000>;
+			regulator-max-microvolt = <5200000>;
+			regulator-active-discharge = <1>;
+			regulator-boot-on;
+			enable-gpios = <&tlmm 152 GPIO_ACTIVE_HIGH>;
+		};
+
+		sgm3804_neg: neg {
+			regulator-name = "panel-avee";
+			regulator-min-microvolt = <5200000>;
+			regulator-max-microvolt = <5200000>;
+			regulator-active-discharge = <1>;
+			regulator-boot-on;
+			enable-gpios = <&tlmm 153 GPIO_ACTIVE_HIGH>;
+		};
 	};
 
 	backlight: sy7758@2e {
@@ -157,7 +173,8 @@
 &display_panel {
 	compatible = "ayaneo,ar16-4inch-panel";
 
-	avdd-supply = <&sgm3804>;
+	avdd-supply = <&sgm3804_pos>;
+	avee-supply = <&sgm3804_neg>;
 	vci-supply = <&vreg_l13b_3p0>;
 	vddio-supply = <&vreg_l12b_1p8>;
 

--- a/projects/ROCKNIX/devices/SM8550/patches/linux/0064-gpu-drm-panel-add-ar16-4inch-panel.patch
+++ b/projects/ROCKNIX/devices/SM8550/patches/linux/0064-gpu-drm-panel-add-ar16-4inch-panel.patch
@@ -14,8 +14,8 @@ Signed-off-by: danyi <mydanyi@users.noreply.github.com>
 ---
  drivers/gpu/drm/panel/Kconfig            |  14 +
  drivers/gpu/drm/panel/Makefile           |   1 +
- drivers/gpu/drm/panel/panel-ar16-4inch.c | 400 +++++++++++++++++++++++
- 3 files changed, 415 insertions(+)
+ drivers/gpu/drm/panel/panel-ar16-4inch.c | 401 +++++++++++++++++++++++
+ 3 files changed, 416 insertions(+)
  create mode 100644 drivers/gpu/drm/panel/panel-ar16-4inch.c
 
 diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
@@ -58,7 +58,7 @@ new file mode 100644
 index 0000000..141da42
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-ar16-4inch.c
-@@ -0,0 +1,400 @@
+@@ -0,0 +1,401 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * DRM driver for the AYANEO Pocket S Mini AR16 panel.
@@ -92,6 +92,7 @@ index 0000000..141da42
 +	{ .supply = "avdd" },
 +	{ .supply = "vci" },
 +	{ .supply = "vddio" },
++	{ .supply = "avee" },
 +};
 +
 +static inline struct ar16_4inch *to_ar16_4inch(struct drm_panel *panel)
@@ -385,9 +386,11 @@ index 0000000..141da42
 +	struct ar16_4inch *ctx;
 +	int ret;
 +
-+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
-+	if (!ctx)
-+		return -ENOMEM;
++	ctx = devm_drm_panel_alloc(dev, struct ar16_4inch, panel,
++				   &ar16_4inch_panel_funcs,
++				   DRM_MODE_CONNECTOR_DSI);
++	if (IS_ERR(ctx))
++		return PTR_ERR(ctx);
 +
 +	ret = devm_regulator_bulk_get_const(dev,
 +					    ARRAY_SIZE(ar16_4inch_supplies),
@@ -413,8 +416,6 @@ index 0000000..141da42
 +			  MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
 +			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
 +
-+	drm_panel_init(&ctx->panel, dev, &ar16_4inch_panel_funcs,
-+		       DRM_MODE_CONNECTOR_DSI);
 +	ctx->panel.prepare_prev_first = true;
 +
 +	ret = drm_panel_of_backlight(&ctx->panel);


### PR DESCRIPTION
The AYANEO Pocket S Mini landed on next while the 7.2 bump was still on its own branch, so it was never converted to the two APIs 7.2 changed. Both sides were green on their own; only the merge is broken.

Build fix: drm_panel_init() is no longer exported in 7.2, so 0064 uses devm_drm_panel_alloc() like the other 13 panel drivers.

Runtime fix: the sgm3804 node still used the pre-7.2 binding - one regulator with both GPIOs in reset-gpios. Upstream's driver registers two rails from pos/neg child nodes, each with its own enable-gpios, so the node is migrated the way the other six boards were and the panel gains the avee supply it was silently missing. Voltages are 5200000, matching the selector the old driver actually programmed.

Verified: all 10 SM8550 panel patches apply with zero rejects on 7.2 and the Pocket S Mini dtb compiles with avdd/avee resolving to tlmm 152/153. NOT hardware validated - a wrong migration shows as a lit backlight over a black panel.

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES
