### PR TITLE
armsx2-sa: bump to 2.6.9

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/armsx2-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/armsx2-sa/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="armsx2-sa"
-PKG_VERSION="2.6.6.5"
-PKG_SHA256="8d391f9887d20d88ad8ee990eaf939991a72eac9c60ce94a32507f775e080e36"
+PKG_VERSION="2.6.9"
+PKG_SHA256="e7b2b6ea6ca26a2b0a5b401b4aa1110b0fbf71a09b84df95571159d892a4cc1f"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ARMSX2/ARMSX2"
 PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"

--- a/projects/ROCKNIX/packages/emulators/standalone/armsx2-sa/patches/000-fix-arm-compilation.patch
+++ b/projects/ROCKNIX/packages/emulators/standalone/armsx2-sa/patches/000-fix-arm-compilation.patch
@@ -1,6 +1,6 @@
 --- a/cmake/BuildParameters.cmake
 +++ b/cmake/BuildParameters.cmake
-@@ -150,10 +150,26 @@
+@@ -155,10 +155,26 @@
  	# If we're running on Linux, we need to detect the page/cache line size.
  	# It could be a virtual machine with 4K pages, or 16K with Asahi.
  	if(LINUX)
@@ -29,5 +29,5 @@
 +			list(APPEND PCSX2_DEFS OVERRIDE_HOST_CACHE_LINE_SIZE=${HOST_CACHE_LINE_SIZE})
 +		endif()
  	endif()
- 	
- 	# Windows page size matches x86-64 (4K).
+ 
+ 	# Android is neither LINUX nor WIN32 to CMake, so without this branch it


### PR DESCRIPTION
Bumps armsx2-sa from 2.6.6.5 to 2.6.9.

The cross-compile page/cache-line patch is still required (upstream's `if(LINUX)` branch still calls `detect_page_size()`/`detect_cache_line_size()`, which FATAL_ERROR under `CMAKE_CROSSCOMPILING`). Its context is refreshed: upstream moved the hunk by 5 lines and added an `if(ANDROID)` block below it, so it applied only at maximum fuzz. Patch body unchanged; it now applies with `-F0`.

Test plan:
- [ ] Build and boot-test on affected devices; attach `.img.gz` / `.tar` artifacts.