### PR TITLE
RK3326: add the RK915 SDIO WiFi driver

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/options
+++ b/projects/ROCKNIX/devices/RK3326/options
@@ -59,7 +59,7 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="mali-bifrost"
+    ADDITIONAL_DRIVERS="mali-bifrost rk915"
 
   # Additional Firmware to use ( )
   # Space separated list is supported,

--- a/projects/ROCKNIX/devices/RK3326/patches/linux/035-rk915-mmc-quirks.patch
+++ b/projects/ROCKNIX/devices/RK3326/patches/linux/035-rk915-mmc-quirks.patch
@@ -1,0 +1,112 @@
+Rockchip RK915 SDIO WiFi: MMC card quirks
+
+The RK915 is not a conforming SDIO card: its CISTPL_FUNCE is shorter than the
+spec minimum, it needs a continuous card clock, and it cannot accept CMD52 while
+the DAT lines are busy.
+
+Express all three through the standard MMC card-quirks framework, matched on the
+"rockchip,rk915" compatible of the SDIO card node - the same mechanism already
+used for ti,wl1251 and silabs,wf200 - rather than vendor hacks in the MMC core.
+Nothing changes for any other card.
+
+Taken from sunshineinabox's rk915 7.1 bring-up:
+https://github.com/stolen/rk915/pull/2 -> docs/mainline-linux-7.1-rk915-quirks.patch
+Verified to apply cleanly to pristine 7.1.2; quirk bits 21-23 are unused there.
+
+--- a/include/linux/mmc/card.h
++++ b/include/linux/mmc/card.h
+@@ -331,6 +331,9 @@
+ #define MMC_QUIRK_NO_UHS_DDR50_TUNING	(1<<18) /* Disable DDR50 tuning */
+ #define MMC_QUIRK_BROKEN_MDT    (1<<19) /* Wrong manufacturing year */
+ #define MMC_QUIRK_FIXED_SECURE_ERASE_TRIM_TIME	(1<<20) /* Secure erase/trim time is fixed regardless of size */
++#define MMC_QUIRK_BROKEN_SDIO_FUNCE	(1<<21)	/* Tolerate short CISTPL_FUNCE, use default enable timeout */
++#define MMC_QUIRK_SDIO_CONT_CLOCK	(1<<22)	/* SDIO card requires a continuous clock */
++#define MMC_QUIRK_SDIO_CMD52_WAIT_DATA	(1<<23)	/* Card can't accept CMD52 while DAT lines are busy */
+ 
+ 	bool			written_flag;	/* Indicates eMMC has been written since power on */
+ 	bool			reenable_cmdq;	/* Re-enable Command Queue */
+--- a/drivers/mmc/core/quirks.h
++++ b/drivers/mmc/core/quirks.h
+@@ -219,6 +219,11 @@
+ 			      MMC_QUIRK_LENIENT_FN0 |
+ 			      MMC_QUIRK_BLKSZ_FOR_BYTE_MODE),
+ 
++	SDIO_FIXUP_COMPATIBLE("rockchip,rk915", add_quirk,
++			      MMC_QUIRK_BROKEN_SDIO_FUNCE |
++			      MMC_QUIRK_SDIO_CONT_CLOCK |
++			      MMC_QUIRK_SDIO_CMD52_WAIT_DATA),
++
+ 	END_FIXUP
+ };
+ 
+--- a/drivers/mmc/core/sdio_cis.c
++++ b/drivers/mmc/core/sdio_cis.c
+@@ -191,14 +191,19 @@
+ 			mmc_hostname(card->host));
+ 		vsn = SDIO_SDIO_REV_1_00;
+ 	} else if (size < min_size) {
+-		return -EINVAL;
++		if (!(card->quirks & MMC_QUIRK_BROKEN_SDIO_FUNCE) || size < 14)
++			return -EINVAL;
++		pr_warn("%s: broken CISTPL_FUNCE, using SDIO 1.0 defaults\n",
++			mmc_hostname(card->host));
++		vsn = SDIO_SDIO_REV_1_00;
+ 	}
+ 
+ 	/* TPLFE_MAX_BLK_SIZE */
+ 	func->max_blksize = buf[12] | (buf[13] << 8);
+ 
+ 	/* TPLFE_ENABLE_TIMEOUT_VAL, present in ver 1.1 and above */
+-	if (vsn > SDIO_SDIO_REV_1_00)
++	if (vsn > SDIO_SDIO_REV_1_00 &&
++	    !(card->quirks & MMC_QUIRK_BROKEN_SDIO_FUNCE))
+ 		func->enable_timeout = (buf[28] | (buf[29] << 8)) * 10;
+ 	else
+ 		func->enable_timeout = jiffies_to_msecs(HZ);
+--- a/drivers/mmc/host/dw_mmc.c
++++ b/drivers/mmc/host/dw_mmc.c
+@@ -253,6 +253,11 @@
+ 	     ((cmd->arg >> 9) & 0x1FFFF) == SDIO_CCCR_ABORT))
+ 		cmdr |= SDMMC_CMD_STOP;
+ 	else if (cmd->opcode != MMC_SEND_STATUS && cmd->data)
++		cmdr |= SDMMC_CMD_PRV_DAT_WAIT;
++
++	/* Some cards can't accept CMD52 while the DAT lines are busy */
++	if (cmd->opcode == SD_IO_RW_DIRECT && !(cmdr & SDMMC_CMD_STOP) &&
++	    mmc->card && (mmc->card->quirks & MMC_QUIRK_SDIO_CMD52_WAIT_DATA))
+ 		cmdr |= SDMMC_CMD_PRV_DAT_WAIT;
+ 
+ 	if (cmd->opcode == SD_SWITCH_VOLTAGE) {
+@@ -1112,6 +1117,13 @@
+ 	}
+ }
+ 
++static bool dw_mci_card_needs_cont_clock(struct dw_mci *host)
++{
++	struct mmc_card *card = host->mmc->card;
++
++	return card && (card->quirks & MMC_QUIRK_SDIO_CONT_CLOCK);
++}
++
+ static void dw_mci_setup_bus(struct dw_mci *host, bool force_clkinit)
+ {
+ 	unsigned int clock = host->clock;
+@@ -1174,7 +1186,8 @@
+ 
+ 		/* enable clock; only low power if no SDIO */
+ 		clk_en_a = SDMMC_CLKEN_ENABLE;
+-		if (!test_bit(DW_MMC_CARD_NO_LOW_PWR, &host->flags))
++		if (!test_bit(DW_MMC_CARD_NO_LOW_PWR, &host->flags) &&
++		    !dw_mci_card_needs_cont_clock(host))
+ 			clk_en_a |= SDMMC_CLKEN_LOW_PWR;
+ 		mci_writel(host, CLKENA, clk_en_a);
+ 
+@@ -1529,6 +1542,8 @@
+ 		clk_en_a = clk_en_a_old & ~clken_low_pwr;
+ 	} else {
+ 		clear_bit(DW_MMC_CARD_NO_LOW_PWR, &host->flags);
++		if (dw_mci_card_needs_cont_clock(host))
++			return;
+ 		clk_en_a = clk_en_a_old | clken_low_pwr;
+ 	}
+ 

