### PR TITLE
gcc-linaro-aarch64-elf: add PKG_SHA256

### DIFF
--- a/projects/ROCKNIX/packages/lang/gcc-linaro-aarch64-elf/package.mk
+++ b/projects/ROCKNIX/packages/lang/gcc-linaro-aarch64-elf/package.mk
@@ -1,5 +1,6 @@
 PKG_NAME="gcc-linaro-aarch64-elf"
 PKG_VERSION="4.9.4-2017.01"
+PKG_SHA256="00c79aaf7ff9b1c22f7b0443a730056b3936561a4206af187ef61a4e3cab1716"
 PKG_LICENSE="GPL"
 PKG_SITE=""
 PKG_URL="https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/aarch64-elf/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-elf.tar.xz"


### PR DESCRIPTION
## Summary

gcc-linaro-aarch64-elf: add PKG_SHA256

## Testing

Tested ok in a local S922X  build

## Additional Context

Trying to fix CI error here: https://github.com/ROCKNIX/distribution/actions/runs/32795803547/job/97744365855#step:8:503

---

### AI Usage

**Did you use AI tools to help write this code?** NO
