### PR TITLE
input_sense: make the device rescan retry actually run

### DIFF
--- a/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
+++ b/projects/ROCKNIX/packages/sysutils/system-utils/sources/scripts/input_sense
@@ -244,7 +244,11 @@ get_devices() {
   local FOUNDKEYS=false
   local FOUNDJOY=false
   local FOUNDTOUCH=false
-  local RETRY=5
+  local RETRY=0
+
+  ### Re-scanning must start from an empty list, otherwise every retry and
+  ### every hotplug reload appends duplicates of what is already there.
+  INPUT_DEVICES=()
 
   while [ ${KJDEVS} = false ]; do
     for DEV in /dev/input/ev*


### PR DESCRIPTION
## Summary

* `get_devices()` initialised `RETRY` to 5, the same value the give-up guard tests with `-ge 5`, so the guard tripped on the first pass. The loop always broke after a single scan and never slept or re-scanned, so devices that probe late were never picked up. Start at 0 so the five retries the guard was written for actually happen.
* That makes the loop repeat for the first time, which exposes a second bug: `INPUT_DEVICES` is appended to with `+=` and never cleared, so every retry and every hotplug reload duplicates what is already in the list. Clear it at the top of the scan.

Split out of #3220 at @porschemad911's suggestion, so each change is independently reviewable rather than one oversized PR. Every file here is unchanged from #3220 and has been hardware-tested on the affected devices; that PR itemizes every change and carries the full test record.

## Testing

* Tested working on a GKD Pixel 2. Late-probing input devices are now picked up on a later pass instead of being missed, and `INPUT_DEVICES` holds one entry per device across retries and hotplug reloads rather than accumulating duplicates.
* Unchanged from #3220, where it was developed and hardware-tested alongside the rest of the series; that PR carries the full test record.

## Additional Context

* The two changes are causally linked and belong together: fixing the retry counter is what makes the loop repeat, and the duplicate-append bug is only reachable once it does. Fixing the counter alone would introduce duplicate entries.
* Userspace script only - no kernel patches, quirk files or `package.mk` changes.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY

