### PR TITLE
alsa-ucm-conf: fix the rk817 playback mixer element

### DIFF
--- a/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/RK3326/0002_rk817_fix_playback_mixer_elem.patch
+++ b/projects/ROCKNIX/packages/audio/alsa-ucm-conf/patches/RK3326/0002_rk817_fix_playback_mixer_elem.patch
@@ -1,0 +1,20 @@
+--- a/ucm2/Rockchip/rk817-sound/HiFi.conf
++++ b/ucm2/Rockchip/rk817-sound/HiFi.conf
+@@ -30,7 +30,7 @@
+ 	]
+ 
+ 	Value {
+-		PlaybackMixerElem "Master Playback Volume"
++		PlaybackMixerElem "Master"
+ 		PlaybackPriority 100
+ 		PlaybackPCM "hw:${CardId}"
+ 	}
+@@ -59,7 +59,7 @@
+ 	]
+ 
+ 	Value {
+-		PlaybackMixerElem "Master Playback Volume"
++		PlaybackMixerElem "Master"
+ 		PlaybackPriority 200
+ 		PlaybackPCM "hw:${CardId}"
+ 		JackControl "Headphones Jack"


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the volume control actually work on RK3326 handhelds using the rk817 codec.

The `rk817-sound` UCM profile sets:

```
PlaybackMixerElem "Master Playback Volume"
```

`PlaybackMixerElem` takes the simple mixer **element** name — `Master` — not the raw kcontrol name. Everywhere else in `alsa-ucm-conf` it is spelled that way (`Headphone`, `Speaker`, `HP`); `rk817-sound` is the only file using the long form.

So the element is never found, pipewire gets no hardware volume control, and its sink volume controls nothing audible — while `common/050-audio` deliberately pins ALSA `Master` to 100%. The symptom is a device that comes up at full volume after a cold boot while the stored setting reads whatever the user had chosen, and where changing the volume moves the number without moving the sound.

## Testing

* **How was this tested?** Built and run on a Gusgu H7 (RK3326, rk817 codec).
* **Test results:** With the fix the pipewire sink drives the hardware on the dB curve — sink `0.30` → `Master` 67%, `0.20` → 56%. Before the fix `Master` never moved from 100% regardless of the sink value. Confirmed audible.

## Additional Context

* This is a two-line change to an existing patch directory (`patches/RK3326/`), so it only affects RK3326.
* I deliberately left `CaptureMasterElem "Master Capture Volume"` alone. It looks like exactly the same error, but I have no way to test capture on this device and did not want to change what I could not verify — worth a look from someone who can.
* I only have one rk817 device. If the volume behaviour above is familiar on other RK3326 handhelds, this is likely the cause there too; a second data point would be welcome.

---

### AI Usage

**Did you use AI tools to help write this code?** YES — Claude Code was used for the investigation and to draft the patch and this description. The root cause was confirmed by reading the alsa-ucm-conf tree for how `PlaybackMixerElem` is spelled elsewhere, and the fix was verified against `amixer` readings on hardware.