### PR TITLE
sm8250: fix Retroid Pocket 5 HDMI audio params

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/filesystem/usr/share/wireplumber/wireplumber.conf.d/52-retroid-pocket-5-hdmi.conf
+++ b/projects/ROCKNIX/devices/SM8250/filesystem/usr/share/wireplumber/wireplumber.conf.d/52-retroid-pocket-5-hdmi.conf
@@ -1,0 +1,31 @@
+# WirePlumber drop-in for Retroid Pocket 5 HDMI/DP audio over USB-C.
+#
+# On RP5, PipeWire's default ALSA params open the HDMI PCM as
+# MMAP_INTERLEAVED + S24_LE, which produces extremely quiet audio.
+# Android uses PCM16/48k/stereo with a 3840-frame buffer. On ROCKNIX,
+# period-size is negotiated to 480, so period-num=8 gives the tested
+# working 3840-frame buffer.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        media.class = "Audio/Sink"
+        alsa.long_card_name = "retroidpocket-RetroidPocket5"
+        api.alsa.path = "hw:RetroidPocket,3"
+      }
+    ]
+    actions = {
+      update-props = {
+        audio.format = "S16LE"
+        audio.rate = 48000
+        audio.channels = 2
+        audio.position = [ "FL" "FR" ]
+
+        api.alsa.disable-mmap = true
+        api.alsa.period-size = 480
+        api.alsa.period-num = 8
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Fixes extremely quiet HDMI / DisplayPort audio on Retroid Pocket 5 over USB-C by adding a device-scoped WirePlumber ALSA rule for the RP5 HDMI sink.

The existing SM8250 UCM config already exposes the HDMI use case correctly via `hw:RetroidPocket,3`; this PR adds the missing PipeWire/WirePlumber runtime params needed for usable output volume.

## Tested On

- Device: Retroid Pocket 5
- ROCKNIX version: 20260901
- PipeWire: 1.2.6
- WirePlumber: 1.2.6
- Output: USB-C HDMI / DisplayPort adapter to TV
- Note: in my setup, USB-C HDMI works reliably only when power is connected to the adapter

## Problem

HDMI audio was detected and routed, but output through PipeWire was extremely quiet even with sink and stream volume at 100%.

Direct ALSA playback to the HDMI PCM was loud:

```sh
speaker-test -D hw:RetroidPocket,3 -c 2 -r 48000 -F S16_LE -t sine
```

But playback through PipeWire was almost inaudible before this workaround:

```sh
speaker-test -D pipewire -c 2 -r 48000 -F S16_LE -t sine
```

Before the fix, PipeWire opened the underlying HDMI PCM as:

access: MMAP_INTERLEAVED
format: S24_LE
channels: 2
rate: 48000
period_size: 480
buffer_size: 3840

The bad combination appears to be MMAP_INTERLEAVED + S24_LE on this RP5 HDMI path.

## Existing UCM State

The existing UCM patch already adds the RP5 HDMI use case:

/usr/share/alsa/ucm2/Qualcomm/sm8250/RetroidPocket.conf
/usr/share/alsa/ucm2/Qualcomm/sm8250/HDMI-RP.conf

HDMI-RP.conf exposes HDMI as:

PlaybackPCM "hw:${CardId},3"
PlaybackChannels 2
PlaybackRate 48000
JackControl "DP0 Jack"

So this PR does not replace the UCM HDMI enable/routing layer. It only controls how PipeWire opens the already-exposed ALSA PCM.

## Fix

Add a WirePlumber ALSA monitor rule scoped to the RP5 HDMI sink:

media.class = "Audio/Sink"
alsa.long_card_name = "retroidpocket-RetroidPocket5"
api.alsa.path = "hw:RetroidPocket,3"

and force:

audio.format = "S16LE"
audio.rate = 48000
audio.channels = 2
audio.position = [ "FL" "FR" ]
api.alsa.disable-mmap = true
api.alsa.period-size = 480
api.alsa.period-num = 8

With this rule active, PipeWire opens the HDMI PCM as:

access: RW_INTERLEAVED
format: S16_LE
subformat: STD
channels: 2
rate: 48000
period_size: 480
buffer_size: 3840

Audio volume is then normal.

## Android Comparison

Stock Android on the same device, adapter, and TV also uses PCM16 / 48 kHz / stereo for HDMI media playback.

From Android while HDMI audio was playing:

/proc/asound/card0/pcm0p/sub0/hw_params
access: RW_INTERLEAVED
format: S16_LE
channels: 2
rate: 48000
period_size: 1920
buffer_size: 3840

Android dumpsys media.audio_flinger showed the active HDMI media path using:

AUDIO_OUTPUT_FLAG_DEEP_BUFFER
AUDIO_FORMAT_PCM_16_BIT
48000 Hz
2 channels
HAL frame count: 1920
HAL buffer size: 7680 bytes

Trying to copy Android's period_size=1920, period_num=2 directly into PipeWire/WirePlumber did not work well on ROCKNIX; PipeWire/ALSA negotiated it to a smaller effective buffer. The tested ROCKNIX setting that gives the desired
runtime buffer is period-size=480 with period-num=8, resulting in buffer_size=3840.

## Validation

After applying the WirePlumber rule and rebooting/reconnecting HDMI:

- speaker-test -D pipewire -c 2 -r 48000 -F S16_LE -t sine is loud
- Saturn emulator / yabasanshiro audio is clean
- Mega Drive through RetroArch audio is clean
- Tested both launch orders after clean reboots:
    - Saturn first, then Mega Drive
    - Mega Drive first, then Saturn

- Sink volume and stream volume were both valid at 1.00 during testing
- Runtime HDMI params stayed at:

RW_INTERLEAVED
S16_LE
48000 Hz
2 channels
period_size: 480
buffer_size: 3840

## Scope / Caveats

This is intentionally scoped to:

alsa.long_card_name = "retroidpocket-RetroidPocket5"
api.alsa.path = "hw:RetroidPocket,3"

so it should not affect other SM8250 devices or the RP5 internal speaker/headphone paths.

A separate USB-C HDMI + NIC adapter did not work at all, likely due to USB-C / power negotiation. This PR does not attempt to fix that separate hotplug/power negotiation issue.

---

### AI Usage

AI helped to find the root cause, proper files to dump, come up with testing scenarios and prepare this text in a nice manner with all details included.

**Did you use AI tools to help write this code?** PARTIALLY