### PR TITLE
add comments discouraging rk3326 image creation

### DIFF
--- a/projects/ROCKNIX/config.xml
+++ b/projects/ROCKNIX/config.xml
@@ -44,6 +44,10 @@
     </DDR3>
   </H700>
   <RK3326 dtb_prefix="rockchip">
+    <!-- NOTE: DO NOT ADD ANY NEW RK3326 IMAGES -->
+    <!-- see projects/ROCKNIX/devices/RK3326/packages/u-boot/package.mk, function generate_custom_extlinux_conf_files -->
+    <!-- By just adding a new dts, you get an extlinux.conf.<dev_name>.
+         Replace extlinux.conf with it, it's enough to boot your device. -->
     <a mkimage_options="dtb,bootscr,extlinux,uboot" fdt_type="fdtdir" fdt="/">
       <file>rk3326-anbernic-rg351m</file>
       <file>rk3326-anbernic-rg351v</file>
@@ -64,6 +68,7 @@
       <file>rk3326-batlexp-g350</file>
       <file>rk3326s-gkd-pixel2</file>
     </b>
+    <!-- NOTE: DO NOT ADD ANY NEW RK3326 IMAGES -->
   </RK3326>
   <RK3399 mkimage_options="dtb,extlinux,uboot" fdt="device_trees/rk3399-anbernic-rg552.dtb" fdt_type="fdt" dtb_prefix="rockchip">
     <file>rk3399-anbernic-rg552</file>

--- a/projects/ROCKNIX/devices/RK3326/packages/u-boot/package.mk
+++ b/projects/ROCKNIX/devices/RK3326/packages/u-boot/package.mk
@@ -54,6 +54,12 @@ make_target() {
   mv uboot.bin uboot.bin.uart5
 }
 
+# IMPORTANT!
+# For every device `<dev_name>` not in any image this function creates
+# an `extlinux.conf.<dev_name>` file passing a corresponding dtb directly
+# (effectively bypassing auto-detection by ADC value).
+# User needs to rename a single file (replacing the generic `extlinux.conf`)
+# to configure any (a/b) image for their device.
 generate_custom_extlinux_conf_files() {
   INI_FILES=""
   for SUBDEVICE in ${SUBDEVICES}; do
@@ -96,6 +102,8 @@ makeinstall_target() {
   sed -e "s/@EXTRA_CMDLINE@/${EXTRA_CMDLINE}/" \
     -i ${INSTALL}/usr/share/bootloader/extlinux/*
 
+  # Next call creates an `extlinux.conf.<dev_name>` files for every dts/dtb not in any image.
+  # User needs to rename a proper file to `extlinux.conf` (replacing it) as a preparation step.
   generate_custom_extlinux_conf_files
 
   find_dir_path config/stock && cp -av ${FOUND_PATH} "${INSTALL}/usr/share/bootloader/"


### PR DESCRIPTION
Got sick of LLMs defining rk3326 images in PRs.  
Added some comments explaining how out-of-image devices should be used instead.  