### PR TITLE
rocknix-bluetooth-agent: pass an explicit event loop to bumped dbussy bd4a5c3

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-bluetooth-agent
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/rocknix-bluetooth-agent
@@ -508,7 +508,8 @@ async def main():
     parser = OptionParser(option_list=option_list)
     options, args = parser.parse_args()
 
-    gbus = await ravel.system_bus_async()
+    # dbussy bd4a5c3 dropped its get_running_loop fallback, so pass the loop in.
+    gbus = await ravel.system_bus_async(loop=asyncio.get_running_loop())
 
     gbus.listen_objects_added(interfaces_added_wrapper)
     gbus.listen_objects_removed(interfaces_removed_wrapper)


### PR DESCRIPTION
Bluetooth pairing from EmulationStation stopped working after the dbussy bump to bd4a5c3. The agent now dies on startup, before it registers:

  NameError: name 'get_running_loop' is not defined
    File "/usr/lib/python3.14/site-packages/dbussy.py", line 2982, in bus_get_async

That dbussy commit got rid of the now deprecated asyncio.get_event_loop() call removed the module-level get_running_loop binding, but only converted one of the four call sites to asyncio.get_running_loop(). bus_get_async() is one of the three still using the bare name, and it is where ravel.system_bus_async() ends up when no loop is given.

Its commit message calls the change out as backward incompatible and says callers should specify a loop.
 The other two stragglers are not reachable from here: call_async() has no callers, and open_async() is only entered from bus_get_async() once the loop has been resolved.

The failure is silent from the UI side. Without the agent nothing writes /run/bt_listing, so rocknix-bluetooth live_devices returns early and the scan in ES just spins with an empty list.

Tested on a Miyoo Flip (unsupported) against a stock dbussy: the agent registers, the scan lists devices, and a headset pairs, trusts and connects from the menu.

## Summary

* **What is the goal of this PR?** (Proposed fix for bluetooth UI)
---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** DOCUMENTATION ONLY
