### PR TITLE
dolphin-sa: prefer full controller GUID in scripts

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
@@ -406,10 +406,14 @@ SDL_DEVICE="${param_device}"
 MAPLINE=""
 if [ -n "${DEVICE}" ] && [ -f "${SDL_DB}" ]; then
   GUID_KEY="$(echo "${DEVICE}" | cut -c1-4)0000$(echo "${DEVICE}" | cut -c9-)"
-  MAPLINE="$(awk -F, -v k="${GUID_KEY}" '!/^#/ && NF>1 {
-      g = substr($1,1,4) "0000" substr($1,9)
-      if (g == k) { print; exit }
-    }' "${SDL_DB}")"
+  MAPLINE="$(awk -F, -v d="${DEVICE}" -v k="${GUID_KEY}" '!/^#/ && NF>1 {
+      if ($1 == d) { exact = $0; exit }
+      if (loose == "" && substr($1,5,4) == "0000") {
+        g = substr($1,1,4) "0000" substr($1,9)
+        if (g == k) { loose = $0 }
+      }
+    }
+    END { print (exact != "" ? exact : loose) }' "${SDL_DB}")"
   MAPPED="$(echo "${MAPLINE}" | cut -d, -f2)"
   [ -n "${MAPPED}" ] && SDL_DEVICE="${MAPPED}"
 fi

--- a/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
@@ -369,10 +369,14 @@ SDL_DEVICE="${param_device}"
 MAPLINE=""
 if [ -n "${DEVICE}" ] && [ -f "${SDL_DB}" ]; then
   GUID_KEY="$(echo "${DEVICE}" | cut -c1-4)0000$(echo "${DEVICE}" | cut -c9-)"
-  MAPLINE="$(awk -F, -v k="${GUID_KEY}" '!/^#/ && NF>1 {
-      g = substr($1,1,4) "0000" substr($1,9)
-      if (g == k) { print; exit }
-    }' "${SDL_DB}")"
+  MAPLINE="$(awk -F, -v d="${DEVICE}" -v k="${GUID_KEY}" '!/^#/ && NF>1 {
+      if ($1 == d) { exact = $0; exit }
+      if (loose == "" && substr($1,5,4) == "0000") {
+        g = substr($1,1,4) "0000" substr($1,9)
+        if (g == k) { loose = $0 }
+      }
+    }
+    END { print (exact != "" ? exact : loose) }' "${SDL_DB}")"
   MAPPED="$(echo "${MAPLINE}" | cut -d, -f2)"
   [ -n "${MAPPED}" ] && SDL_DEVICE="${MAPPED}"
 fi

--- a/projects/ROCKNIX/packages/virtual/emulators/sources/Start Dolphin.sh
+++ b/projects/ROCKNIX/packages/virtual/emulators/sources/Start Dolphin.sh
@@ -28,10 +28,15 @@ SDL_DB="${SDL_GAMECONTROLLERCONFIG_FILE:-/storage/.config/gptokeyb/gamecontrolle
 SDL_DEVICE="${param_device}"
 if [ -n "${DEVICE}" ] && [ -f "${SDL_DB}" ]; then
   GUID_KEY="$(echo "${DEVICE}" | cut -c1-4)0000$(echo "${DEVICE}" | cut -c9-)"
-  MAPPED="$(awk -F, -v k="${GUID_KEY}" '!/^#/ && NF>1 {
-      g = substr($1,1,4) "0000" substr($1,9)
-      if (g == k) { print $2; exit }
-    }' "${SDL_DB}")"
+  MAPLINE="$(awk -F, -v d="${DEVICE}" -v k="${GUID_KEY}" '!/^#/ && NF>1 {
+      if ($1 == d) { exact = $0; exit }
+      if (loose == "" && substr($1,5,4) == "0000") {
+        g = substr($1,1,4) "0000" substr($1,9)
+        if (g == k) { loose = $0 }
+      }
+    }
+    END { print (exact != "" ? exact : loose) }' "${SDL_DB}")"
+  MAPPED="$(echo "${MAPLINE}" | cut -d, -f2)"
   [ -n "${MAPPED}" ] && SDL_DEVICE="${MAPPED}"
 fi
 for CFG in "${CONF_DIR}/Hotkeys.ini" "${CONF_DIR}/GCPadNew.ini" "${CONF_DIR}/WiimoteNew.ini"; do


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Actually matches the correct SDL3 controller string a device provides instead of defaulting to the first one seen in the list with a zeroed GUID.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Tested on Odin 2 and custom T618 build, controls still work.

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

Need verification from an AyaNeo device (I don't own one, sorry) before I can call this a proper fix.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES
Diagnosed and corrected logic with Claude Code
