### PR TITLE
inputplumber: bump to v0.79.0 and drop overlapping upstream configs

### DIFF
--- a/projects/ROCKNIX/packages/tools/inputplumber/package.mk
+++ b/projects/ROCKNIX/packages/tools/inputplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025 ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="inputplumber"
-PKG_VERSION="v0.75.2"
-PKG_SHA256="8e8e84853138689081a60201d448f51cd6b46e160e4a0e02b95e52f2e30f27f0"
+PKG_VERSION="v0.79.0"
+PKG_SHA256="123c858139d3b78e3f075158ce16b8fdc8067a10e31a93cb1e7f2aea816106bd"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ShadowBlip/InputPlumber"
 PKG_URL="https://github.com/ShadowBlip/InputPlumber/releases/download/${PKG_VERSION}/inputplumber-aarch64.tar.gz"
@@ -11,9 +11,32 @@ PKG_DEPENDS_TARGET="toolchain systemd libevdev libiio polkit"
 PKG_LONGDESC="Open source input router and remapper daemon for Linux"
 PKG_TOOLCHAIN="manual"
 
+# Upstream composite device configs for the handhelds we support ourselves.
+# Our own configs (projects/ROCKNIX/devices/*/filesystem/usr/share/inputplumber)
+# match the same hardware but map it to a DualSense target, so the upstream
+# files would compete for the same source devices. Drop them.
+PKG_DROP_DEVICE_CONFIGS="
+  50-ayaneo_pocket_s2.yaml
+  50-ayn_odin2.yaml
+  50-ayn_odin2_mini.yaml
+  50-ayn_odin3.yaml
+  50-ayn_thor.yaml
+  50-konkr_pocket_fit.yaml
+  50-konkr_pocket_fit_elite.yaml
+  50-retroid_pocket5.yaml
+  50-retroid_pocket6.yaml
+  50-retroid_pocket_flip2.yaml
+  50-retroid_pocket_mini.yaml
+  50-retroid_pocket_nova.yaml
+"
+
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr
   rsync -ar ${PKG_BUILD}/usr/ ${INSTALL}/usr/
+
+  for config in ${PKG_DROP_DEVICE_CONFIGS}; do
+    rm -f ${INSTALL}/usr/share/inputplumber/devices/${config}
+  done
 }
 
 post_install() {


### PR DESCRIPTION
## Summary

0.79.0 is the first release that ships composite device configs for the ARM handhelds we support: AYN Odin 2/2 Mini/3/Thor, Retroid Pocket 5/6/Mini/Flip 2/Nova, KONKR Pocket FIT/FIT Elite and AYANEO Pocket S2.

Those upstream configs match the same devicetree machines and claim the same source devices as our own configs in
projects/ROCKNIX/devices/*/filesystem/usr/share/inputplumber, but emit an xbox-elite target instead of ds5 + keyboard, so both would compete for e.g. rsinput-gamepad/input0 and gpio-keys-paddles. Remove them at install time and keep ours.

The remaining upstream configs match on x86 DMI and cannot trigger on any of our aarch64 targets, so they are left alone.

Claude-Session: https://claude.ai/code/session_01TR1WCHFHJ1iWsZcvNQ3kFw

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES
