### PR TITLE
batteryplus: tidy up, add BATTERYPLUS_SUPPORT to build options

### DIFF
--- a/projects/ROCKNIX/devices/S922X/options
+++ b/projects/ROCKNIX/devices/S922X/options
@@ -48,7 +48,10 @@
 
   # VULKAN_SUPPORT
     VULKAN_SUPPORT="yes"
-    
+
+  # Batteryplus voltage-based battery percentage daemon (yes / no)
+    BATTERYPLUS_SUPPORT="yes"
+
   # Displayserver to use (wl / x11 / no)
     DISPLAYSERVER="wl"
 

--- a/projects/ROCKNIX/packages/apps/mangohud/package.mk
+++ b/projects/ROCKNIX/packages/apps/mangohud/package.mk
@@ -16,10 +16,9 @@ case ${DEVICE} in
   SM6115|SM8250|SM8550|SM8650|SM8750)
     PKG_PATCH_DIRS+=" qualcomm"
   ;;
-  S922X)
-    PKG_PATCH_DIRS+=" batteryplus"
-  ;;
 esac
+
+[ "${BATTERYPLUS_SUPPORT}" = "yes" ] && PKG_PATCH_DIRS+=" batteryplus"
 
 PKG_PATCH_DIRS+=" ${DEVICE}"
 

--- a/projects/ROCKNIX/packages/emulators/libretro/retroarch/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/retroarch/package.mk
@@ -23,6 +23,8 @@ case ${ARCH} in
     ;;
 esac
 
+[ "${BATTERYPLUS_SUPPORT}" = "yes" ] && PKG_PATCH_DIRS+=" batteryplus"
+
 PKG_CONFIGURE_OPTS_TARGET="--disable-qt \
                            --enable-alsa \
                            --enable-udev \

--- a/projects/ROCKNIX/packages/emulators/libretro/retroarch/patches/batteryplus/0001-batteryplus-capacity.patch
+++ b/projects/ROCKNIX/packages/emulators/libretro/retroarch/patches/batteryplus/0001-batteryplus-capacity.patch
@@ -1,0 +1,30 @@
+retroarch: read battery percent from batteryplus when available
+
+The menu battery display reads /sys/class/power_supply/*/capacity
+directly, bypassing the batteryplus daemon's voltage-based estimate
+that EmulationStation, MangoHud and rocknix-info already use. Read
+/tmp/battery.percent first and fall back to the sysfs value when it
+is absent, so every UI agrees. Same form as Knulli's
+031-batteryplus-percentage.patch. Applied only when
+BATTERYPLUS_SUPPORT=yes.
+
+---
+--- a/frontend/drivers/platform_unix.c
++++ b/frontend/drivers/platform_unix.c
+@@ -964,9 +964,13 @@
+       buf = NULL;
+    }
+ 
+-   fill_pathname_join_special(path, basenode, "capacity", sizeof(path));
+-   if (filestream_read_file(path, (void**)&buf, &length) != 1)
+-      goto end;
++   if (filestream_read_file("/tmp/battery.percent", (void**)&buf, &length) != 1)
++   {
++      fill_pathname_join_special(path, basenode, "capacity", sizeof(path));
++
++      if (filestream_read_file(path, (void**)&buf, &length) != 1)
++         goto end;
++   }
+ 
+    capacity = atoi(buf);
+ 

--- a/projects/ROCKNIX/packages/rocknix/profile.d/001-functions
+++ b/projects/ROCKNIX/packages/rocknix/profile.d/001-functions
@@ -145,7 +145,11 @@ function set_setting() {
 }
 
 function battery_percent() {
-  awk 'BEGIN {FS="="} /POWER_SUPPLY_CAPACITY=/ {print $2}' /sys/class/power_supply/[Bb][Aa][Tt]*/uevent 2>/dev/null
+  if [ -f /tmp/battery.percent ]; then
+    cat /tmp/battery.percent
+  else
+    awk 'BEGIN {FS="="} /POWER_SUPPLY_CAPACITY=/ {print $2}' /sys/class/power_supply/[Bb][Aa][Tt]*/uevent 2>/dev/null
+  fi
 }
 
 function get_es_setting() {

--- a/projects/ROCKNIX/packages/virtual/image/package.mk
+++ b/projects/ROCKNIX/packages/virtual/image/package.mk
@@ -102,6 +102,9 @@ fi
 # modules packages
 [ "${MODULES_PKG}" = "yes" ] && PKG_DEPENDS_TARGET+=" modules"
 
+# Batteryplus voltage-based battery percentage daemon
+[ "${BATTERYPLUS_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" batteryplus"
+
 # Entware support
 mkdir -p ${INSTALL}
 ln -sf /storage/.opt ${INSTALL}/opt


### PR DESCRIPTION
## Summary

batteryplus: tidy up, add `BATTERYPLUS_SUPPORT` to build options

All credit goes to @Jacob-Matthew-Cook as these changes were cherry-picked manually from: https://github.com/ROCKNIX/distribution/pull/3220

## Testing

Tested on Odroid Go Ultra (S922X)

## Additional Context

Also include the Retroarch batteryplus patch

---

### AI Usage

**Did you use AI tools to help write this code?** NO