### PR TITLE
dwc2: fix resume crash, suspend hang, and vbus leak on role switch

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/patches/linux/035-dwc2-release-vbus-supply-on-role-switch.patch
+++ b/projects/ROCKNIX/devices/RK3326/patches/linux/035-dwc2-release-vbus-supply-on-role-switch.patch
@@ -1,0 +1,102 @@
+usb: dwc2: release vbus-supply when a role switch leaves host mode
+
+Not from upstream (mainline drd.c still has no vbus handling on role
+changes as of this writing). Root-caused on the GKD Pixel2 with a
+sysfs trace of the role switch, the usb2phy's USB-HOST extcon cable
+and the RK817 otg_switch regulator:
+
+  12:53:45 role=host  (usbgadget: gadget disabled -> set_role host)
+  12:53:53 role=host USB-HOST=1 otg_switch=enabled   (OTG adapter in)
+  12:54:13 role=host USB-HOST=0 otg_switch=enabled   (adapter out)
+  12:55:18 role=device USB-HOST=0 otg_switch=enabled (set_role device)
+  ... otg_switch stayed enabled until reboot
+
+dwc2 enables vbus-supply from the hub port-power path once host mode
+starts and releases it only in _dwc2_hcd_stop()/_dwc2_hcd_suspend()
+or the Connector ID B-device path. A usb-role-switch driven change
+out of host mode takes neither: dwc2_drd_role_sw_set() forces device
+mode and returns, the HCD is never stopped, and the Connector ID
+status-change work does not run, so the regulator is leaked and the
+port keeps driving 5V out while in device mode. On a single-port
+board that also charges through that port this means the PMIC never
+sees an external supply, and with usbgadget switching the role back
+to device while a charger or PC is attached it briefly sources VBUS
+against the other end.
+
+Remember whether the core was in host mode when the role switch is
+requested and, after the mode has been forced, release vbus-supply
+when the new role is not host. Done outside the spinlock since
+regulator_disable() may sleep. The exit helper is reference counted
+by 010-dwc2-track-vbus-supply-state.patch, so this is a no-op when
+nothing is held, and the next host session re-enables it through the
+normal port-power path.
+
+---
+--- a/drivers/usb/dwc2/core.h
++++ b/drivers/usb/dwc2/core.h
+@@ -1504,6 +1504,7 @@
+ int dwc2_hcd_get_future_frame_number(struct dwc2_hsotg *hsotg, int us);
+ void dwc2_hcd_connect(struct dwc2_hsotg *hsotg);
+ void dwc2_hcd_disconnect(struct dwc2_hsotg *hsotg, bool force);
++void dwc2_hcd_vbus_supply_exit(struct dwc2_hsotg *hsotg);
+ void dwc2_hcd_start(struct dwc2_hsotg *hsotg);
+ int dwc2_core_init(struct dwc2_hsotg *hsotg, bool initial_setup);
+ int dwc2_port_suspend(struct dwc2_hsotg *hsotg, u16 windex);
+@@ -1531,6 +1532,7 @@
+ { return 0; }
+ static inline void dwc2_hcd_connect(struct dwc2_hsotg *hsotg) {}
+ static inline void dwc2_hcd_disconnect(struct dwc2_hsotg *hsotg, bool force) {}
++static inline void dwc2_hcd_vbus_supply_exit(struct dwc2_hsotg *hsotg) {}
+ static inline void dwc2_hcd_start(struct dwc2_hsotg *hsotg) {}
+ static inline void dwc2_hcd_remove(struct dwc2_hsotg *hsotg) {}
+ static inline int dwc2_core_init(struct dwc2_hsotg *hsotg, bool initial_setup)
+--- a/drivers/usb/dwc2/hcd.c
++++ b/drivers/usb/dwc2/hcd.c
+@@ -163,6 +163,12 @@
+ 	return ret;
+ }
+ 
++/* For role switch based mode changes, which bypass the host stop path. */
++void dwc2_hcd_vbus_supply_exit(struct dwc2_hsotg *hsotg)
++{
++	dwc2_vbus_supply_exit(hsotg);
++}
++
+ /**
+  * dwc2_enable_host_interrupts() - Enables the Host mode interrupts
+  *
+--- a/drivers/usb/dwc2/drd.c
++++ b/drivers/usb/dwc2/drd.c
+@@ -88,6 +88,7 @@
+ 	struct dwc2_hsotg *hsotg = usb_role_switch_get_drvdata(sw);
+ 	unsigned long flags;
+ 	int already = 0;
++	bool was_host;
+ 
+ 	/* Skip session not in line with dr_mode */
+ 	if ((role == USB_ROLE_DEVICE && hsotg->dr_mode == USB_DR_MODE_HOST) ||
+@@ -119,6 +120,8 @@
+ 
+ 	spin_lock_irqsave(&hsotg->lock, flags);
+ 
++	was_host = dwc2_is_host_mode(hsotg);
++
+ 	if (role == USB_ROLE_NONE) {
+ 		/* default operation mode when usb role is USB_ROLE_NONE */
+ 		if (hsotg->role_sw_default_mode == USB_DR_MODE_HOST)
+@@ -160,6 +163,15 @@
+ 		/* This will raise a Connector ID Status Change Interrupt */
+ 		dwc2_force_mode(hsotg, role == USB_ROLE_HOST);
+ 
++	/*
++	 * The host side enables vbus-supply when the root port is powered,
++	 * but a role switch away from host never stops the HCD, so nothing
++	 * releases it: the port keeps sourcing VBUS in device mode. Drop it
++	 * here, outside the lock (regulator_disable may sleep).
++	 */
++	if (was_host && role != USB_ROLE_HOST)
++		dwc2_hcd_vbus_supply_exit(hsotg);
++
+ 	if (!hsotg->ll_hw_enabled && hsotg->clk)
+ 		clk_disable_unprepare(hsotg->clk);
+ 

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/GameKiddy GKD Pixel2/001-device_config
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/GameKiddy GKD Pixel2/001-device_config
@@ -5,4 +5,5 @@
 cat <<EOF >/storage/.config/profile.d/001-device_config
 # Device Features
 DEVICE_BATTERY_LED_STATUS="true"
+DEVICE_USB_ROLE_FOLLOW_ID="true"
 EOF

--- a/projects/ROCKNIX/packages/linux/patches/mainline-rockchip/003-usb-dwc2-gadget-fix-null-deref-on-register-restore.patch
+++ b/projects/ROCKNIX/packages/linux/patches/mainline-rockchip/003-usb-dwc2-gadget-fix-null-deref-on-register-restore.patch
@@ -1,0 +1,70 @@
+From: Jacob Cook <jacobmcook1984@gmail.com>
+Date: Thu, 27 Aug 2026 20:45:00 -0400
+Subject: [PATCH] usb: dwc2: gadget: Fix NULL pointer dereference in
+ dwc2_restore_device_registers()
+
+dwc2_restore_device_registers() applies a descriptor-DMA workaround for
+every endpoint whose backed-up D{I,O}EPCTL has EPENA set, dereferencing
+hsotg->eps_in[i] / hsotg->eps_out[i] to fetch desc_list_dma.
+
+On cores with dedicated-direction endpoints (GHWCFG1 dev_ep_dirs), only
+one direction per endpoint number is allocated in dwc2_hsotg_hw_cfg(),
+so the array slot for the opposite direction is NULL. The workaround
+dereferences it unconditionally and oopses.
+
+The crash is reachable on every system resume where the controller
+power domain was shut off during suspend: dwc2_resume() finds GUSBCFG
+cleared and calls dwc2_restore_critical_registers() ->
+dwc2_gadget_restore_critical_registers() ->
+dwc2_restore_device_registers(). Since the oops happens in the
+device-resume phase, userspace never thaws and the machine hangs.
+
+Observed on Rockchip PX30 (dev_ep_dirs = 0x6664: ep2 is OUT-only, so
+eps_in[2] == NULL) when resuming from suspend on battery power; with
+VBUS present the power domain is retained and the restore path never
+runs, masking the bug:
+
+  Unable to handle kernel NULL pointer dereference at virtual address 0000000000000098
+  pc : dwc2_restore_device_registers+0x130/0x3e8
+  lr : dwc2_gadget_restore_critical_registers+0x28/0x90
+  Call trace:
+   dwc2_restore_device_registers+0x130/0x3e8 (P)
+   dwc2_gadget_restore_critical_registers+0x28/0x90
+   dwc2_resume+0xe0/0x204
+   dpm_run_callback+0x48/0x100
+   device_resume+0xc8/0x1e8
+   dpm_resume+0x19c/0x1c0
+   dpm_resume_end+0x10/0x24
+   suspend_devices_and_enter+0x160/0x65c
+   pm_suspend+0x294/0x33c
+
+Only apply the workaround when the endpoint exists in the given
+direction.
+
+Cc: stable@vger.kernel.org
+Signed-off-by: Jacob Cook <jacobmcook1984@gmail.com>
+---
+ drivers/usb/dwc2/gadget.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/usb/dwc2/gadget.c b/drivers/usb/dwc2/gadget.c
+--- a/drivers/usb/dwc2/gadget.c
++++ b/drivers/usb/dwc2/gadget.c
+@@ -5252,7 +5252,7 @@ int dwc2_restore_device_registers(struct dwc2_hsotg *hsotg, unsigned int flags)
+ 		 * as result BNA interrupt asserted on hibernation exit
+ 		 * by restoring from saved area.
+ 		 */
+-		if (using_desc_dma(hsotg) &&
++		if (using_desc_dma(hsotg) && hsotg->eps_in[i] &&
+ 		    (dr->diepctl[i] & DXEPCTL_EPENA))
+ 			dr->diepdma[i] = hsotg->eps_in[i]->desc_list_dma;
+ 		dwc2_writel(hsotg, dr->dtxfsiz[i], DPTXFSIZN(i));
+@@ -5264,7 +5264,7 @@ int dwc2_restore_device_registers(struct dwc2_hsotg *hsotg, unsigned int flags)
+ 		 * as result BNA interrupt asserted on hibernation exit
+ 		 * by restoring from saved area.
+ 		 */
+-		if (using_desc_dma(hsotg) &&
++		if (using_desc_dma(hsotg) && hsotg->eps_out[i] &&
+ 		    (dr->doepctl[i] & DXEPCTL_EPENA))
+ 			dr->doepdma[i] = hsotg->eps_out[i]->desc_list_dma;
+ 		dwc2_writel(hsotg, dr->doepdma[i], DOEPDMA(i));

--- a/projects/ROCKNIX/packages/linux/patches/mainline-rockchip/004-usb-dwc2-skip-pm-callbacks-after-failed-core-reset.patch
+++ b/projects/ROCKNIX/packages/linux/patches/mainline-rockchip/004-usb-dwc2-skip-pm-callbacks-after-failed-core-reset.patch
@@ -1,0 +1,120 @@
+From: Jacob Cook <jacobmcook1984@gmail.com>
+Date: Fri, 28 Aug 2026 17:10:00 -0400
+Subject: [PATCH] usb: dwc2: Skip PM register save/restore if the core reset
+ timed out
+
+If dwc2_core_reset() times out, the core never came out of soft reset -
+typically because the UTMI clock is stopped, e.g. on a peripheral that
+was activated while no cable was attached and whose PHY never started
+its clock output. dwc2_hsotg_core_init_disconnected() ignores the error
+and the controller is left in this dead state.
+
+The system suspend path then backs up the device registers
+unconditionally (dwc2_suspend() ->
+dwc2_gadget_backup_critical_registers()). With the UTMI clock domain
+dead, reading DCFG and the other device-mode CSRs does not fail - it
+stalls the AHB and wedges the CPU. The machine hangs hard with no
+oops, and only a hardware watchdog can recover it.
+
+Observed on Rockchip PX30 (GKD Pixel 2) when booting on battery with
+no USB cable and entering system suspend, 100% reproducible:
+
+  dwc2 ff300000.usb: dwc2_core_reset: HANG! Soft Reset timeout GRSTCTL_CSFTRST
+  ...
+  PM: suspend entry (deep)
+  ...
+  dwc2 ff300000.usb: PM: calling dwc2_suspend @ 2730, parent: platform
+  <hard hang - captured via ramoops + hardware watchdog reset>
+
+Track the reset failure in the hsotg structure and make the system
+suspend/resume callbacks leave the controller alone while it is set. A
+later successful core reset (e.g. cable plug-in restarting the PHY and
+re-running dwc2_hsotg_core_init_disconnected()) clears the flag and
+re-enables normal PM handling.
+
+Cc: stable@vger.kernel.org
+Signed-off-by: Jacob Cook <jacobmcook1984@gmail.com>
+---
+--- a/drivers/usb/dwc2/core.c
++++ b/drivers/usb/dwc2/core.c
+@@ -434,6 +434,7 @@
+ 					      GRSTCTL_CSFTRST, 10000)) {
+ 			dev_warn(hsotg->dev, "%s: HANG! Soft Reset timeout GRSTCTL_CSFTRST\n",
+ 				 __func__);
++			hsotg->core_reset_failed = 1;
+ 			return -EBUSY;
+ 		}
+ 	} else {
+@@ -441,6 +442,7 @@
+ 					    GRSTCTL_CSFTRST_DONE, 10000)) {
+ 			dev_warn(hsotg->dev, "%s: HANG! Soft Reset timeout GRSTCTL_CSFTRST_DONE\n",
+ 				 __func__);
++			hsotg->core_reset_failed = 1;
+ 			return -EBUSY;
+ 		}
+ 		greset = dwc2_readl(hsotg, GRSTCTL);
+@@ -469,12 +471,15 @@
+ 	if (dwc2_hsotg_wait_bit_set(hsotg, GRSTCTL, GRSTCTL_AHBIDLE, 10000)) {
+ 		dev_warn(hsotg->dev, "%s: HANG! AHB Idle timeout GRSTCTL GRSTCTL_AHBIDLE\n",
+ 			 __func__);
++		hsotg->core_reset_failed = 1;
+ 		return -EBUSY;
+ 	}
+ 
+ 	if (wait_for_host_mode && !skip_wait)
+ 		dwc2_wait_for_mode(hsotg, true);
+ 
++	hsotg->core_reset_failed = 0;
++
+ 	return 0;
+ }
+ 
+--- a/drivers/usb/dwc2/core.h
++++ b/drivers/usb/dwc2/core.h
+@@ -875,6 +875,9 @@
+  * @reset_phy_on_wake:	Quirk saying that we should assert PHY reset on a
+  *			remote wakeup.
+  * @phy_off_for_suspend: Status of whether we turned the PHY off at suspend.
++ * @core_reset_failed:	Set when the last core soft reset timed out; the
++ *			core CSRs may be inaccessible until a further
++ *			successful reset.
+  * @need_phy_for_wake:	Quirk saying that we should keep the PHY on at
+  *			suspend if we need USB to wake us up.
+  * @frame_number:       Frame number read from the core. For both device
+@@ -1073,6 +1076,7 @@
+ 	unsigned int reset_phy_on_wake:1;
+ 	unsigned int need_phy_for_wake:1;
+ 	unsigned int phy_off_for_suspend:1;
++	unsigned int core_reset_failed:1;
+ 	u16 frame_number;
+ 
+ 	struct phy *phy;
+--- a/drivers/usb/dwc2/platform.c
++++ b/drivers/usb/dwc2/platform.c
+@@ -655,6 +655,15 @@
+ 	if (!dwc2->ll_hw_enabled)
+ 		return 0;
+ 
++	/*
++	 * If the last core soft reset timed out, the core never came out of
++	 * reset (e.g. no UTMI clock because the controller was activated
++	 * with no cable attached). Accessing most CSRs would stall the AHB
++	 * and hang the machine; leave the controller alone.
++	 */
++	if (dwc2->core_reset_failed)
++		return 0;
++
+ 	is_device_mode = dwc2_is_device_mode(dwc2);
+ 	if (is_device_mode)
+ 		dwc2_hsotg_suspend(dwc2);
+@@ -735,6 +744,10 @@
+ 	if (!dwc2->ll_hw_enabled)
+ 		return 0;
+ 
++	/* A core that failed its last soft reset cannot be safely touched. */
++	if (dwc2->core_reset_failed)
++		return 0;
++
+ 	if (dwc2->phy_off_for_suspend && dwc2->ll_hw_enabled) {
+ 		ret = __dwc2_lowlevel_hw_enable(dwc2);
+ 		if (ret)

--- a/projects/ROCKNIX/packages/rocknix/sources/scripts/usbgadget
+++ b/projects/ROCKNIX/packages/rocknix/sources/scripts/usbgadget
@@ -461,6 +461,32 @@ usb_stop() {
 	) >/dev/null 2>&1
 }
 
