### PR TITLE
dolphin-sa: add Sync GPU Thread ES setting

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_gc.sh
@@ -136,6 +136,7 @@ EFBACCESS=$(get_setting skip_efb_cpu_access "${PLATFORM}" "${GAME}")
 EFBTEXTURE=$(get_setting store_efb_to_texture_only "${PLATFORM}" "${GAME}")
 XFBTEXTURE=$(get_setting store_xfb_to_texture_only "${PLATFORM}" "${GAME}")
 TEXTURE_CACHE_ACCURACY=$(get_setting texture_cache_accuracy "${PLATFORM}" "${GAME}")
+SYNC_GPU_THREAD=$(get_setting sync_gpu_thread "${PLATFORM}" "${GAME}")
 RUMBLE=$(get_setting rumble "${PLATFORM}" "${GAME}")
 WHACK=$(get_setting widescreen_hack "${PLATFORM}" "${GAME}")
 WPC=$(get_setting write_protect_configs "${PLATFORM}" "${GAME}")
@@ -252,6 +253,13 @@ fi
     sed -i '/GFXBackend/c\GFXBackend = OGL' ${CONF_DIR}/${DOLPHIN_INI}
   else
     sed -i '/GFXBackend/c\GFXBackend = @GRENDERER@' ${CONF_DIR}/${DOLPHIN_INI}
+  fi
+
+  # Sync GPU thread
+  if [ "$SYNC_GPU_THREAD" = "true" ]; then
+    sed -i '/SyncGPU =/c\SyncGPU = True' ${CONF_DIR}/${DOLPHIN_INI}
+  else
+    sed -i '/SyncGPU =/c\SyncGPU = False' ${CONF_DIR}/${DOLPHIN_INI}
   fi
 
   # Internal Resolution
@@ -492,6 +500,7 @@ fi
   echo "EFBTEXTURE set to: ${EFBTEXTURE}"
   echo "XFBTEXTURE set to: ${XFBTEXTURE}"
   echo "TEXTURE_CACHE_ACCURACY set to: ${TEXTURE_CACHE_ACCURACY}"
+  echo "SYNC_GPU_THREAD set to: ${SYNC_GPU_THREAD}"
   echo "RUMBLE set to: ${RUMBLE}"
   echo "WHACK set to: ${WHACK}"
   echo "WPC set to: ${WPC}"

--- a/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/dolphin-sa/scripts/start_dolphin_wii.sh
@@ -124,6 +124,7 @@ EFBACCESS=$(get_setting skip_efb_cpu_access "${PLATFORM}" "${GAME}")
 EFBTEXTURE=$(get_setting store_efb_to_texture_only "${PLATFORM}" "${GAME}")
 XFBTEXTURE=$(get_setting store_xfb_to_texture_only "${PLATFORM}" "${GAME}")
 TEXTURE_CACHE_ACCURACY=$(get_setting texture_cache_accuracy "${PLATFORM}" "${GAME}")
+SYNC_GPU_THREAD=$(get_setting sync_gpu_thread "${PLATFORM}" "${GAME}")
 RUMBLE=$(get_setting rumble "${PLATFORM}" "${GAME}")
 WHACK=$(get_setting widescreen_hack "${PLATFORM}" "${GAME}")
 WPC=$(get_setting write_protect_configs "${PLATFORM}" "${GAME}")
@@ -233,6 +234,13 @@ fi
     sed -i '/GFXBackend/c\GFXBackend = OGL' ${CONF_DIR}/${DOLPHIN_INI}
   else
     sed -i '/GFXBackend/c\GFXBackend = @GRENDERER@' ${CONF_DIR}/${DOLPHIN_INI}
+  fi
+
+  # Sync GPU thread
+  if [ "$SYNC_GPU_THREAD" = "true" ]; then
+    sed -i '/SyncGPU =/c\SyncGPU = True' ${CONF_DIR}/${DOLPHIN_INI}
+  else
+    sed -i '/SyncGPU =/c\SyncGPU = False' ${CONF_DIR}/${DOLPHIN_INI}
   fi
 
   # Internal Resolution
@@ -450,6 +458,7 @@ fi
   echo "EFBTEXTURE set to: ${EFBTEXTURE}"
   echo "XFBTEXTURE set to: ${XFBTEXTURE}"
   echo "TEXTURE_CACHE_ACCURACY set to: ${TEXTURE_CACHE_ACCURACY}"
+  echo "SYNC_GPU_THREAD set to: ${SYNC_GPU_THREAD}"
   echo "RUMBLE set to: ${RUMBLE}"
   echo "WHACK set to: ${WHACK}"
   echo "WPC set to: ${WPC}"

--- a/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
+++ b/projects/ROCKNIX/packages/ui/emulationstation/config/common/es_features.cfg
@@ -602,6 +602,10 @@
         <choice name="yes" value="true"/>
         <choice name="no" value="false"/>
       </feature>
+      <feature name="sync gpu thread">
+        <choice name="yes" value="true"/>
+        <choice name="no" value="false"/>
+      </feature>
       <feature name="store xfb to texture only">
         <choice name="yes" value="true"/>
         <choice name="no" value="false"/>
@@ -735,6 +739,10 @@
         <choice name="balanced" value="512"/>
         <choice name="fast" value="128"/>
       </feature>
+      <feature name="sync gpu thread">
+        <choice name="yes" value="true"/>
+        <choice name="no" value="false"/>
+      </feature>
       <feature name="use bios">
         <choice name="yes" value="false"/>
         <choice name="no" value="true"/>
@@ -840,6 +848,10 @@
         <choice name="balanced" value="512"/>
         <choice name="fast" value="128"/>
       </feature>
+      <feature name="sync gpu thread">
+        <choice name="yes" value="true"/>
+        <choice name="no" value="false"/>
+      </feature>
       <feature name="vsync">
         <choice name="on" value="1"/>
         <choice name="off" value="0"/>
@@ -940,6 +952,10 @@
         <choice name="safe" value="0"/>
         <choice name="balanced" value="512"/>
         <choice name="fast" value="128"/>
+      </feature>
+      <feature name="sync gpu thread">
+        <choice name="yes" value="true"/>
+        <choice name="no" value="false"/>
       </feature>
       <feature name="vsync">
         <choice name="on" value="1"/>


### PR DESCRIPTION
## Summary

dolphin-sa: add Sync GPU Thread ES setting

## Testing

Tested on my OGU, testing on SM8550: https://discord.com/channels/948029830325235753/1341661999372832828/1547601068828008448

## Additional Context

This setting solves crashing in some games, but has a performance penalty

---

### AI Usage

**Did you use AI tools to help write this code?** NO