--- a/projects/ROCKNIX/packages/linux-drivers/rk915/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/rk915/package.mk
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+PKG_NAME="rk915"
+PKG_VERSION="86f0d0e07afe156651ce5eec3e315f66ef79a59f"
+PKG_SHA256="27ca0f8ce96e62a0b28d0404a0516a2d188df1d5a7a5a3f9c98ad4944e9581c8"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/sunshineinabox/rk915"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_LONGDESC="rk915: Rockchip RK915 SDIO WiFi driver, mainline port"
+
+# Pinned to the head of https://github.com/stolen/rk915/pull/2, which targets
+# Linux 7.1 and moves the kernel-side changes onto the standard MMC card-quirks
+# framework. The upstream main branch still targets 6.12.
+
+PKG_TOOLCHAIN="manual"
+PKG_IS_KERNEL_PKG="yes"
+
+# Needs 035-rk915-mmc-quirks.patch, which registers the card quirks this driver
+# relies on, keyed off compatible = "rockchip,rk915" in the DT.
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  kernel_make -C $(kernel_path) M=${PKG_BUILD} CONFIG_RK915=m
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+    cp *.ko ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+
+  # Loaded via request_firmware as "rockchip/rk915_fw.bin" and
+  # "rockchip/rk915_patch.bin" (inc/firmware.h). Byte-identical to the blobs in
+  # the vendor EmuELEC image, so this is the right firmware for the revision.
+  mkdir -p ${INSTALL}/$(get_kernel_overlay_dir)/lib/firmware/rockchip
+    cp -av firmware/rockchip/rk915_fw.bin firmware/rockchip/rk915_patch.bin \
+       ${INSTALL}/$(get_kernel_overlay_dir)/lib/firmware/rockchip
+  # The driver detects its own firmware faults and asks mac80211 to restart the
+  # hardware, but the firmware re-download that follows always fails, so
+  # mac80211 gives up and the link never comes back. Reloading the module does
+  # restore it, reliably. Ship a watchdog that watches for that signature and
+  # does exactly that; see the header of rk915-recover.sh.
+  mkdir -p ${INSTALL}/usr/lib/systemd/system
+    cp ${PKG_DIR}/system.d/rk915-recover.service ${INSTALL}/usr/lib/systemd/system
+  mkdir -p ${INSTALL}/usr/lib/rk915
+    cp ${PKG_DIR}/system.d/rk915-recover.sh ${INSTALL}/usr/lib/rk915
+    chmod +x ${INSTALL}/usr/lib/rk915/rk915-recover.sh
+}
+
+post_install() {
+  enable_service rk915-recover.service
+}

