### PR TITLE
libmali: pin the sha256 of the 32-bit build's own source archive

### DIFF
--- a/projects/ROCKNIX/packages/graphics/libmali/package.mk
+++ b/projects/ROCKNIX/packages/graphics/libmali/package.mk
@@ -46,6 +46,7 @@ case "${DEVICE}" in
   RK3326|RK3566|RK3576)
     PKG_SITE="https://github.com/JeffyCN/mirrors"
     PKG_VERSION="4233031d818e97a19e8a9cdbbd5c15795ededd93"
+    PKG_SHA256="54b8af924f582f7da7e120fbad4812a502cc7cc67f6d6ab061377cb403f3eb2d"
     # zip format makes extract very fast (<1s). tgz takes 20 seconds to scan the whole file
     PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.zip"
     PKG_DEPENDS_TARGET+=" mesa vulkan-tools vulkan-headers vulkan-wsi-layer"


### PR DESCRIPTION
The RK3326/RK3566/RK3576 case overrides PKG_VERSION to the JeffyCN
mirrors archive but inherits the top-level PKG_SHA256 added for the
default archive, so the downloaded file never matches, the fallback
mirror returns 404 (sources-v2 does not carry this file), and every
build of those devices fails in scripts/get. Pin the archive's own
checksum, verified identical across three independent downloads.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Introduced by e0a68c95bd ("packages: add sha256"): the arch case for RK3326/RK3566/RK3576 overrides `PKG_VERSION` but not `PKG_SHA256`, so those builds download the JeffyCN archive, fail verification against the default archive's hash, fall back to the sources-v2 mirror (404 for this file), and abort. Hash verified identical across three independent downloads today.

This is a build-breakage bugfix (freeze-period exempt candidate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)