### PR TITLE
rocknix-joypad: ratelimit the saradc read-failure message

### DIFF
--- a/projects/ROCKNIX/packages/linux-drivers/rocknix-joypad/patches/002-ratelimit-saradc-read-failures.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/rocknix-joypad/patches/002-ratelimit-saradc-read-failures.patch
@@ -1,0 +1,44 @@
+rocknix-joypad: ratelimit the saradc read-failure message
+
+joypad_adc_check() runs from the input polling loop. When joypad_adc_read()
+fails it returns 0, and the driver logs at dev_err level with no ratelimiting -
+so a persistent ADC failure emits one line per poll, about 8 per second, for as
+long as the condition lasts.
+
+On a 1.5Mbaud serial console that is a permanent stream of identical lines. It
+drowns out whatever actually broke, and it adds console work to a machine that
+by that point is usually already in trouble. Observed on a Gusgu H7 whenever the
+SARADC stops answering: tens of thousands of identical messages, which actively
+hindered debugging an unrelated interrupt storm.
+
+Use dev_err_ratelimited() at all three call sites.
+
+--- a/rocknix-joypad.c	2026-08-27 19:05:34.283963099 -0400
++++ b/rocknix-joypad.c	2026-08-27 19:05:34.284933731 -0400
+@@ -143,7 +143,7 @@
+ 		/* Read first joystick axis */
+ 		adcx->value = joypad_adc_read(joypad, adcx);
+ 		if (!adcx->value) {
+-			dev_err(joypad->dev, "saradc channels[%d]!\n", nbtn);
++			dev_err_ratelimited(joypad->dev, "saradc channels[%d]!\n", nbtn);
+ 			continue;
+ 		}
+ 		adcx->value = adcx->value - adcx->cal;
+@@ -151,7 +151,7 @@
+ 		/* Read second joystick axis */
+ 		adcy->value = joypad_adc_read(joypad, adcy);
+ 		if (!adcy->value) {
+-			dev_err(joypad->dev, "saradc channels[%d]!\n", nbtn + 1);
++			dev_err_ratelimited(joypad->dev, "saradc channels[%d]!\n", nbtn + 1);
+ 			continue;
+ 		}
+ 		adcy->value = adcy->value - adcy->cal;
+@@ -229,7 +229,7 @@
+ 
+ 		adc->value = joypad_adc_read(joypad, adc);
+ 		if (!adc->value) {
+-			dev_err(joypad->dev, "saradc channels[%d]!\n", nbtn);
++			dev_err_ratelimited(joypad->dev, "saradc channels[%d]!\n", nbtn);
+ 			continue;
+ 		}
+ 		adc->cal = adc->value;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop a failing SARADC from flooding the console.

`joypad_adc_check()` runs from the input polling loop. When `joypad_adc_read()` fails it returns 0 and the driver logs at `dev_err` level with no ratelimiting, so a *persistent* ADC failure emits one line per poll — about 8 per second — for as long as the condition lasts.

On a 1.5Mbaud serial console that is a permanent stream of identical lines. It drowns out whatever actually broke, and it adds console work to a machine that by that point is usually already in trouble.

Switches the three call sites to `dev_err_ratelimited()`. A genuine ADC failure still gets reported; it just stops repeating thousands of times.

## Testing

* **How was this tested?** Built and run on a Gusgu H7 (RK3326).
* **Test results:** Before, whenever the SARADC stopped answering, the console filled with tens of thousands of identical `saradc channels[N]!` messages — this actively hindered debugging an unrelated interrupt storm, since the useful output scrolled away. After, the message appears at the ratelimited rate and the surrounding log stays readable.

## Additional Context

* Behaviour-only change to logging; no functional path is altered, and the `continue` on failure is untouched.
* `dev_err_ratelimited()` is the standard helper for exactly this case and is already used widely in the kernel's input drivers.
* This touches `rocknix-joypad`, which is shared across device families, so it is worth a glance from someone with other hardware — but the change is confined to three log statements.

---

### AI Usage

**Did you use AI tools to help write this code?** YES — Claude Code was used to trace the log flood back to the polling loop and to draft the patch and this description.