--- a/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0001-keep-lmac-awake.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0001-keep-lmac-awake.patch
@@ -1,0 +1,41 @@
+rk915: keep the LMAC awake
+
+The BSP driver declared lpw_no_sleep as a module parameter defaulting to 0
+(sleep permitted), and paired that with trigger_wakeup(),
+check_and_wakeup_rpu_nonblocking() and get_rpu_sleep_status() in hal.c, which
+woke the chip before touching it over SDIO.
+
+The mainline port dropped that entire wake path - hal.c went from 1971 to 883
+lines - but kept the firmware being told it may sleep, and also dropped the
+module_param so there is no way to change it. Once traffic goes idle for a
+moment the chip sleeps, and the next CMD52 pair in rk915_read_data_len() reads
+back 0xF0/0xF0. The driver reports
+
+    rk915: rk915_serias_read: length(61680) too long error.
+
+then tries firmware recovery, which fails because SDIO is already incoherent
+("30550/48056 bytes differ, first at 0x0"), and mac80211 tears the device down.
+That matches the upstream "chip disconnects soon after association" defect:
+association itself succeeds because it keeps the chip busy.
+
+Default to keeping the LMAC awake and restore the parameter so it can be
+switched back once a wake path exists. Costs idle power; buys a stable link.
+
+--- a/src/procfs.c	2026-08-26 21:59:06.219423215 -0400
++++ b/src/procfs.c	2026-08-26 21:59:06.234497545 -0400
+@@ -12,7 +12,14 @@
+ #include "hal_io.h"
+ #include "if_io.h"
+ 
+-unsigned int lpw_no_sleep;
++/*
++ * Must stay 1 while the driver has no wake path: letting the LMAC sleep
++ * leaves CMD52 reads returning 0xF0F0 once the link goes idle.
++ */
++unsigned int lpw_no_sleep = 1;
++module_param(lpw_no_sleep, uint, 0444);
++MODULE_PARM_DESC(lpw_no_sleep,
++		 "keep the LMAC permanently awake (default 1; 0 needs a wake path)");
+ 
+ unsigned int default_phy_threshold = DAPT_DEFAULT_PHY_THRESH;
+ 

--- a/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0002-atomic-fw-error-claim.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0002-atomic-fw-error-claim.patch
@@ -1,0 +1,48 @@
+rk915: claim firmware error recovery atomically
+
+rk915_signal_io_error() guards recovery with a plain test-then-set:
+
+    if (!hal->fw_error_processing) {
+            hal->fw_error_processing = 1;
+            schedule_work(&hal->fw_err_work);
+    }
+
+The rx and tx threads both signal io errors, and both get through the test
+before either performs the set. Observed on a Gusgu H7 under inbound TCP load:
+
+    [2250.486151] rk915: -------- fw error recovery (0) start --------
+    [2250.486275] rk915: fw error (0): requesting mac80211 restart
+    [2250.486292] ieee80211 phy3: Hardware restart was requested
+    [2250.486314] rk915: -------- fw error recovery (0) start --------
+    [2250.486421] rk915: fw error (0): requesting mac80211 restart
+
+two recoveries 163us apart, so ieee80211_restart_hw() is called a second time
+while the first restart is still in flight.
+
+Claim the recovery with cmpxchg() so exactly one runs. Verified on hardware:
+the same reproducer now logs a single recovery and a single restart request.
+
+Note this does not by itself make recovery succeed - the firmware re-download
+that follows still fails - but it removes the duplicate restart from the picture.
+
+--- a/src/umac_if.c	2026-08-27 11:14:36.689792575 -0400
++++ b/src/umac_if.c	2026-08-27 11:14:36.690819895 -0400
+@@ -464,10 +464,16 @@
+ 		return;
+ 	hal->fw_error = 1;
+ 	rk915_wake_waiters(hal);
+-	if (!hal->fw_error_processing) {
++	/*
++	 * The rx and tx threads both signal io errors, and a plain
++	 * test-then-set lets both through: two recoveries start within
++	 * microseconds of each other and ieee80211_restart_hw() is called
++	 * twice, the second landing while the first restart is still in
++	 * flight. Claim the recovery atomically so exactly one runs.
++	 */
++	if (cmpxchg(&hal->fw_error_processing, 0, 1) == 0) {
+ 		__pm_stay_awake(hal->fw_err_ws);
+ 
+-		hal->fw_error_processing = 1;
+ 		hal->fw_error_counter++;
+ 		hal->fw_error_reason = reason;
+ 

--- a/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0003-clear-sdio-reset-latch-on-power-cycle.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0003-clear-sdio-reset-latch-on-power-cycle.patch
@@ -1,0 +1,67 @@
+rk915: clear the sdio_reset latch when the chip is power-cycled
+
+_sdio_reset() latches a file-static flag on the first io error:
+
+    static bool sdio_reset;
+    int _sdio_reset(struct host_io_info *host) { sdio_reset = true; return 0; }
+
+and every sdio accessor then short-circuits *returning success without doing any
+i/o*:
+
+    static int sdio_send_data(struct host_io_info *host, u32 addr, u8 *buf, u32 len)
+    {
+            if (sdio_reset == true)
+                    return 0;
+            return sdio_memcpy_toio(func, addr, buf, len);
+    }
+
+rk915_io_reset() calls it from six sites in hal_io.c, so any io error arms it.
+Nothing cleared it except sdio_probe(), i.e. a module (re)load.
+
+The consequence is that firmware error recovery could never work. Recovery
+power-cycles the chip and re-downloads the firmware, but every write is a silent
+no-op that reports success. Measured with per-block timing, a failing download
+wrote 4096 bytes in 2us - 2 GB/s, which the bus cannot do - against 269us for the
+same block on a working download. The readback is therefore all zeroes:
+
+    rk915: 30550/48056 bytes differ, first at 0x0 (wrote 0x81 read 0x00)
+    rk915: rk915_download: check downloaded fw failed
+    rk915: fw_bring_up: rk915_download_firmware failed
+    WARNING: net/mac80211/util.c:1956 at ieee80211_reconfig+0xb0c/0x12b4
+
+mac80211 then shuts every interface down and the link stays dead - which is
+exactly why reloading the module was the only thing that ever brought it back:
+sdio_probe() cleared the latch.
+
+By the time rk915_sdio_power_cycle() has reset the card, re-enabled the function
+and restored the block size, i/o is valid again, so drop the latch there.
+
+Verified on a Gusgu H7 with a reproducer that kills the link in ~10s under
+inbound TCP: 23 recoveries, 31 successful firmware downloads, zero download
+failures, and the link returns on its own with the same interface and lease.
+
+--- a/src/sdio.c	2026-08-27 13:24:01.819863640 -0400
++++ b/src/sdio.c	2026-08-27 13:24:01.820603502 -0400
+@@ -542,6 +542,22 @@
+ 		ret = sdio_enable_func(func);
+ 	if (!ret)
+ 		ret = sdio_set_block_size(func, 512);
++	if (!ret) {
++		/*
++		 * _sdio_reset() latches sdio_reset on the first io error, and
++		 * every accessor then returns 0 *without doing any i/o*. The
++		 * latch was only ever cleared by sdio_probe(), so after one
++		 * error the firmware download that error recovery depends on
++		 * writes into nothing while reporting success - 4KB "written"
++		 * in 2us - the readback is all zeroes, the chip never reaches
++		 * WAIT_PATCH, and mac80211 tears the device down. That is why
++		 * only a module reload ever brought the link back.
++		 *
++		 * The card has just been reset, re-enabled and had its block
++		 * size restored, so i/o is valid again: drop the latch.
++		 */
++		sdio_reset = false;
++	}
+ 	sdio_release_host(func);
+ 	if (ret)
+ 		rk915_err("%s: failed (%d)\n", __func__, ret);

--- a/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0004-reset-vif-accounting-on-hw-restart.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/rk915/patches/rk915-0004-reset-vif-accounting-on-hw-restart.patch
@@ -1,0 +1,43 @@
+rk915: reset the vif accounting when the hardware is restarted
+
+current_vif_count and active_vifs are incremented by add_interface(), decremented
+by remove_interface(), and otherwise only cleared by rpu_init() at module load.
+
+mac80211 re-adds every interface after a hardware restart but never calls
+remove_interface() for the ones that were up before it, so the count only ever
+climbs. Once firmware recovery started working, the second restart hit
+
+    rk915: add_interface: Exceeded Maximum supported VIF's cur:2 max: 2
+
+add_interface() returned -ENOTSUPP, mac80211 tore the interface down, and the
+link stayed dead despite the firmware having reloaded cleanly.
+
+start() is always called before interfaces are re-added, on first bring-up and
+after a restart alike, so clear the accounting there.
+
+--- a/src/umac_if.c	2026-08-27 13:24:01.825222478 -0400
++++ b/src/umac_if.c	2026-08-27 13:24:01.826363899 -0400
+@@ -607,6 +607,23 @@
+ 	INIT_DELAYED_WORK(&priv->roc_complete_work, rpu_roc_complete_work);
+ 
+ 	priv->state = STARTED;
++
++	/*
++	 * mac80211 re-adds every interface after a hardware restart, but it
++	 * never calls remove_interface() for the ones that were up before, and
++	 * the vif accounting is otherwise only cleared by rpu_init() at module
++	 * load. Without this the second restart trips
++	 *
++	 *   rk915: add_interface: Exceeded Maximum supported VIF's cur:2 max: 2
++	 *
++	 * add_interface() returns -ENOTSUPP, mac80211 tears the interface down
++	 * and the link never comes back even though the firmware reloaded
++	 * cleanly. start() is always called before interfaces are re-added, so
++	 * this is the right place to drop the stale accounting.
++	 */
++	priv->current_vif_count = 0;
++	priv->active_vifs = 0;
++
+ 	memset(priv->params->pdout_voltage, 0,
+ 		sizeof(char) * MAX_AUX_ADC_SAMPLES);
+ 

--- a/projects/ROCKNIX/packages/linux-drivers/rk915/system.d/rk915-recover.service
+++ b/projects/ROCKNIX/packages/linux-drivers/rk915/system.d/rk915-recover.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=rk915 WiFi watchdog (reload the driver when firmware recovery fails)
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=simple
+# on-failure, not always: the script exits 0 on a board that has no rk915, and
+# that decision should stick rather than respawn a poll loop every 10 seconds.
+Restart=on-failure
+RestartSec=10
+ExecStart=/usr/lib/rk915/rk915-recover.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/projects/ROCKNIX/packages/linux-drivers/rk915/system.d/rk915-recover.sh
+++ b/projects/ROCKNIX/packages/linux-drivers/rk915/system.d/rk915-recover.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# rk915 watchdog.
+#
+# The driver detects its own firmware faults and asks mac80211 to restart the
+# hardware, but the firmware re-download that follows always fails
+# ("N/48056 bytes differ, first at 0x0"), so mac80211 gives up and shuts the
+# interface down and the link never comes back. Reloading the module does
+# restore it, reliably. Watch for that signature and do exactly that.
+#
+# This is a mitigation, not a fix: the underlying fault is unresolved, and it
+# cannot help the variant where the tx thread spins in the SDIO busy-wait,
+# because modprobe -r hangs there.
+# The driver has more than one fatal face and they are not interchangeable:
+#
+#   fw_bring_up: rk915_download_firmware failed   the firmware re-download that
+#                                                 follows a runtime fw error
+#   rpu_core_init: wait_for_reset_complete failed the chip never comes out of
+#                  / RPUWIFI-80211IF: umac init failed   reset - this is the
+#                                                 boot race losing earlier, and
+#                                                 it never reaches a download,
+#                                                 so matching only the line
+#                                                 above misses it entirely and
+#                                                 the link stays down for good
+DEAD='fw_bring_up: rk915_download_firmware failed|rpu_core_init: wait_for_reset_complete failed|RPUWIFI-80211IF: umac init failed'
+COOLDOWN=60
+POLL=5
+
+reload_driver() {
+        logger -t rk915-recover "link is dead - reloading rk915"
+        modprobe -r rk915
+        sleep 3
+        modprobe cfg80211 2>/dev/null
+        modprobe mac80211 2>/dev/null
+        modprobe rk915
+        sleep 10
+        systemctl restart iwd
+        sleep 20
+        if ip route | grep -q '^default'; then
+                logger -t rk915-recover "recovered"
+        else
+                logger -t rk915-recover "still down after reload"
+        fi
+}
+
+# The driver ships for the whole RK3326 family but only a few boards carry the
+# chip. Give it a chance to probe, then stand down where it never appears: there
+# is nothing to watch, and the poll loop below would otherwise run a dmesg every
+# five seconds forever on every other handheld in the family.
+waited=0
+while [ ! -d /sys/module/rk915 ]; do
+        waited=$((waited + 1))
+        if [ "$waited" -ge 30 ]; then
+                logger -t rk915-recover "no rk915 module here - nothing to watch"
+                exit 0
+        fi
+        sleep 1
+done
+
+# Boot-time check: the driver can lose the same race while the system is busy
+# starting up.
+sleep 30
+seen=$(dmesg | grep -cE "$DEAD")
+if [ "$seen" -gt 0 ] && ! ip route | grep -q '^default'; then
+        # A fault was logged during boot AND the link is not working. The
+        # route check is only a second condition here, never the trigger on
+        # its own: with wifi unconfigured or out of range there is no route
+        # and no fault either, and reloading then would churn the driver and
+        # restart iwd underneath the user for nothing.
+        reload_driver
+        seen=$(dmesg | grep -cE "$DEAD")
+fi
+
+while true; do
+        sleep $POLL
+        now=$(dmesg | grep -cE "$DEAD")
+        if [ "$now" -gt "$seen" ]; then
+                reload_driver
+                seen=$(dmesg | grep -cE "$DEAD")
+                sleep $COOLDOWN
+        elif [ "$now" -lt "$seen" ]; then
+                seen=$now          # ring buffer wrapped
+        fi
+done


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Add wifi support for RK3326 handhelds carrying a Rockchip RK915.

The RK915 is the wifi part on several unbranded RK3326 handhelds (I found it on a Gusgu H7). It has no mainline driver. This packages the mainline port at [sunshineinabox/rk915](https://github.com/sunshineinabox/rk915), pinned to the head of [stolen/rk915#2](https://github.com/stolen/rk915/pull/2), which targets Linux 7.1 and moves the kernel-side changes onto the standard MMC card-quirks framework. That project's `main` branch still targets 6.12, hence the pin.

Two pieces:

**`035-rk915-mmc-quirks.patch`** registers the three quirks the card needs — short `CISTPL_FUNCE`, continuous card clock, and no CMD52 while the DAT lines are busy — through the standard MMC card-quirks framework, matched on the `rockchip,rk915` compatible of the SDIO card node. That is the same mechanism already used for `ti,wl1251` and `silabs,wf200`, rather than vendor hacks in the MMC core. It claims three unused quirk bits (21–23) and changes nothing for any other card.

**The `rk915` package** builds the module out of tree and installs the two firmware blobs it `request_firmware()`s. Four patches sit on top of the ported driver, each covering a fault reproduced on hardware:

| | |
|---|---|
| `0001` | Keep the LMAC awake. The BSP defaulted `lpw_no_sleep` to 0 and the chip disconnects shortly after association. |
| `0002` | Claim firmware error recovery atomically — the plain test-then-set lets two threads both enter recovery. |
| `0003` | Clear the `sdio_reset` latch when the chip is power-cycled, so recovery works more than once. |
| `0004` | Reset the vif accounting when mac80211 restarts the hardware. |

## Testing

* **How was this tested?** Built and run on a Gusgu H7 (RK3326), which carries the chip. Also built for the RK3326 family as a whole to confirm the driver's presence is inert on boards without it.
* **Test results:** Association and sustained traffic work; the device holds a link across reboots and survives the post-association disconnect that `0001` addresses. On boards with no RK915 the module never binds and the watchdog exits at startup (see below), so nothing runs.

## Additional Context

* **One known unresolved fault.** After a firmware error the driver asks mac80211 to restart the hardware, but the firmware re-download that follows always fails (`N/48056 bytes differ, first at 0x0`), so mac80211 gives up and the link never comes back. Reloading the module *does* restore it, reliably. The package therefore ships a small watchdog that watches for exactly that dmesg signature and reloads. **This is a mitigation, not a fix** — I have flagged it as such in the script header rather than dressing it up, and it cannot help the variant where the tx thread spins in the SDIO busy-wait, because `modprobe -r` hangs there. If shipping a workaround like this is not acceptable, I am happy to drop it and take the driver alone.
* **The watchdog stands down on boards without the chip.** `ADDITIONAL_DRIVERS` is family-wide, so the driver and its service reach every RK3326 image. The script waits up to 30s for `/sys/module/rk915` and then exits 0, and the unit is `Restart=on-failure` so that decision sticks. Without that it would run a `dmesg` every five seconds forever on every other handheld in the family.
* **`PKG_VERSION` points at an individual's fork.** Worth a maintainer opinion on whether this should be mirrored under the ROCKNIX org before it lands, as is done for other vendored sources.
* The SDIO bus fixes that make this chip's failure modes survivable are in #3251, which is independent of this PR — but on a device that actually has an RK915, the two are related in practice.

---

### AI Usage

**Did you use AI tools to help write this code?** YES — Claude Code was used for the driver investigation (identifying each of the four faults from hardware behaviour and kernel logs), for writing the four driver patches and the watchdog, and to draft this description. The mainline port itself and the MMC quirks patch are sunshineinabox's work, credited in the package and patch headers.