### PR TITLE
network: fix Local Play with NetworkManager/iwd

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/wifictl
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/wifictl
@@ -15,12 +15,12 @@ NMCLI="$(command -v nmcli 2>/dev/null)"
 ###     wifictl command [ssid] [psk]
 ###
 
-IWD_AP_CFG_DIR="/storage/.cache/iwd/ap"
 WIFI_TYPE=$(get_setting wifi.adhoc.enabled)
 NETWORK_ADDRESS="192.168.80"
 ADHOC_CLIENT_ID=$(get_setting wifi.adhoc.id)
+[ -z "${ADHOC_CLIENT_ID}" ] && ADHOC_CLIENT_ID="1"
+NETPLAY_SSID="NETPLAY_AP"
 WIFI_DEV="$(ls /sys/class/net | grep -m1 ^wlan)"
-DEFAULT_CHAN="6"
 
 # Exit the script if the WiFi device isn't available
 [ -z "${WIFI_DEV}" ] && exit 0
@@ -32,14 +32,8 @@ PSK="${3:-$(get_setting wifi.key 2>/dev/null)}"
 COUNTRY="${4:-$(get_setting wifi.country | tr -d '[:space:]' 2>/dev/null)}"
 
 if [ "${WIFI_TYPE}" = "1" ]; then
-  SSID="NETPLAY_AP"
+  SSID="${NETPLAY_SSID}"
   PSK="deadbeef"
-fi
-
-ADHOC_CHAN=$(get_setting wifi.adhoc.channel)
-if [ -z "${ADHOC_CHAN}" ]; then
-  ADHOC_CHAN="${DEFAULT_CHAN}"
-  set_setting wifi.adhoc.channel ${DEFAULT_CHAN}
 fi
 
 ###
@@ -86,33 +80,52 @@ connect_wifi() {
 
 create_adhoc() {
   wait_for_wifi
-  "${NMCLI}" device set "${WIFI_DEV}" managed no >/dev/null 2>&1
+  # NetworkManager drives iwd into AP mode itself (Device.Mode + AP.Start).
+  # Switching the mode behind its back only makes NM force the device back to
+  # station mode, so the netplay AP has to be a NetworkManager connection.
+  # No DHCP: the clients derive their address from the local play ID.
+  "${NMCLI}" connection delete id "${SSID}" >/dev/null 2>&1
+  "${NMCLI}" connection add type wifi ifname "${WIFI_DEV}" con-name "${SSID}" ssid "${SSID}" \
+    802-11-wireless.mode ap \
+    802-11-wireless.band bg \
+    802-11-wireless-security.key-mgmt wpa-psk \
+    802-11-wireless-security.psk "${PSK}" \
+    ipv4.method manual ipv4.addresses "${NETWORK_ADDRESS}.${ADHOC_CLIENT_ID}/24" \
+    ipv6.method disabled || return 1
+  "${NMCLI}" -w 30 connection up id "${SSID}" || return 1
+}
 
-  # Create an iwd AP profile file
-  mkdir -p "${IWD_AP_CFG_DIR}"
-  cat <<EOF >"${IWD_AP_CFG_DIR}/${SSID}.ap"
-[General]
-Channel=${ADHOC_CHAN}
-DisableHT=true
-
-[Security]
-Passphrase=${PSK}
-
-[IPv4]
-Address=${NETWORK_ADDRESS}.${ADHOC_CLIENT_ID}
-Netmask=255.255.255.0
-Gateway=${NETWORK_ADDRESS}.${ADHOC_CLIENT_ID}
-EOF
-
-  iwctl device ${WIFI_DEV} set-property Mode ap
-  # Start the AP profile
-  iwctl ap ${WIFI_DEV} start-profile "${SSID}" 2>/dev/null
+connect_adhoc_client() {
+  destroy_adhoc
+  # Static lease: the netplay host runs no DHCP server, so the client
+  # address is derived from the local play ID. Autoconnect stays off so a
+  # vanished host doesn't keep the device from returning to ordinary
+  # networks; rejoining is an explicit wifictl connect (ES toggle).
+  "${NMCLI}" connection add type wifi ifname "${WIFI_DEV}" con-name "${SSID}" ssid "${SSID}" \
+    802-11-wireless-security.key-mgmt wpa-psk \
+    802-11-wireless-security.psk "${PSK}" \
+    ipv4.method manual ipv4.addresses "${NETWORK_ADDRESS}.${ADHOC_CLIENT_ID}/24" \
+    ipv6.method disabled connection.autoconnect no || return 1
+  # The iwd backend fails "connection up" instantly when the SSID is not in
+  # the scan cache yet, so make sure the host AP shows up first
+  for i in $(seq 1 15); do
+    "${NMCLI}" device wifi rescan ifname "${WIFI_DEV}" >/dev/null 2>&1
+    sleep 2
+    "${NMCLI}" -t -f SSID device wifi list ifname "${WIFI_DEV}" 2>/dev/null | grep -q "^${SSID}$" && break
+  done
+  "${NMCLI}" -t -f SSID device wifi list ifname "${WIFI_DEV}" 2>/dev/null | grep -q "^${SSID}$" || return 1
+  # The host may still be coming up
+  for i in $(seq 1 3); do
+    "${NMCLI}" -w 20 connection up id "${SSID}" && return 0
+    sleep 3
+  done
+  return 1
 }
 
 destroy_adhoc() {
-  iwctl ap ${WIFI_DEV} stop 2>/dev/null
-  rm -f "${IWD_AP_CFG_DIR}/${SSID}.ap" 2>/dev/null
-  "${NMCLI}" device set "${WIFI_DEV}" managed yes >/dev/null 2>&1
+  # Remove the netplay connection (host or client) so NM autoconnect
+  # can't resurrect it and the device returns to the ordinary networks
+  "${NMCLI}" connection delete id "${NETPLAY_SSID}" >/dev/null 2>&1
 }
 
 # Prefer the network currently in use for the next automatic connection. On
@@ -168,18 +181,17 @@ case "${1}" in
   connect)
     if [ "${WIFI_TYPE}" = "1" ] && \
        [ "${ADHOC_CLIENT_ID}" = "1" ]; then
-      create_adhoc >/dev/null 2>&1
+      create_adhoc
+    elif [ "${WIFI_TYPE}" = "1" ]; then
+      connect_adhoc_client
     else
-      destroy_adhoc >/dev/null 2>&1
-      # Allow NetworkManager time to re-initialize the device after setting managed=yes
-      sleep 3
-      connect_wifi >/dev/null 2>&1
+      destroy_adhoc
+      connect_wifi
     fi
   ;;
   disconnect)
     if [ "${WIFI_TYPE}" = "1" ]; then
-      destroy_adhoc >/dev/null 2>&1
-      iwctl ap ${WIFI_DEV} stop 2>/dev/null
+      destroy_adhoc
     else
       "${NMCLI}" device disconnect "${WIFI_DEV}" >/dev/null 2>&1
     fi


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

Fix Local Play, broken since the NetworkManager migration (beb5d8a239):

* iwd runs with EnableNetworkConfiguration=false, so the [IPv4] block wifictl wrote into the iwd AP profile was silently ignored and the AP never got an address.
* Switching the interface to AP mode behind NetworkManager cannot work: after `nmcli device set managed no` iwd's own autoconnect re-associates the station, and NM's iwd backend forces Device.Mode back to station on deactivation paths (reset_mode in nm-device-iwd.c). The result is `iwctl ap start-profile` failing with "Operation aborted" and NETPLAY_AP never appearing.
* Clients had no way to obtain an address: iwd no longer configures IPs and the netplay AP runs no DHCP server.

Rework Local Play to be NetworkManager-native (NM: IP + lifecycle, iwd: 802.11):

* Host (ID 1): NM wifi connection in AP mode (WPA-PSK, NETPLAY_AP) with a static 192.168.80.1/24.
* Clients (IDs 2-4): NM wifi connection with a static 192.168.80.&lt;id&gt;/24 derived from the local play ID; the SSID must be in the scan cache before `connection up`, the iwd backend fails activation instantly otherwise.
* Teardown deletes the netplay connection so NM returns the device to the ordinary networks; the normal path also cleans stale netplay profiles.

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

Tested on two handhelds running the stock 20260901 image with only wifictl replaced: RG353V (RK3566) as host, RG34XX SP (H700) as client.

* Host: NETPLAY_AP comes up, 192.168.80.1/24 assigned, real clients (the second handheld and a laptop) associate and ping both ways.
* Client: keeps its static 192.168.80.2/24, returns to the ordinary network within a second after the host disappears.
* 5 enable/disable cycles: no stale profiles, station mode and ordinary Wi-Fi restored every time.
* 10MB file transferred between the two handhelds over the netplay network (scp, checksum verified).

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

* Known limitation: the AP channel is fixed by iwd (6, 2.4GHz) because NM's iwd AP activation calls `Start(ssid, psk)` and does not pass a channel through, and iwd falls back to channel 6 when no profile channel is set (`ap_load_config()` in iwd's src/ap.c, with an upstream TODO to pick the channel via a survey: https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/src/ap.c?h=3.10#n3685). The LOCAL NETWORK CHANNEL selector is therefore removed from the frontend (ROCKNIX/emulationstation-next#32).
* Needs the EmulationStation-side fix that persists the local play ID (ROCKNIX/emulationstation-next#32); without it the ID selection reverts to host, as reported in https://www.reddit.com/r/ANBERNIC/comments/1pednpa/rocknix_multiplayer/

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO

YES — agent assisted (GLM by z.ai, opencode): root-cause analysis, patch and testing driven by the author