### PR TITLE
RK3326: add the Gusgu H7 subdevice

### DIFF
--- a/projects/ROCKNIX/bootloader/mkimage
+++ b/projects/ROCKNIX/bootloader/mkimage
@@ -30,7 +30,17 @@ mkimage_uboot() {
 }
 
 mkimage_extlinux() {
-  if [ -d "${RELEASE_DIR}/3rdparty/bootloader/extlinux" ]; then
+  # A subdevice whose stock bootloader cannot parse the shared conf can ship its
+  # own as extlinux/extlinux.conf.sub-<subdevice>. (Gusgu H7: its vendor U-Boot
+  # 2017.09 predates FDTOVERLAYS and never runs boot.scr, so it needs an explicit
+  # FDT and literal LABEL= values rather than ${partition_boot} placeholders.)
+  if [ -f "${RELEASE_DIR}/3rdparty/bootloader/extlinux/extlinux.conf.sub-${SUBDEVICE}" ]; then
+    echo "image: copying ${SUBDEVICE}-specific extlinux.conf..."
+    mkdir -p "${IMG_TMP}/extlinux"
+    cp "${RELEASE_DIR}/3rdparty/bootloader/extlinux/extlinux.conf.sub-${SUBDEVICE}" \
+       "${IMG_TMP}/extlinux/extlinux.conf"
+    mcopy -s -o "${IMG_TMP}/extlinux" ::
+  elif [ -d "${RELEASE_DIR}/3rdparty/bootloader/extlinux" ]; then
     echo "image: copying custom extlinux.conf..."
     mcopy -s -o "${RELEASE_DIR}/3rdparty/bootloader/extlinux" ::
   else

--- a/projects/ROCKNIX/config.xml
+++ b/projects/ROCKNIX/config.xml
@@ -64,6 +64,12 @@
       <file>rk3326-batlexp-g350</file>
       <file>rk3326s-gkd-pixel2</file>
     </b>
+    <!-- Gusgu H7: unbranded RK3326 clone, 1024x768 ST7703 DSI panel.
+         No ADC autodetect (see h7_boot.ini); DTB is pinned to the eeclone
+         base and the H7 panel comes from /overlays/mipi-panel.dtbo. -->
+    <h7 mkimage_options="dtb,bootscr,extlinux,uboot" fdt_type="fdtdir" fdt="/">
+      <file>rk3326-gusgu-h7</file>
+    </h7>
   </RK3326>
   <RK3399 mkimage_options="dtb,extlinux,uboot" fdt="device_trees/rk3399-anbernic-rg552.dtb" fdt_type="fdt" dtb_prefix="rockchip">
     <file>rk3399-anbernic-rg552</file>

--- a/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-gusgu-h7.dts
+++ b/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-gusgu-h7.dts
@@ -1,0 +1,601 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Gusgu H7 - unbranded Rockchip RK3326 handheld.
+ *
+ * Derived from the eeclone base, which is the only RK3326 tree here defining
+ * every node this device needs to override, and whose serial2 = &uart5 alias
+ * puts the H7's UART5 debug port on ttyS2 so the stock console= works.
+ *
+ * Everything below was taken from the device's own stock vendor DTB
+ * (rk3326-evb-lp3-v12-linux.dtb): the panel via generic-dsi's stock-DTB
+ * importer, the GPIO pin assignments verified against physical button presses.
+ */
+
+/dts-v1/;
+#include "rk3326-gameconsole-eeclone.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	model = "Gusgu H7";
+	compatible = "gusgu,h7", "rockchip,rk3326";
+
+	/* RK915 power-up sequence. gpio0 RK_PA2 is WIFI,poweren_gpio in the stock
+	 * device tree; the chip stays dark without it being driven. */
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_enable_h>;
+		post-power-on-delay-ms = <100>;
+		reset-gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
+	};
+
+	/* Real GPIO volume buttons. Kept off the joypad so the OS treats them as
+	 * system keys - and so the initramfs recovery check still finds
+	 * KEY_VOLUMEDOWN on a real button rather than a floating ADC line. */
+	volume-keys {
+		compatible = "gpio-keys";
+		autorepeat;
+
+		vol-up {
+			gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
+			label = "VOLUMEUP";
+			linux,code = <KEY_VOLUMEUP>;
+		};
+
+		vol-down {
+			gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;
+			label = "VOLUMEDOWN";
+			linux,code = <KEY_VOLUMEDOWN>;
+		};
+	};
+};
+
+/* 1024x768 Sitronix ST7703 (eeclone ships a 720x720 HX8394). */
+&internal_display {
+	panel_description =
+		"G size=153,85 delays=20,20,20,120,20 format=rgb888 lanes=4 flags=0xe03",
+
+		"M clock=62000 horizontal=1024,90,80,80 vertical=768,16,8,8 default=1",
+		"M clock=62050 horizontal=1024,90,115,80 vertical=768,16,157,8",
+		"M clock=62010 horizontal=1024,90,131,80 vertical=768,16,144,8",
+		"M clock=63620 horizontal=1024,90,123,80 vertical=768,16,174,8",
+		"M clock=62560 horizontal=1024,90,86,80 vertical=768,16,58,8",
+		"M clock=68280 horizontal=1024,90,114,80 vertical=768,16,82,8",
+		"M clock=63000 horizontal=1024,90,80,80 vertical=768,16,33,8",
+		"M clock=62160 horizontal=1024,90,101,80 vertical=768,16,8,8",
+		"M clock=75890 horizontal=1024,90,120,80 vertical=768,16,169,8",
+		"M clock=90540 horizontal=1024,90,120,80 vertical=768,16,121,8",
+		"M clock=91800 horizontal=1024,90,81,80 vertical=768,16,8,8",
+		"M clock=122400 horizontal=1024,90,81,80 vertical=768,16,8,8",
+
+		"I seq=ee01",
+		"I seq=ea07",
+		"I seq=eb12",
+		"I seq=0a5e",
+		"I seq=1314",
+		"I seq=1735",
+		"I seq=1d33",
+		"I seq=2101",
+		"I seq=2828",
+		"I seq=2918",
+		"I seq=2a63",
+		"I seq=2ff3",
+		"I seq=ee02",
+		"I seq=39a9",
+		"I seq=0000",
+		"I seq=010d",
+		"I seq=0212",
+		"I seq=0308",
+		"I seq=040e",
+		"I seq=0530",
+		"I seq=060b",
+		"I seq=070e",
+		"I seq=080f",
+		"I seq=090e",
+		"I seq=0a11",
+		"I seq=0b4e",
+		"I seq=0c14",
+		"I seq=0d1a",
+		"I seq=0e2f",
+		"I seq=0f36",
+		"I seq=103f",
+		"I seq=2000",
+		"I seq=210d",
+		"I seq=2212",
+		"I seq=2308",
+		"I seq=240e",
+		"I seq=2530",
+		"I seq=260b",
+		"I seq=270e",
+		"I seq=280f",
+		"I seq=290e",
+		"I seq=2a11",
+		"I seq=2b4e",
+		"I seq=2c14",
+		"I seq=2d1a",
+		"I seq=2e2f",
+		"I seq=2f36",
+		"I seq=303f",
+		"I seq=ee04",
+		"I seq=0005",
+		"I seq=0101",
+		"I seq=0280",
+		"I seq=0304",
+		"I seq=0400",
+		"I seq=0606",
+		"I seq=0705",
+		"I seq=081a",
+		"I seq=0920",
+		"I seq=0a0e",
+		"I seq=0b00",
+		"I seq=2040",
+		"I seq=2408",
+		"I seq=ee05",
+		"I seq=0001",
+		"I seq=0109",
+		"I seq=0205",
+		"I seq=0305",
+		"I seq=0705",
+		"I seq=080d",
+		"I seq=0900",
+		"I seq=0a12",
+		"I seq=0b14",
+		"I seq=0c66",
+		"I seq=1003",
+		"I seq=1107",
+		"I seq=1205",
+		"I seq=1305",
+		"I seq=1912",
+		"I seq=1af6",
+		"I seq=4055",
+		"I seq=4100",
+		"I seq=4303",
+		"I seq=4401",
+		"I seq=4581",
+		"I seq=4606",
+		"I seq=4700",
+		"I seq=ee06",
+		"I seq=0045",
+		"I seq=0201",
+		"I seq=0488",
+		"I seq=06cd",
+		"I seq=08ef",
+		"I seq=09cd",
+		"I seq=0aab",
+		"I seq=0b89",
+		"I seq=0c67",
+		"I seq=0d45",
+		"I seq=0e23",
+		"I seq=0f01",
+		"I seq=ee07",
+		"I seq=003c",
+		"I seq=013c",
+		"I seq=023c",
+		"I seq=033c",
+		"I seq=040d",
+		"I seq=053c",
+		"I seq=063c",
+		"I seq=073c",
+		"I seq=0808",
+		"I seq=0910",
+		"I seq=0a12",
+		"I seq=0b14",
+		"I seq=0c16",
+		"I seq=0d18",
+		"I seq=0e1a",
+		"I seq=0f1c",
+		"I seq=101e",
+		"I seq=1104",
+		"I seq=1200",
+		"I seq=133c",
+		"I seq=140c",
+		"I seq=153c",
+		"I seq=203c",
+		"I seq=213c",
+		"I seq=223c",
+		"I seq=233c",
+		"I seq=240d",
+		"I seq=253c",
+		"I seq=263c",
+		"I seq=273c",
+		"I seq=2808",
+		"I seq=2911",
+		"I seq=2a13",
+		"I seq=2b15",
+		"I seq=2c17",
+		"I seq=2d19",
+		"I seq=2e1b",
+		"I seq=2f1d",
+		"I seq=301f",
+		"I seq=3105",
+		"I seq=3201",
+		"I seq=333c",
+		"I seq=340c",
+		"I seq=353c",
+		"I seq=ee08",
+		"I seq=1000",
+		"I seq=12dc",
+		"I seq=131c",
+		"I seq=1723",
+		"I seq=1820",
+		"I seq=2080",
+		"I seq=ee0f",
+		"I seq=0001",
+		"I seq=0100",
+		"I seq=ee00",
+		"I seq=ea00",
+		"I seq=eb00",
+		"I seq=3600",
+		"I seq=11 wait=200",
+		"I seq=29 wait=20";
+};
+
+/* eeclone samples SARADC ch2 for volume; on the H7 that line is the right
+ * stick X axis. A centred stick reads as KEY_VOLUMEDOWN held, which sends
+ * ROCKNIX init into USB-MSC recovery on every boot. */
+&adc_keys {
+	status = "disabled";
+};
+
+/* No analog mux on this hardware - both sticks wire straight to SARADC 0-3.
+ * amux-count = 0 until a driver that reads four direct channels exists. */
+/* The H7 has ONE stick on SARADC ch1 (X) and ch2 (Y), wired direct - no analog
+ * mux. rocknix-singleadc-joypad can only read a single muxed channel
+ * (devm_iio_channel_get "amux_adc"), so switch to rocknix-joypad, which takes
+ * "joy_x"/"joy_y" directly. Both drivers emit the same button set, and the
+ * driver reads linux,code per child, so the sw<N> nodes below carry over.
+ *
+ * Measured raw values: X left=92 centre=460 right=873, Y up=155 centre=536
+ * down=921 - both rise in the ABS_X/ABS_Y positive direction, so NO inversion.
+ * Note invert-absx/absy are device_property_present() checks: setting them to
+ * <0> still inverts. They must be absent.
+ */
+&joypad {
+	compatible = "rocknix-joypad";
+	/* The driver maps ADC channels positionally, and defaults to
+	 * right-stick-first {"rx","ry","x","y"}. With only two channels the
+	 * single stick would land on ABS_RX/ABS_RY. abs-left-first selects
+	 * {"x","y","rx","ry"} so it reports as the left stick. */
+	abs-left-first;
+	io-channel-names = "joy_x", "joy_y";
+	io-channels = <&saradc 1>, <&saradc 2>;
+	button-adc-count = <2>;
+	button-adc-scale = <1>;
+	button-adc-deadzone = <20>;
+	button-adc-fuzz = <32>;
+	button-adc-flat = <32>;
+	/delete-property/ amux-count;
+	/delete-property/ amux-channel-mapping;
+	/delete-property/ amux-en-gpios;
+	/delete-property/ amux-a-gpios;
+	/delete-property/ amux-b-gpios;
+	/delete-property/ invert-absx;
+	/delete-property/ invert-absy;
+
+	/delete-node/ sw1;
+	/delete-node/ sw2;
+	/delete-node/ sw3;
+	/delete-node/ sw4;
+	/delete-node/ sw5;
+	/delete-node/ sw6;
+	/delete-node/ sw7;
+	/delete-node/ sw8;
+	/delete-node/ sw11;
+	/delete-node/ sw12;
+	/delete-node/ sw13;
+	/delete-node/ sw15;
+	/delete-node/ sw16;
+	/delete-node/ sw19;
+	/delete-node/ sw20;
+	/delete-node/ sw21;
+	/delete-node/ sw22;
+
+	sw1 {
+		gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-RIGHT";
+		linux,code = <BTN_TR>;
+	};
+
+	sw2 {
+		gpios = <&gpio3 RK_PA0 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-RIGHT2";
+		linux,code = <BTN_TR2>;
+	};
+
+	sw3 {
+		gpios = <&gpio3 RK_PB5 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-LEFT";
+		linux,code = <BTN_TL>;
+	};
+
+	sw4 {
+		gpios = <&gpio3 RK_PA6 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-LEFT2";
+		linux,code = <BTN_TL2>;
+	};
+
+	sw5 {
+		gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN-A";
+		linux,code = <BTN_EAST>;
+	};
+
+	sw6 {
+		gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN-B";
+		linux,code = <BTN_SOUTH>;
+	};
+
+	sw7 {
+		gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN-X";
+		linux,code = <BTN_NORTH>;
+	};
+
+	sw8 {
+		gpios = <&gpio3 RK_PC3 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN-Y";
+		linux,code = <BTN_WEST>;
+	};
+
+	sw9 {
+		gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-LEFT";
+		linux,code = <BTN_DPAD_LEFT>;
+	};
+
+	sw10 {
+		gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-RIGHT";
+		linux,code = <BTN_DPAD_RIGHT>;
+	};
+
+	sw11 {
+		gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-UP";
+		linux,code = <BTN_DPAD_UP>;
+	};
+
+	sw12 {
+		gpios = <&gpio3 RK_PC7 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-DOWN";
+		linux,code = <BTN_DPAD_DOWN>;
+	};
+
+	sw13 {
+		gpios = <&gpio3 RK_PD0 GPIO_ACTIVE_LOW>;
+		label = "GPIO SELECT";
+		linux,code = <BTN_SELECT>;
+	};
+
+	sw14 {
+		gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
+		label = "GPIO START";
+		linux,code = <BTN_START>;
+	};
+
+	sw15 {
+		gpios = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
+		label = "GPIO FN";
+		linux,code = <BTN_MODE>;
+	};
+
+	sw17 {
+		gpios = <&gpio2 RK_PB5 GPIO_ACTIVE_LOW>;
+		label = "GPIO THUMBL";
+		linux,code = <BTN_THUMBL>;
+	};
+
+	sw18 {
+		gpios = <&gpio2 RK_PB6 GPIO_ACTIVE_LOW>;
+		label = "GPIO THUMBR";
+		linux,code = <BTN_THUMBR>;
+	};
+};
+
+/* Pull-ups for the H7's own button lines. */
+&btn_pins {
+	rockchip,pins =
+		<2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>,
+		<2 RK_PB6 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PA0 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC1 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC2 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PC7 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>,
+		<3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
+};
+
+/* WiFi: Rockchip RK915 on SDIO.
+ *
+ * eeclone configures &sdio as an SD card slot - including
+ * cd-gpios = <&gpio0 RK_PA2>, which on the H7 is the WiFi power-enable line.
+ * That leaves the pin as a card-detect input, the chip unpowered and nothing
+ * on the bus (mmc2 comes up, no card enumerates, no wlan0).
+ *
+ * Values below match the stock device tree: 50 MHz, cap-sd-highspeed,
+ * keep-power-in-suspend and non-removable. The card node's
+ * compatible = "rockchip,rk915" is what 035-rk915-mmc-quirks.patch matches on. host-wake is gpio0 RK_PA1 per the stock
+ * WIFI,host_wake_irq (the upstream driver's example dtsi uses RK_PA5, which is
+ * that author's board, not this one).
+ */
+/ {
+	/*
+	 * The ported rk915 driver falls back to eth_random_addr() when the DT
+	 * carries no MAC, so the interface came up with a new address - and a
+	 * new DHCP lease - on every module load. The BSP avoided that by
+	 * calling rockchip_wifi_mac_addr(), which reads the factory MAC out of
+	 * Rockchip vendor storage; there is no mainline equivalent.
+	 *
+	 * The vendor U-Boot already reads that same vendor storage and exports
+	 * it as ethaddr (and the derived P2P address as eth1addr). Point
+	 * ethernet0 at the wifi node and U-Boot's fdt_fixup_ethernet() writes
+	 * ethaddr into it as mac-address, which of_get_mac_address() then
+	 * finds. That keeps the address per-device instead of baking one
+	 * handheld's MAC into a DTS everyone shares.
+	 */
+	aliases {
+		ethernet0 = &rk915_wifi;
+	};
+};
+
+&sdio {
+	/delete-property/ cd-gpios;
+	/delete-property/ card-detect-delay;
+	/delete-property/ sd-uhs-sdr12;
+	/delete-property/ sd-uhs-sdr25;
+	/delete-property/ sd-uhs-sdr50;
+	/delete-property/ sd-uhs-sdr104;
+	/delete-property/ vmmc-supply;
+	/delete-property/ vqmmc-supply;
+	cap-sd-highspeed;
+	cap-sdio-irq;
+	keep-power-in-suspend;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	max-frequency = <50000000>;
+	no-sd;
+	no-mmc;
+	non-removable;
+	status = "okay";
+
+	rk915_wifi: wifi@1 {
+		compatible = "rockchip,rk915";
+		reg = <1>;
+		interrupt-names = "host-wake";
+		interrupt-parent = <&gpio0>;
+		interrupts = <RK_PA1 IRQ_TYPE_LEVEL_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_host_wake_l>;
+	};
+};
+
+&pinctrl {
+	wifi {
+		wifi_enable_h: wifi-enable-h {
+			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+		wifi_host_wake_l: wifi-host-wake-l {
+			rockchip,pins = <0 RK_PA1 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+	};
+};
+
+/*
+ * Sound.
+ *
+ * eeclone defines two candidate cards and ships both disabled, expecting the
+ * including board to pick one; the H7 picked neither, so no ALSA card was
+ * instantiated at all ("no soundcards found", and not a single ASoC line in
+ * dmesg).
+ *
+ * The H7 has an external speaker amplifier, so the amplified card is the right
+ * one. The stock tree agrees on both pins:
+ *
+ *   stock  spk-ctl-gpios = <&gpio3 7 0>    use-ext-amplifier
+ *   here   spk_amp enable-gpios = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>
+ *
+ *   stock  hp-det-gpio   = <&gpio2 22 0>   (22 = RK_PC6)
+ *   here   hp-det-gpios  = <&gpio2 RK_PC6 GPIO_ACTIVE_HIGH>
+ *
+ * i2s1_2ch is already enabled by eeclone and the rk817 codec already carries
+ * #sound-dai-cells, so enabling the card is the only thing missing.
+ */
+&{/rk817-sound-amplified} {
+	status = "okay";
+};
+
+/*
+ * RGB LEDs (the illuminated button and the ring around the analog stick).
+ *
+ * These are WS2812-style addressable LEDs on a single data line, not anything
+ * the LED class can drive: the stock firmware has no LED node in its device
+ * tree at all and instead runs a userspace binary, /usr/bin/ws2812, which
+ * talks to /dev/spidev1.0 and encodes the WS2812 bit timing into the SPI
+ * bitstream. Only MOSI actually reaches the LEDs; CLK is there to clock the
+ * pattern out at the right rate.
+ *
+ * Pins are taken from the stock tree and deliberately avoid CS0: mainline's
+ * spi1_csn0 is gpio3 RK_PB1, which is a button on this board. The stock tree
+ * muxes spi1_csn1 (RK_PB2) instead, which is free. Nothing else collides —
+ * the buttons take PB0/PB1/PB3/PB5 and SPI1 takes PB2/PB4/PB6/PB7.
+ *
+ * "rohm,bh2228fv" is the conventional generic compatible for a raw spidev
+ * node; the stock tree's "rockchip,spidev" is not a mainline binding.
+ */
+/*
+ * Panel reset is gpio3 RK_PD3 on this board, not eeclone's RK_PB7.
+ *
+ * eeclone's value is wrong here and it also squats on spi1_clk, which is why
+ * SPI1 would not probe:
+ *
+ *   rockchip-pinctrl: pin gpio3-15 already requested by ff450000.dsi.0;
+ *                     cannot claim for ff1d8000.spi
+ *
+ * The stock tree is unambiguous - its st7703 panel node has
+ * reset-gpios = <&gpio3 27 1>, i.e. RK_PD3 active-low, and muxes RK_PB7 as
+ * spi1_clk (function 4). PD3 is otherwise unused on this board; the buttons
+ * stop at PD2.
+ *
+ * The display came up anyway with the wrong pin because U-Boot has already
+ * initialised the panel by the time Linux toggles it, so the bogus reset was
+ * simply a no-op on an unrelated pin.
+ */
+&internal_display {
+	reset-gpios = <&gpio3 RK_PD3 GPIO_ACTIVE_LOW>;
+};
+
+&lcd_rst {
+	rockchip,pins = <3 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi1_clk>, <&spi1_csn1>, <&spi1_miso>, <&spi1_mosi>;
+	status = "okay";
+
+	rgb_leds: spidev@0 {
+		compatible = "rohm,bh2228fv";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+	};
+};
+
+/*
+ * LEDs.
+ *
+ * This board has exactly two light sources, confirmed by toggling every
+ * candidate line on the hardware:
+ *
+ *   - three WS2812s in the ring around the analog stick, on spi1 MOSI
+ *     (see the spi1 node above, driven by h7-rgb)
+ *   - one red charging LED on gpio0 RK_PC1
+ *
+ * eeclone also declares a blue power LED on gpio0 RK_PA0. That pin drives
+ * nothing here: it sat at brightness 1 with a default-on trigger from boot
+ * and no light ever came from it, and driving it high and low by hand changed
+ * nothing either. Drop it rather than ship a phantom entry in
+ * /sys/class/leds that no amount of writing to will do anything.
+ *
+ * There is no illuminated button on this board, despite the ring making it
+ * look like there might be more.
+ */
+&leds {
+	/delete-node/ led-1;
+
+	/* Was "none", so the charging LED never lit. It is a charging
+	 * indicator, so let it indicate charging. */
+	led-0 {
+		linux,default-trigger = "battery-charging";
+	};
+};

--- a/projects/ROCKNIX/devices/RK3326/options
+++ b/projects/ROCKNIX/devices/RK3326/options
@@ -67,7 +67,7 @@
     FIRMWARE="esp8089-firmware"
   
   # Additional packages to install
-    ADDITIONAL_PACKAGES="device-switch libmali generic-dsi"
+    ADDITIONAL_PACKAGES="device-switch libmali generic-dsi h7-rgb-leds"
     ADDITIONAL_PACKAGES_32BIT="libmali"
 
   # Debug tty path

--- a/projects/ROCKNIX/devices/RK3326/packages/h7-rgb-leds/package.mk
+++ b/projects/ROCKNIX/devices/RK3326/packages/h7-rgb-leds/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+PKG_NAME="h7-rgb-leds"
+PKG_VERSION="1"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/ROCKNIX/distribution"
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Gusgu H7: control the WS2812 RGB LEDs over /dev/spidev1.0"
+PKG_TOOLCHAIN="manual"
+
+# The H7's RGB LEDs are WS2812s on spi1 MOSI. There is no kernel driver for
+# them in 7.1 and the stock firmware drives them from userspace too, so this
+# is a small tool rather than a module. The wire format is documented at the top
+# of scripts/h7-rgb, along with how it was recovered.
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp ${PKG_DIR}/scripts/h7-rgb ${INSTALL}/usr/bin/
+  chmod 0755 ${INSTALL}/usr/bin/h7-rgb
+
+  mkdir -p ${INSTALL}/usr/lib/systemd/system
+  cp ${PKG_DIR}/system.d/*.service ${INSTALL}/usr/lib/systemd/system/
+  enable_service h7-rgb-leds.service
+}

--- a/projects/ROCKNIX/devices/RK3326/packages/h7-rgb-leds/scripts/h7-rgb
+++ b/projects/ROCKNIX/devices/RK3326/packages/h7-rgb-leds/scripts/h7-rgb
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Gusgu H7 RGB ring: three WS2812s on /dev/spidev1.0, cycled by the RGB button.
+
+Wire format recovered from the stock firmware's own binary by capturing its
+ioctl(SPI_IOC_MESSAGE) buffers:
+
+    one SPI byte per WS2812 bit at the 8 MHz device default (125 ns/bit)
+        0xc0 = 11000000 -> 250 ns high -> a 0
+        0xfc = 11111100 -> 750 ns high -> a 1
+    three LEDs, three bytes each, wire order GRB
+    no latch bytes - the idle gap between frames is the reset
+
+The RGB button is BTN_MODE on the gamepad, the same physical button the stock
+firmware read as KEY_FN. The daemon reads it without EVIOCGRAB so the UI still
+sees it too.
+
+  h7-rgb <r> <g> <b>   all three to one colour
+  h7-rgb off
+  h7-rgb mode <name>   set a named mode (see MODES)
+  h7-rgb next          advance one mode
+  h7-rgb boot          re-apply the saved mode
+  h7-rgb daemon        render effects and follow the RGB button
+  h7-rgb list          list the modes
+"""
+import fcntl, math, os, select, struct, sys, time
+
+DEV   = "/dev/spidev1.0"
+NLED  = 3
+CONF  = "/storage/.config/h7-rgb.conf"
+ZERO, ONE = 0xC0, 0xFC
+SPEED = 8_000_000
+SPI_IOC_WR_MODE          = 0x40016B01
+SPI_IOC_WR_BITS_PER_WORD = 0x40016B03
+SPI_IOC_WR_MAX_SPEED_HZ  = 0x40046B04
+BTN_MODE = 316
+EV_KEY   = 0x01
+
+R, G, B = (255, 0, 0), (0, 255, 0), (0, 0, 255)
+
+# The stock firmware's list, in its order, so the button walks the same cycle.
+MODES = [
+    ("Red",                   "static",    [R]),
+    ("Red_Green",             "static",    [R, G]),
+    ("Green",                 "static",    [G]),
+    ("Green_Blue",            "static",    [G, B]),
+    ("Blue",                  "static",    [B]),
+    ("Blue_Red",              "static",    [B, R]),
+    ("Red_Green_Blue",        "static",    [R, G, B]),
+    ("Breathing_Red",         "breathing", [R]),
+    ("Breathing_Green",       "breathing", [G]),
+    ("Breathing_Blue",        "breathing", [B]),
+    ("Breathing_Blue_Red",    "breathing", [B, R]),
+    ("Breathing_Green_Blue",  "breathing", [G, B]),
+    ("Breathing_Red_Green",   "breathing", [R, G]),
+    ("Breathing_Red_Green_Blue", "breathing", [R, G, B]),
+    ("Breathing",             "breathing", [R, G, B]),
+    ("Scrolling",             "scrolling", [R, G, B]),
+    ("OFF",                   "static",    [(0, 0, 0)]),
+]
+NAMES = [m[0] for m in MODES]
+
+
+def encode(pixels):
+    out = bytearray()
+    for r, g, b in pixels:
+        for byte in (g, r, b):                       # GRB on the wire
+            for i in range(7, -1, -1):               # MSB first
+                out.append(ONE if (byte >> i) & 1 else ZERO)
+    return bytes(out)
+
+
+def open_spi():
+    fd = open(DEV, "wb", buffering=0)
+    fcntl.ioctl(fd, SPI_IOC_WR_MODE, struct.pack("B", 0))
+    fcntl.ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, struct.pack("B", 8))
+    fcntl.ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, struct.pack("I", SPEED))
+    return fd
+
+
+def show(fd, pixels):
+    fd.write(encode(pixels)); fd.flush()
+
+
+def render(kind, colours, phase):
+    """One frame. phase advances continuously; static modes ignore it."""
+    if kind == "static":
+        return [colours[i % len(colours)] for i in range(NLED)]
+    if kind == "breathing":
+        # sine on brightness, never fully dark so the ring stays visible
+        k = 0.15 + 0.85 * (0.5 - 0.5 * math.cos(phase * 2 * math.pi))
+        return [tuple(int(c * k) for c in colours[i % len(colours)])
+                for i in range(NLED)]
+    if kind == "scrolling":
+        off = int(phase * len(colours) * NLED) % len(colours)
+        return [colours[(i + off) % len(colours)] for i in range(NLED)]
+    return [(0, 0, 0)] * NLED
+
+
+def load_mode():
+    try:
+        with open(CONF) as f:
+            first = f.read().split("\n")[0].strip()
+    except OSError:
+        return "Scrolling"
+    if first in NAMES:
+        return first
+    parts = first.split()
+    if len(parts) >= 3:                              # legacy "R G B" file
+        return parts[:3]
+    return "Scrolling"
+
+
+def save_mode(name):
+    try:
+        os.makedirs(os.path.dirname(CONF), exist_ok=True)
+        with open(CONF, "w") as f:
+            f.write(name + "\n")
+    except OSError:
+        pass                                          # read-only /storage, fine
+
+
+def spec_for(mode):
+    if isinstance(mode, list):                        # legacy explicit colour
+        rgb = tuple(max(0, min(255, int(v))) for v in mode)
+        return "static", [rgb]
+    for name, kind, colours in MODES:
+        if name == mode:
+            return kind, colours
+    return "static", [(32, 32, 32)]
+
+
+def find_gamepad():
+    for n in range(0, 16):
+        path = f"/dev/input/event{n}"
+        try:
+            name = open(f"/sys/class/input/event{n}/device/name").read().strip()
+        except OSError:
+            continue
+        if "gamepad" in name.lower() or "joypad" in name.lower():
+            return path
+    return None
+
+
+def daemon(fd):
+    mode = load_mode()
+    kind, colours = spec_for(mode)
+    path = find_gamepad()
+    ev = None
+    if path:
+        try:
+            ev = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        except OSError:
+            ev = None
+    fmt, sz = "llHHi", struct.calcsize("llHHi")
+
+    phase, last = 0.0, time.time()
+    while True:
+        animated = kind in ("breathing", "scrolling")
+        timeout = 0.02 if animated else 0.25
+        if ev is not None:
+            r, _, _ = select.select([ev], [], [], timeout)
+            if r:
+                try:
+                    data = os.read(ev, sz * 64)
+                except OSError:
+                    data = b""
+                for i in range(0, len(data) - sz + 1, sz):
+                    _, _, typ, code, val = struct.unpack(fmt, data[i:i+sz])
+                    if typ == EV_KEY and code == BTN_MODE and val == 1:
+                        cur = mode if isinstance(mode, str) else "Scrolling"
+                        idx = (NAMES.index(cur) + 1) % len(NAMES) if cur in NAMES else 0
+                        mode = NAMES[idx]
+                        kind, colours = spec_for(mode)
+                        save_mode(mode)
+                        phase = 0.0
+        else:
+            time.sleep(timeout)
+
+        now = time.time()
+        if animated:
+            phase = (phase + (now - last) * 0.4) % 1.0
+        last = now
+        show(fd, render(kind, colours, phase))
+        if not animated:
+            # static: repaint slowly, enough to recover if something else wrote
+            time.sleep(0.25)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); return 1
+    cmd = sys.argv[1]
+
+    if cmd == "list":
+        for n in NAMES:
+            print(" ", n)
+        return 0
+
+    fd = open_spi()
+
+    if cmd == "daemon":
+        daemon(fd)
+    elif cmd == "boot":
+        kind, colours = spec_for(load_mode())
+        show(fd, render(kind, colours, 0.0))
+    elif cmd == "off":
+        save_mode("OFF")
+        show(fd, [(0, 0, 0)] * NLED)
+    elif cmd == "mode":
+        name = sys.argv[2]
+        if name not in NAMES:
+            print(f"unknown mode {name!r}; try: h7-rgb list"); return 1
+        save_mode(name)
+        kind, colours = spec_for(name)
+        show(fd, render(kind, colours, 0.0))
+    elif cmd == "next":
+        cur = load_mode()
+        cur = cur if isinstance(cur, str) and cur in NAMES else NAMES[0]
+        name = NAMES[(NAMES.index(cur) + 1) % len(NAMES)]
+        save_mode(name)
+        kind, colours = spec_for(name)
+        show(fd, render(kind, colours, 0.0))
+        print(" ", name)
+    else:
+        r, g, b = (int(x) for x in sys.argv[1:4])
+        save_mode(f"{r} {g} {b}")
+        show(fd, [(r, g, b)] * NLED)
+    return 0
+
+
+sys.exit(main())

--- a/projects/ROCKNIX/devices/RK3326/packages/h7-rgb-leds/system.d/h7-rgb-leds.service
+++ b/projects/ROCKNIX/devices/RK3326/packages/h7-rgb-leds/system.d/h7-rgb-leds.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Gusgu H7 RGB ring (mode cycling on the RGB button)
+After=multi-user.target
+ConditionPathExists=/dev/spidev1.0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+# Renders the saved mode and advances it when the RGB button (BTN_MODE) is
+# pressed. Reads the gamepad without EVIOCGRAB, so the UI still sees the key.
+ExecStart=/usr/bin/h7-rgb daemon
+ExecStopPost=-/usr/bin/h7-rgb off
+
+[Install]
+WantedBy=multi-user.target

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/extlinux/extlinux.conf.sub-h7
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/extlinux/extlinux.conf.sub-h7
@@ -1,0 +1,4 @@
+LABEL ROCKNIX
+  LINUX /KERNEL
+  FDT /rk3326-gusgu-h7.dtb
+  APPEND boot=LABEL=ROCKNIX disk=LABEL=STORAGE quiet console=tty0 console=ttyS2,1500000 systemd.debug_shell=ttyS2

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/h7_boot.ini
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/config/h7_boot.ini
@@ -1,0 +1,62 @@
+# ROCKNIX boot script for the Gusgu H7 (Rockchip RK3326 clone handheld).
+#
+# Unlike a_boot.ini / b_boot.ini, this performs NO ADC-based board detection.
+# The H7's hwid ADC value is unknown, and its analog sticks are wired directly
+# to SARADC channels 0-3 with no analog mux, so the channel the hwid probe
+# samples carries no board-identifying voltage. The DTB is pinned instead.
+#
+# Base DTB: rk3326-gameconsole-eeclone
+#   The only RK3326 device tree in this tree that defines every node
+#   mipi-panel.dtbo targets (the `joypad` label, a rocknix,generic-dsi
+#   internal_display, adc-keys and audio-amplifier), AND which aliases
+#   serial2 = &uart5 with uart2 disabled -- that aliasing is what makes the
+#   stock console=ttyS2,1500000 land on the H7's actual UART5 debug port
+#   (0xff178000, 1500000 8N1), so serial works with no cmdline change.
+#
+# The H7's own panel (1024x768 ST7703) is baked into rk3326-gusgu-h7.dts as a
+# generic-dsi panel_description read out of the stock vendor DTB, overriding
+# eeclone's 720x720 HX8394. It is deliberately not an overlay: the H7's vendor
+# u-boot predates FDTOVERLAYS, so extlinux.conf.sub-h7 carries no FDTOVERLAYS
+# line and the panel has to be in the DTB itself.
+
+# Legacy u-boot doesn't have distro_bootpart
+if test -z "${distro_bootpart}"; then
+  echo "No distro_bootpart; setting it to 1"
+  setenv distro_bootpart 1
+fi
+
+# distro_storagepart=$((${distro_bootpart} + 1))
+if   test ${distro_bootpart} = '0'; then setenv distro_storagepart 1
+elif test ${distro_bootpart} = '1'; then setenv distro_storagepart 2
+elif test ${distro_bootpart} = '2'; then setenv distro_storagepart 3
+elif test ${distro_bootpart} = '3'; then setenv distro_storagepart 4
+else                                     setenv distro_storagepart 2
+fi
+
+# reduce copy-paste referring to active partition
+setenv thispart "${devtype} ${devnum}:${distro_bootpart}"
+setenv storagepart "${devtype} ${devnum}:${distro_storagepart}"
+
+# if possible, ensure system uses partitions on exactly this media
+if fsuuid ${thispart} partition_boot; then
+  setenv partition_boot "UUID=${partition_boot}"
+else
+  setenv partition_boot "LABEL=@DISTRO_BOOTLABEL@"
+fi
+if fsuuid ${devtype} ${devnum}:2 partition_storage; then
+  setenv partition_storage "UUID=${partition_storage}"
+else
+  setenv partition_storage "LABEL=@DISTRO_DISKLABEL@"
+fi
+
+# Pinned board -- record that in the cmdline for userspace introspection
+setenv hwid_adc h7,pinned
+
+setenv fdtfile "rk3326-gusgu-h7.dtb"
+echo "Gusgu H7: using ${fdtfile}"
+
+# Let syslinux do the load stuff.
+# User will be able to edit extlinux.conf if needed
+setenv kernel_addr_r "0x09000000"
+setenv fdtoverlay_addr_r "0x08000000"
+sysboot ${thispart} any 0x100000 /extlinux/extlinux.conf


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Add support for the Gusgu H7, an unbranded RK3326 handheld that ships a vendor EmuELEC 4.7 build.

`rk3326-gusgu-h7.dts` includes the eeclone base and overrides it. eeclone is the only RK3326 tree here that defines every node the H7 needs (`internal_display`, `joypad`, `adc_keys`, `btn_pins`), and its `serial2 = &uart5` alias puts the H7's UART5 debug port on `ttyS2`, so the stock `console=` works unchanged. Everything else came from the device's own stock vendor DTB, with the GPIO assignments verified one at a time against physical button presses.

Three device-specific findings are encoded in the DTS:

* **`adc_keys` is disabled.** eeclone samples SARADC ch2 for volume; on the H7 that line is the analog stick's Y axis. A centred stick therefore reads as `KEY_VOLUMEDOWN` held, and ROCKNIX init drops into USB-MSC recovery on *every* boot. The H7's real volume buttons are GPIOs, moved to a `gpio-keys` node.
* **`joypad` switches to `rocknix-joypad` with `abs-left-first`.** The H7 has one stick wired direct to SARADC ch1/ch2 with no analog mux, which `rocknix-singleadc-joypad` cannot read. `rocknix-joypad` maps channels positionally and defaults to right-stick-first, so `abs-left-first` is what makes the stick report as `ABS_X`/`ABS_Y`.
* **`btn_pins` gains pull-ups** for the five H7 button lines eeclone does not configure.

**The one shared-code change** is in `mkimage`. The H7's vendor U-Boot is a 2017.09 fork that predates `FDTOVERLAYS` and never reaches `boot.scr` (it scans extlinux before scripts), so it needs an explicit `FDT` and literal `LABEL=` values rather than `${partition_boot}` placeholders. Rather than change the shared `extlinux.conf`, `mkimage_extlinux()` now prefers `extlinux/extlinux.conf.sub-<subdevice>` when one is present. No existing subdevice ships such a file, so the `-a` and `-b` images are byte-identical.

**`h7-rgb-leds`** drives the three WS2812s in the ring around the stick, which hang off spi1 MOSI with no kernel driver in 7.1 (the stock firmware drives them from userspace too). The wire format was recovered by capturing the stock firmware's own `ioctl(SPI_IOC_MESSAGE)` buffers and is documented at the top of the script. The service is gated on `ConditionPathExists=/dev/spidev1.0`, which only the H7 DTS enables, so it does not start on any other RK3326 device.

## Testing

* **How was this tested?** Built and run on the physical device. Each subsystem was checked individually rather than assumed from a clean boot.
* **Test results:** Working — display (1024x768 ST7703), audio, all 17 buttons, the volume keys, the analog stick, and the RGB ring cycling through the stock firmware's mode list from the RGB button. Serial console works with the stock `console=ttyS2,1500000` and no cmdline change. The `-a` and `-b` images were rebuilt to confirm the `mkimage` change leaves them unaffected.

## Additional Context

* **WiFi is not part of this PR.** The H7's RK915 chip is handled separately in #3252. The DTS here does carry the `rockchip,rk915` SDIO card node, but it simply binds nothing without that driver — the device boots and works fine on this PR alone, just without wireless.
* **Related fixes split out** so this PR stays device-scoped: #3249 (rk817 volume, which the H7 needs for working audio), #3250 (SARADC log flood), #3251 (dw_mmc SDIO robustness). None of them are prerequisites for this one.
* **Not included deliberately:** the device's stock vendor DTB. `config/stock/` is copied wholesale into `/usr/share/bootloader/` in every RK3326 image, and its README says users drop their *own* stock DTB there — shipping one device's 108KB vendor blob to the whole family seemed wrong on both size and licensing grounds. Everything needed was already extracted into the DTS.
* **Panel handling:** the 1024x768 ST7703 timings are baked into the DTS as a generic-dsi `panel_description` read out of the stock DTB, not supplied as an overlay, because this device's u-boot cannot apply overlays.
* I am the only person I know of with this device, so I cannot speak to hardware revision variance. Happy to adjust naming or layout to whatever fits the project's conventions for unbranded clones.

---

### AI Usage

**Did you use AI tools to help write this code?** YES — Claude Code was used extensively: reverse-engineering the stock DTB and the RGB LED SPI protocol, working out the `adc_keys`/stick channel collision from the boot-into-recovery symptom, writing the DTS and the LED tool, and drafting this description. Every claim in the Testing section was checked on the physical device.