+# Role implied by the OTG ID pin, read from the usb2 phy's extcon: host while
+# an OTG cable grounds ID (USB-HOST cable on), device otherwise. Fails when
+# the kernel exposes no such cable.
+id_role() {
+	for cable in /sys/class/extcon/*/cable.*; do
+		[ "$(cat ${cable}/name 2>/dev/null)" = "USB-HOST" ] || continue
+		[ "$(cat ${cable}/state 2>/dev/null)" = "1" ] && echo host || echo device
+		return 0
+	done
+	return 1
+}
+
+# Devices whose single OTG port both charges and self-sources VBUS in host
+# mode (DEVICE_USB_ROLE_FOLLOW_ID) track the ID pin instead of parking in
+# host: dwc2 keeps driving 5V out until the role changes, so a fixed host
+# role can never accept a charger again. Also runs from udev on extcon
+# changes, where the login environment is absent, so read the quirk config
+# directly.
+follow_id_role() {
+	[ -r /storage/.config/profile.d/001-device_config ] && . /storage/.config/profile.d/001-device_config
+	[ "${DEVICE_USB_ROLE_FOLLOW_ID}" = "true" ] || return 1
+	[ "${CURRENT_MODE}" = "disabled" ] || return 1
+	ROLE=$(id_role) || return 1
+	set_role "${ROLE}"
+}
+
 set_usb_mode() {
 	case "${1}" in
 		cdc|mtp)
@@ -468,7 +494,7 @@ set_usb_mode() {
 			;;
 		*)
 			usb_stop
-			set_role host
+			follow_id_role || set_role host
 			;;
 	esac
 }
@@ -523,6 +549,7 @@ case "$1" in
 		usb_stop
 		;;
 	trigger)
+		follow_id_role || :
 		usb_trigger
 		;;
 	restart)


### PR DESCRIPTION
## Summary

Three dwc2 fixes plus the userspace role handling that goes with the last one. All root-caused on a GKD Pixel 2 (PX30/RK3326) from pstore/ramoops captures.

* **003 — gadget NULL deref on resume.** `dwc2_restore_device_registers()` dereferences `hsotg->eps_in[i]`/`eps_out[i]` for every endpoint with `EPENA` set, but on cores with dedicated-direction endpoints (`GHWCFG1 dev_ep_dirs`) only one direction per endpoint number is allocated, so the opposite slot is NULL. Reachable on every resume where the controller power domain was off during suspend; the oops lands in the device-resume phase, so userspace never thaws and the machine hangs. On PX30 `dev_ep_dirs = 0x6664`, so `eps_in[2] == NULL`.
* **004 — hard hang suspending after a failed core reset.** If `dwc2_core_reset()` times out the core never leaves soft reset, and the suspend path still backs up the device registers unconditionally. With the UTMI clock domain dead those reads do not fail — they stall the AHB and wedge the CPU. No oops; only a watchdog recovers it. Skip the save/restore when the reset failed.
* **035 — vbus-supply leaked leaving host mode (RK3326).** dwc2 releases `vbus-supply` only via `_dwc2_hcd_stop()`/`_dwc2_hcd_suspend()` or the Connector ID B-device path. A `usb-role-switch` driven change out of host mode takes neither: `dwc2_drd_role_sw_set()` forces device mode and returns, the HCD is never stopped, so the port keeps driving 5V while in device mode. Release it when the new role is not host.
* **usbgadget** — single-port boards that also charge through the OTG port cannot park in host mode, since dwc2 keeps sourcing 5V and the PMIC never sees a charger. Follow the ID pin via the usb2phy's `USB-HOST` extcon instead, gated on the new `DEVICE_USB_ROLE_FOLLOW_ID` quirk so no other device changes behaviour.

Split out of #3220 at @porschemad911's suggestion, so each change is independently reviewable rather than one oversized PR. Every file here is unchanged from #3220 and has been hardware-tested on the affected devices; that PR itemizes every change and carries the full test record. 003/004 and 035+usbgadget are kept together because the role-switch fix is what makes the charging path work, and it is the same subsystem and the same hardware.

## Testing

* Both crash fixes verified on the previously 100%-reproducing hardware (GKD Pixel 2). 004 reproduced 100% before the fix: boot on battery with no USB cable, then enter system suspend.
* 035 root-caused from a sysfs trace of the role switch, the usb2phy `USB-HOST` extcon and the RK817 `otg_switch` regulator — `otg_switch` stayed enabled after leaving host mode until reboot. Full trace is in the patch header.
* Patches apply cleanly to both kernels shipped for these devices (7.1.2 RK3326, 7.0.2 RK3566).
* Full test record is in #3220, where these were developed; the files here are unchanged from it.

## Additional Context

* **Released builds are not affected by the 003/004 crashes.** Latest stable (20260901) was tested on the Pixel 2 with no crashes, despite shipping the same 7.1.2 dwc2 code without these fixes — the triggering conditions are not met there. These are latent-bug fixes and hardening, not a regression fix, so they can be scheduled accordingly.
* `035` depends on `010-dwc2-track-vbus-supply-state.patch`, which is already in `RK3326/patches/linux/` — the exit helper is reference counted there, so the release is a no-op when nothing is held.
* `mainline-rockchip/` starts at 003 here; 001/002/005 are the rk817 patches still in #3220 and will follow in a later PR. Gaps are consistent with the existing `mainline/` set, which starts at 0002 and skips 0006.
* `usbgadget` reads the quirk file directly rather than via the environment, since it also runs from udev on extcon changes where the login environment is absent.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY


