### PR TITLE
inputplumber: drop upstream configs in post_unpack

### DIFF
--- a/projects/ROCKNIX/packages/tools/inputplumber/package.mk
+++ b/projects/ROCKNIX/packages/tools/inputplumber/package.mk
@@ -30,13 +30,15 @@ PKG_DROP_DEVICE_CONFIGS="
   50-retroid_pocket_nova.yaml
 "
 
+post_unpack() {
+  for config in ${PKG_DROP_DEVICE_CONFIGS}; do
+    rm -f ${PKG_BUILD}/usr/share/inputplumber/devices/${config}
+  done
+}
+
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr
   rsync -ar ${PKG_BUILD}/usr/ ${INSTALL}/usr/
-
-  for config in ${PKG_DROP_DEVICE_CONFIGS}; do
-    rm -f ${INSTALL}/usr/share/inputplumber/devices/${config}
-  done
 }
 
 post_install() {


### PR DESCRIPTION
Follow-up to #3274 addressing review feedback: do the cleanup in `post_unpack()` rather than after the rsync in `makeinstall_target()`.

The overlapping upstream composite device configs are now removed from the unpacked tree, so the install step stays a plain copy of what we actually want to ship. `post_unpack` runs after `${PKG_BUILD}` is populated (`scripts/unpack:122`), so the files are present at that point.

No functional change to the resulting image.

https://claude.ai/code/session_0192nnogbhma1CpV48mF3DYv

---

### AI Usage

While ROCKNIX does not have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES