### PR TITLE
gl4es: reinstate for libmali / bigpemu

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/bigpemu-sa/scripts/start_bigpemu.sh
+++ b/projects/ROCKNIX/packages/emulators/standalone/bigpemu-sa/scripts/start_bigpemu.sh
@@ -34,4 +34,9 @@ else
   unset EMUPERF
 fi
 
+# libmali GPU driver needs gl4es
+if [ -x "/usr/bin/gpudriver" ] && [ $(/usr/bin/gpudriver) = "libmali" ]; then
+  export LD_PRELOAD=/usr/lib/gl4es/libGL.so.1
+fi
+
 ${EMUPERF} /usr/share/bigpemu/bigpemu "${1}"

--- a/projects/ROCKNIX/packages/graphics/gl4es/package.mk
+++ b/projects/ROCKNIX/packages/graphics/gl4es/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present ROCKNIX (https://github.com/ROCKNIX)
+
+PKG_NAME="gl4es"
+PKG_VERSION="81547d986798e876de8b434193920b606a72363f"
+PKG_SHA256="475c30409fd64a649352487d0df0dc3f8ef200ea5c54b7de5f61d099948877ed"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/ptitSeb/gl4es"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="GL4ES - OpenGL for GLES Hardware"
+PKG_TOOLCHAIN="cmake"
+
+configure_package() {
+  PKG_CMAKE_OPTS_TARGET="-DODROID=1 -DNOX11=1 -DNOEGL=1"
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/gl4es
+  cp -rf ${PKG_BUILD}/lib/* ${INSTALL}/usr/lib/gl4es
+}

--- a/projects/ROCKNIX/packages/graphics/libmali/package.mk
+++ b/projects/ROCKNIX/packages/graphics/libmali/package.mk
@@ -10,7 +10,7 @@ PKG_VERSION="0fe30426b822699f0a660268a6040fdafce229d1"
 PKG_SHA256="b2d0b4904577aa1cf737f1402052a6651f84fcbc94aca0601b782ff63cc9167b"
 # zip format makes extract very fast (<1s). tgz takes 20 seconds to scan the whole file
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.zip"
-PKG_DEPENDS_TARGET="toolchain libdrm patchelf:host gpudriver SDL2_glesonly"
+PKG_DEPENDS_TARGET="toolchain libdrm patchelf:host gpudriver SDL2_glesonly gl4es"
 PKG_LONGDESC="OpenGL ES user-space binary for the ARM Mali GPU family"
 PKG_TOOLCHAIN="meson"
 PKG_PATCH_DIRS+=" ${DEVICE}"

--- a/projects/ROCKNIX/packages/virtual/emulators/sources/Start BigPEmu.sh
+++ b/projects/ROCKNIX/packages/virtual/emulators/sources/Start BigPEmu.sh
@@ -7,6 +7,11 @@ source /etc/profile
 
 set_kill set "bigpemu"
 
+# libmali GPU driver needs gl4es
+if [ -x "/usr/bin/gpudriver" ] && [ $(/usr/bin/gpudriver) = "libmali" ]; then
+  export LD_PRELOAD=/usr/lib/gl4es/libGL.so.1
+fi
+
 sway_fullscreen "bigpemu" &
 
 /usr/share/bigpemu/bigpemu >/dev/null 2>&1


### PR DESCRIPTION
## Summary

gl4es: reinstate for libmali / bigpemu

## Testing

Tested on my OGU, regression tested SM8250 build

## Additional Context

May also come in handy for running some Portmaster ports with libmali

An older build was named `libegl` package in our old buildroot: https://github.com/ROCKNIX/distribution-old/blob/dev/packages/graphics/libegl/package.mk

---

### AI Usage

**Did you use AI tools to help write this code?** NO
