### PR TITLE
rocknix: runemu.sh returns how the launch ended

### DIFF
--- a/projects/ROCKNIX/packages/rocknix/profile.d/001-functions
+++ b/projects/ROCKNIX/packages/rocknix/profile.d/001-functions
@@ -82,7 +82,12 @@ function wait_lock() {
   do
     if (set -o noclobber; echo "$$" > "${J_CONF_LOCK}") 2>/dev/null
     then
-      trap 'rm -f "$lockfile"; exit $?' INT TERM EXIT
+      # Save the exit status before anything else runs: 'exit $?' after rm
+      # re-exited with rm's 0, so every script that ever took this lock (runemu.sh
+      # among them) exited 0 however it ended. Release only a lock this shell still
+      # holds -- callers rm it themselves, the trap outlives them, and another
+      # process may own the file by the time this one exits.
+      trap 'rc=$?; [ "$(cat "${J_CONF_LOCK}" 2>/dev/null)" = "$$" ] && rm -f "${J_CONF_LOCK}"; exit "${rc}"' INT TERM EXIT
       break
     else
      sleep 1

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/runemu.sh
@@ -497,10 +497,23 @@ then
 fi
 
 ${VERBOSE} && log $0 "Checking errors: ${ret_error} "
-if [ "${ret_error}" == "0" ]
-then
+### Report how the launch ended. EmulationStation records play count, play time
+### and last-played only on 0 (FileData::launchGame) and passes the same code to
+### whatever runs after the game. The global exit hotkey (input_sense, execute_kill) ends
+### a standalone emulator with killall -9 and RetroArch with SIGTERM, so 137 and
+### 143 are the player leaving, not a failed launch: a clean exit. Every other
+### non-zero status still collapses to 1 -- ES keeps 200-300 for messages it can
+### name, and an emulator's own codes would land in that range.
+case "${ret_error}" in
+  0)
         quit 0
-else
+  ;;
+  137|143)
+        log $0 "emulator ended by signal (${ret_error}, the exit hotkey); a clean exit"
+        quit 0
+  ;;
+  *)
         log $0 "exiting with ${ret_error}"
         quit 1
-fi
+  ;;
+esac


### PR DESCRIPTION
## What

`wait_lock()` in `profile.d/001-functions` installs

```
trap 'rm -f "$lockfile"; exit $?' INT TERM EXIT
```

On EXIT the trap runs `rm` (status 0) and then re-exits with **rm's** status, so every script that has taken the settings lock exits 0 however it ended. `runemu.sh` takes it (cooling profile, netplay mode), so its `quit 1` after a failed launch reaches EmulationStation as 0 — a RetroArch `Failed to load content` looked like a clean exit. `$lockfile` is also never assigned anywhere, so the trap never removed the lock it was there to release: a script killed while holding it left `/tmp/.system.cfg.lock` behind and later `set_setting` calls spun forever.

## Fix

- Save `$?` first and exit with it. Name the lock (`J_CONF_LOCK`) and remove it only when this shell still owns it: every caller releases the lock itself a few lines after taking it, the trap stays installed for the rest of the shell's life, and by the time a long-lived script like `runemu.sh` exits another process may hold the file. The EXIT arm stays for callers under `set -e`, where a failed `sed` inside `del_setting` exits with the lock held.
- With the status reported for the first time, an emulator ended by the global exit hotkey (`killall -9` → 137, SIGTERM → 143) would read as a failed launch — EmulationStation records play count and last-played only on 0. `runemu.sh` maps 137 and 143 to 0 with a log line; every other non-zero status still collapses to 1, leaving 200–300 for the messages EmulationStation can name.

## Testing

On a GENERIC_X64 build: with a 64 KiB zero ROM, `runemu.sh` logged `exiting with 1` and returned 0 before, 1 after; `exit 7` while holding the lock returns 7 and releases it; a lock another pid owns at exit is left alone; TERM while holding returns 143 and releases it; `set -e` with a failed `sed` in `del_setting` returns 1 and releases the lock (was 0 with the lock left behind); a live RetroArch ended with SIGKILL returns 0. The same failed launch, driven through EmulationStation, reached the post-launch step as exit 1. Also running on two Anbernic H700 handhelds.

Known edge, left as is: RetroArch force-quit by the hotkey's SIGTERM exits 1 on its own, indistinguishable from a failed load.

No user-facing option or documentation changes.
