### PR TITLE
inputplumber: add an inert setfacl shim so device hiding works again

### DIFF
--- a/projects/ROCKNIX/packages/tools/inputplumber/package.mk
+++ b/projects/ROCKNIX/packages/tools/inputplumber/package.mk
@@ -39,6 +39,9 @@ post_unpack() {
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr
   rsync -ar ${PKG_BUILD}/usr/ ${INSTALL}/usr/
+
+  # sources/ is overlaid with cp, so pin the mode udev needs to run the shim.
+  chmod 0755 ${INSTALL}/usr/lib/inputplumber/setfacl-shim/setfacl
 }
 
 post_install() {

--- a/projects/ROCKNIX/packages/tools/inputplumber/sources/usr/lib/inputplumber/setfacl-shim/setfacl
+++ b/projects/ROCKNIX/packages/tools/inputplumber/sources/usr/lib/inputplumber/setfacl-shim/setfacl
@@ -1,0 +1,18 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026 ROCKNIX (https://github.com/ROCKNIX)
+#
+# Inert stand-in for setfacl(1), reachable only via inputplumber.service's PATH.
+#
+# InputPlumber >= 0.78.1 aborts hide_device() (src/udev/mod.rs) when setfacl is
+# not on PATH, before the branch that moves the source node away. ROCKNIX has no
+# acl package, so without this nothing is hidden and HIDE_DEVICES_FROM_ROOT=1 is
+# silently ignored.
+#
+# Doing nothing is safe: the generated udev rule runs chmod 000 first, which
+# writes the ACL mask and leaves any named-user entry ineffective, and ROCKNIX
+# builds systemd with -Dacl=disabled so no uaccess ACLs exist to clear. If that
+# changes, add a real acl package; this directory is last on PATH, so a real
+# setfacl takes precedence automatically.
+
+exit 0

--- a/projects/ROCKNIX/packages/tools/inputplumber/sources/usr/lib/systemd/system/inputplumber.service
+++ b/projects/ROCKNIX/packages/tools/inputplumber/sources/usr/lib/systemd/system/inputplumber.service
@@ -7,6 +7,9 @@ BusName=org.shadowblip.InputPlumber
 Environment=LOG_LEVEL=info
 Environment=HIDE_DEVICES_FROM_ROOT=1
 Environment=INSECURE_DISABLE_POLKIT=1
+# InputPlumber hides nothing unless setfacl is on PATH; see the shim's header.
+# Kept last so a real /usr/bin/setfacl would take precedence.
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/lib/inputplumber/setfacl-shim
 ExecStart=/usr/bin/inputplumber
 ProtectSystem=full
 


### PR DESCRIPTION
## Summary

InputPlumber 0.78.1 added a hard setfacl lookup to hide_device() in src/udev/mod.rs:

  let Some(setfacl_cmd) = find_executable("setfacl") else {
    return Err("Unable to determine setfacl command location".into());
  };

find_executable() only walks $PATH and ROCKNIX ships no acl package, so this returns early -- before the branch that moves the device node away. No udev rule is written at all, /run/udev/rules.d stays empty, HIDE_DEVICES_FROM_ROOT=1 is silently ignored, and source evdev/js nodes stay visible next to the target device. The flag that gates the lookup, HideFlag::ChangePermissions, is always set, so this broke hiding for every device and not just the ones asking to be hidden from root.

Broken since 72973969c7 (inputplumber 0.79.0); 0.77.1 and earlier are unaffected. Still present in upstream main.

Satisfy the lookup with an inert shim rather than pulling in acl. setfacl -b is only cleanup here: the generated udev rule runs chmod 000 first, and chmod on a file carrying a POSIX ACL writes the group bits to the ACL mask, which gates every named-user entry. ROCKNIX also builds systemd with -Dacl=disabled, so logind never applies uaccess ACLs to begin with. The shim documents all of this in its header, including what to do if systemd ever gains ACL support.

The shim is not on the global PATH; only inputplumber.service sees it, and it sits last so a real /usr/bin/setfacl would take precedence if an acl package is ever added.

Verified on an SM8250 unit with an equivalent shim: event7 and js0 move to /dev/inputplumber/sources mode 000, leaving only the DualSense target in /dev/input.

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES
