### PR TITLE
mmc: retry a failed SD card resume after a power cycle

### DIFF
--- a/projects/ROCKNIX/packages/linux/patches/mainline/0008-mmc-sd-retry-a-failed-resume-after-a-power-cycle.patch
+++ b/projects/ROCKNIX/packages/linux/patches/mainline/0008-mmc-sd-retry-a-failed-resume-after-a-power-cycle.patch
@@ -1,0 +1,83 @@
+From dccc95fa0ff484ae206d81ddb7703af8701a68ed Mon Sep 17 00:00:00 2001
+From: Jacob Cook <jacobmcook1984@gmail.com>
+Date: Fri, 11 Sep 2026 19:01:02 -0400
+Subject: [PATCH] mmc: core: Retry a failed SD card resume after a power cycle
+
+_mmc_sd_resume() re-initialises the card and hands the result back to
+mmc_sd_runtime_resume(), which logs it and returns 0. The PM core is
+therefore told the resume succeeded even when the card was never
+brought back, and every request already queued against it waits
+forever. jbd2, the writeback worker and the block queue end up in
+uninterruptible sleep, and so does every task that touches the
+filesystem. On a boot medium that takes the whole machine down:
+userspace stops responding while the kernel still answers pings.
+
+Two unrelated failures reach this path on Rockchip handhelds.
+
+A card that is still busy when the host re-initialises it. dw_mmc
+waits up to 500 ms for the card to release DAT0, then issues the
+command anyway, so CMD0 times out:
+
+  dwmmc_rockchip ff370000.mmc: Busy; trying anyway
+  mmc_host mmc0: Timeout sending command (cmd 0x202000 arg 0x0 status 0x80202000)
+  mmc0: error -95 doing runtime resume
+
+And a card that times out the optional SD "Cache Enable" write during
+that same re-initialisation:
+
+  mmc2: error -110 writing Cache Enable bit
+  mmc2: card 5048 removed
+  Aborting journal on device mmcblk2p1-8.
+  EXT4-fs (mmcblk2p1): shut down requested (2)
+
+Both cards are healthy: each is re-detected seconds later and works.
+What they have in common is that the card's state is unusable at the
+moment the resume runs, and no amount of carrying on repairs it. A
+card is entitled to be busy for longer than the host waits, and an
+optional feature is entitled to fail, so neither is a card defect.
+
+Give the card a second chance from a clean slate. The failed attempt
+has already spent several seconds in command timeouts, so the card
+has had time to become ready, and the power cycle also resets the
+host controller state.
+
+Raising dw_mmc's busy timeout was considered instead and rejected:
+that poll is readl_poll_timeout_atomic(), so a longer wait means
+spinning longer in atomic context, and it would only help one host
+driver.
+
+Cc: stable@vger.kernel.org
+Assisted-by: Claude:claude-fable-5-1
+---
+ drivers/mmc/core/sd.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/mmc/core/sd.c b/drivers/mmc/core/sd.c
+index c763efb..fb738e4 100644
+--- a/drivers/mmc/core/sd.c
++++ b/drivers/mmc/core/sd.c
+@@ -1772,6 +1772,21 @@ static int _mmc_sd_resume(struct mmc_host *host)
+ 
+ 	mmc_power_up(host, host->card->ocr);
+ 	err = mmc_sd_init_card(host, host->card->ocr, host->card);
++	if (err) {
++		/*
++		 * A card still busy from before the suspend can make the
++		 * first command time out. Retry once after a power cycle:
++		 * a failed resume is reported as success, leaving queued
++		 * requests to hang forever.
++		 */
++		pr_warn("%s: resume failed (%d), retrying after a power cycle\n",
++			mmc_hostname(host), err);
++		mmc_power_cycle(host, host->card->ocr);
++		err = mmc_sd_init_card(host, host->card->ocr, host->card);
++		if (err)
++			pr_err("%s: card could not be re-initialised on resume (%d)\n",
++			       mmc_hostname(host), err);
++	}
+ 	mmc_card_clr_suspended(host->card);
+ 
+ out:
+-- 
+2.47.3
+

--- a/projects/ROCKNIX/packages/virtual/emulators/udev.d/99-automount.rules
+++ b/projects/ROCKNIX/packages/virtual/emulators/udev.d/99-automount.rules
@@ -4,6 +4,14 @@ ENV{installer}=="1", GOTO="exit"
 
 SUBSYSTEM!="block", KERNEL!="mmc*", GOTO="exit"
 
+# A card that drops off the bus - pulled by the user, or removed by the
+# controller after an error - leaves its mounts behind with the filesystem
+# on them shut down. Clear them up here, otherwise the add rule below sees
+# the stale entry in /proc/mounts, skips the remount, and the card stays
+# unusable until reboot even though the kernel re-detected it immediately.
+ACTION=="remove", ENV{DEVTYPE}=="partition|disk", PROGRAM="/usr/bin/sh -c '/usr/bin/grep -E ^/dev/%k\  /proc/mounts || true'", RESULT!="", RUN+="/usr/bin/systemctl restart rocknix-automount.service"
+ACTION!="add", GOTO="exit"
+
 # check for special partitions we dont want mount
 IMPORT{builtin}="blkid"
 ENV{ID_FS_LABEL}=="EFI|BOOT|Recovery|RECOVERY|SETTINGS|boot|root0|share0", GOTO="exit"


### PR DESCRIPTION
## Summary

> **This kernel patch is a mainline candidate and will be submitted to linux-mmc shortly.** It is carried here only until it lands upstream, and should be dropped the moment it does. It is not a ROCKNIX-specific workaround — it fixes a generic `drivers/mmc/core/sd.c` bug that affects any device with an SD card, and is written as an upstream submission (failure logs, rejected alternatives, no device-specific conditionals).

This addresses @sydarn's point on #3220 about being uneasy carrying custom mmc patches. Agreed — the intent was always to report these upstream, and splitting them out here makes that easier to track independently of the rk817 work.

* **0008 — a failed resume is reported as success.** `_mmc_sd_resume()` hands its result to `mmc_sd_runtime_resume()`, which logs it and returns 0, so the PM core is told the resume worked even though the card was never brought back. Every queued request then waits forever: jbd2, the writeback worker and the block queue end up in uninterruptible sleep, and on a boot medium that takes the whole machine down — userspace stops responding while the kernel carries on answering pings. Retry once from a clean slate after a power cycle.
* **99-automount** — a card that drops off the bus leaves its mounts behind with the filesystem shut down. The add rule then sees the stale entry in `/proc/mounts`, skips the remount, and the card stays unusable until reboot even though the kernel re-detected it immediately. Clear them on removal.

### The second patch was dropped after hardware testing (2026-09-11)

This PR previously also carried `0007-mmc-sd-do-not-fail-card-init-when-the-cache-cannot-be.patch`, which made a failed SD "Cache Enable" write non-fatal to card init. Testing on the RG353M that produced the original failure removed it:

* The patch fired exactly as designed — `could not enable card cache (-110), continuing without it` — and the card was **still** removed 0.16 ms later, because the post-resume presence check found it unresponsive. ext4 aborted its journal, and only the automount rule above brought the card back.
* Worse, by turning the init error into a success it stopped `0008`'s retry from ever running.
* Rebuilt without it, the same card on the same device hit the same trigger and the retry recovered it with the mount intact.

The cache failure is therefore not a separate bug needing its own fix. It is one more way a resume fails, and the retry covers it. What is broken at that moment is the card's state, not the return value, so suppressing the error only hides it from the code that can repair it.

## Testing

Two triggers, two devices, two cards — the retry handles both.

* **Card still busy when the host re-initialises it** — GKD Pixel2 (PX30), boot/root card, kernel 7.1.2. 8 rapid suspend/resume cycles reproduced the failure twice, and the retry recovered the card both times at SDR104: no card removal, no ext4 or journal errors, no D-state tasks, root filesystem verified read-write seconds after each recovery. Unpatched, the same sequence wedges the machine until a hard reset.
* **Card times out the optional cache-enable write** — Anbernic RG353M (RK3566), games card (Phison, manfid `0x000027`, oemid `0x5048`, 03/2025), ext4, kernel 7.0.2, 2026-09-11. With the retry alone: the trigger fired, the retry fired 11 µs later, the card was back and re-tuned 212 ms later, and for that whole boot there were **0 card removals, 0 ext4 aborts and 0 failed retries**. The mount never left `/proc/mounts` and userspace never re-ran its automount, so the filesystem was never torn down.
* Applies at strict zero fuzz (`-F0`) across every kernel in the tree: 6.18.45 (RK3399), 7.0.2 (RK3566/76), 7.1.2 (RK3326) and 7.2 (H700/SM6115/SM8xxx), and to mainline 7.3-rc3.

## Additional Context

* **Not device-specific.** The trigger on the Pixel2 is a card still busy when host re-init starts — dw_mmc waits 500 ms for DAT0 and then issues the command regardless, and a card is entitled to be busy longer than that. The trigger on the RG353M is an optional feature failing to enable. Any card can hit either; the handhelds just suspend and resume far more often than most hardware.
* Raising dw_mmc's busy timeout was considered instead and rejected: that poll is `readl_poll_timeout_atomic()`, so a longer wait means spinning longer in atomic context, and it would only help one host driver.
* `mainline/` rather than `mainline-rockchip/` deliberately — this benefits every device with an SD card, not just the Rockchip ones.

---

### AI Usage

**Did you use AI tools to help write this code?** PARTIALLY
