### PR TITLE
h700: alias PCF8563 as rtc0

### DIFF
--- a/projects/ROCKNIX/devices/H700/filesystem/usr/lib/udev/rules.d/80-clock.rules
+++ b/projects/ROCKNIX/devices/H700/filesystem/usr/lib/udev/rules.d/80-clock.rules
@@ -1,0 +1,2 @@
+# Overrides the project default: only rtc0 (PCF8563) holds time across power off.
+ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc0", RUN+="/sbin/hwclock --hctosys --utc --rtc=/dev/%k"

--- a/projects/ROCKNIX/devices/H700/patches/linux/0156-rg35xx-plus-add-pcf8563-rtc.patch
+++ b/projects/ROCKNIX/devices/H700/patches/linux/0156-rg35xx-plus-add-pcf8563-rtc.patch
@@ -2,16 +2,30 @@ From: Philippe Simons <simons.philippe@gmail.com>
 Subject: [PATCH] arm64: dts: allwinner: rg35xx-plus: add PCF8563 RTC
 
 The RG35XX Plus has a NXP PCF8563 RTC on the same bus as the AXP717 PMIC.
+It is battery backed, so alias it to rtc0 and the SoC RTC to rtc1, making
+the PCF8563 the hctosys device.
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-plus.dts b/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-plus.dts
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-plus.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h700-anbernic-rg35xx-plus.dts
-@@ -31,6 +31,14 @@
+@@ -9,6 +9,11 @@
+ 	model = "Anbernic RG35XX Plus";
+ 	compatible = "anbernic,rg35xx-plus", "allwinner,sun50i-h700";
+ 
++	aliases {
++		rtc0 = &pcf8563;
++		rtc1 = &rtc;
++	};
++
+ 	wifi_pwrseq: pwrseq {
+ 		compatible = "mmc-pwrseq-simple";
+ 		clocks = <&rtc CLK_OSC32K_FANOUT>;
+@@ -37,6 +42,14 @@
  	};
  };
  
 +&r_i2c {
-+	rtc@51 {
++	pcf8563: rtc@51 {
 +		compatible = "nxp,pcf8563";
 +		reg = <0x51>;
 +		#clock-cells = <0>;


### PR DESCRIPTION
The SoC RTC does not hold time across power off. Alias the battery backed
PCF8563 as rtc0 and sun6i-rtc as rtc1; rtc0 is already HCTOSYS/SYSTOHC.

Override 80-clock.rules for H700 so `hwclock --hctosys` runs only for rtc0 —
otherwise rtc1 also fires and can overwrite the system clock with a stale value.

Affects every H700 dtb descending from sun50i-h700-anbernic-rg35xx-plus.dts
(rg35xx-plus/-h/-sp, rg34xx, rg40xx, rgcubexx, rg28xx, pro). rg35xx-2024 unchanged.

Verified against 7.2: patch applies clean, dtbs compile, aliases resolve to
`/soc/i2c@7081400/rtc@51` and `/soc/rtc@7000000`.

Build artifacts: pending

https://claude.ai/code/session_012mxkaMGxmvet1haKrccsTT