### PR TITLE
SM8250: prefer 60Hz on the RP5/Flip 2 Visionox panel

### DIFF
--- a/projects/ROCKNIX/devices/SM8250/patches/linux/0105-drm-panel-visionox-vtdr6130-add-sm8250.patch
+++ b/projects/ROCKNIX/devices/SM8250/patches/linux/0105-drm-panel-visionox-vtdr6130-add-sm8250.patch
@@ -16,40 +16,45 @@ regulator supplies exposed by the SM8250 device tree.
 Correct the missing F0 byte in the vendor page-selection command to
 match the Android initialization sequence.
 
+The RP5 and Flip 2 are sold and run by Android at 60Hz, so give the
+sm8250 desc its own mode table with the 60Hz timing first: the first
+entry is the preferred mode and gamescope runs it. The 120Hz timing
+stays available.
+
 Co-authored-by: spycat88 <spycat88@users.noreply.github.com>
 Signed-off-by: Jacob Pyke <github@pyk.ee>
 ---
- .../drm/panel/panel-visionox-vtdr6130-cog.c   | 65 +++++++++++++++----
- 1 file changed, 52 insertions(+), 13 deletions(-)
+ .../drm/panel/panel-visionox-vtdr6130-cog.c   | 87 ++++++++++++++++++++----
+ 1 file changed, 75 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/gpu/drm/panel/panel-visionox-vtdr6130-cog.c b/drivers/gpu/drm/panel/panel-visionox-vtdr6130-cog.c
-index e9766ab..1a1db84 100644
 --- a/drivers/gpu/drm/panel/panel-visionox-vtdr6130-cog.c
 +++ b/drivers/gpu/drm/panel/panel-visionox-vtdr6130-cog.c
-@@ -48,9 +48,21 @@ struct panel_desc {
+@@ -48,10 +48,22 @@
  	int (*init_sequence)(struct panel_info *pinfo);
  
  	struct drm_dsc_config dsc;
 +
 +	const struct regulator_bulk_data *supplies;
 +	unsigned int num_supplies;
-+};
-+
+ };
+ 
+-static const struct regulator_bulk_data panel_supplies[] = {
 +/* SM8250 regulators */
 +static const struct regulator_bulk_data sm8250_panel_supplies[] = {
 +	{ .supply = "vdd1v2" },
 +	{ .supply = "vddio" },
-+	{ .supply = "vdd" },
+ 	{ .supply = "vdd" },
 +	{ .supply = "avdd" },
- };
- 
--static const struct regulator_bulk_data panel_supplies[] = {
++};
++
 +/* SM8550 regulators */
 +static const struct regulator_bulk_data sm8550_panel_supplies[] = {
- 	{ .supply = "vdd" },
++	{ .supply = "vdd" },
  	{ .supply = "vddio" },
  	{ .supply = "vci" },
-@@ -143,7 +155,7 @@ static int vtdr6130_rp6_init_sequence(struct panel_info *pinfo)
+ 	{ .supply = "vdd18" },
+@@ -143,7 +155,7 @@
  					0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
  	}
  
@@ -58,17 +63,46 @@ index e9766ab..1a1db84 100644
  
  	mipi_dsi_generic_write_seq_multi(&dsi_ctx, 0xB1, 
  				0x02, 0x16, 0x00, 0x14, 0x00, 0x1C, 0x00, 0x02,
-@@ -249,6 +261,32 @@ static struct panel_desc vtdr6130_rp6_desc = {
+@@ -248,9 +260,63 @@
+ 		.bits_per_component = 8,
  		.bits_per_pixel = 8 << 4,
  		.block_pred_enable = true,
- 	},
++	},
 +	.supplies = sm8550_panel_supplies,
 +	.num_supplies = ARRAY_SIZE(sm8550_panel_supplies),
 +};
 +
++/* The RP5 / Flip 2 run this panel at 60Hz: list it first so it is the preferred mode. */
++static const struct drm_display_mode vtdr6130_sm8250_modes[] = {
++	{
++		/* 60Hz */
++		.clock = (1080 + 16 + 2 + 22) * (1920 + 16 + 4 + 1972) * 60 / 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 16,
++		.hsync_end = 1080 + 16 + 2,
++		.htotal = 1080 + 16 + 2 + 22,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 16,
++		.vsync_end = 1920 + 16 + 4,
++		.vtotal = 1920 + 16 + 4 + 1972,
+ 	},
++	{
++		/* 120Hz */
++		.clock = (1080 + 16 + 2 + 22) * (1920 + 20 + 4 + 16) * 120 / 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 16,
++		.hsync_end = 1080 + 16 + 2,
++		.htotal = 1080 + 16 + 2 + 22,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 20,
++		.vsync_end = 1920 + 20 + 4,
++		.vtotal = 1920 + 20 + 4 + 16,
++	},
+ };
+ 
 +static struct panel_desc vtdr6130_sm8250_desc = {
-+	.modes = vtdr6130_rp6_modes,
-+	.num_modes = ARRAY_SIZE(vtdr6130_rp6_modes),
++	.modes = vtdr6130_sm8250_modes,
++	.num_modes = ARRAY_SIZE(vtdr6130_sm8250_modes),
 +	.width_mm = 120,
 +	.height_mm = 68,
 +	.bpc = 8,
@@ -88,10 +122,12 @@ index e9766ab..1a1db84 100644
 +	},
 +	.supplies = sm8250_panel_supplies,
 +	.num_supplies = ARRAY_SIZE(sm8250_panel_supplies),
- };
- 
++};
++
  static void vtdr6130_reset(struct panel_info *pinfo)
-@@ -266,7 +304,7 @@ static int vtdr6130_prepare(struct drm_panel *panel)
+ {
+ 	gpiod_set_value_cansleep(pinfo->reset_gpio, 0);
+@@ -266,7 +332,7 @@
  	struct panel_info *pinfo = to_panel_info(panel);
  	int ret;
  
@@ -100,7 +136,7 @@ index e9766ab..1a1db84 100644
  	if (ret < 0) {
  		dev_err(panel->dev, "failed to enable regulators: %d\n", ret);
  		return ret;
-@@ -276,7 +314,7 @@ static int vtdr6130_prepare(struct drm_panel *panel)
+@@ -276,7 +342,7 @@
  
  	ret = pinfo->desc->init_sequence(pinfo);
  	if (ret < 0) {
@@ -109,7 +145,7 @@ index e9766ab..1a1db84 100644
  		dev_err(panel->dev, "failed to initialize panel: %d\n", ret);
  		return ret;
  	}
-@@ -304,7 +342,7 @@ static int vtdr6130_unprepare(struct drm_panel *panel)
+@@ -304,7 +370,7 @@
  	struct panel_info *pinfo = to_panel_info(panel);
  
  	gpiod_set_value_cansleep(pinfo->reset_gpio, 1);
@@ -118,7 +154,7 @@ index e9766ab..1a1db84 100644
  
  	return 0;
  }
-@@ -432,20 +470,19 @@ static int vtdr6130_probe(struct mipi_dsi_device *dsi)
+@@ -432,20 +498,19 @@
  	if (IS_ERR(pinfo))
  		return PTR_ERR(pinfo);
  
@@ -146,7 +182,7 @@ index e9766ab..1a1db84 100644
  	pinfo->dsi = dsi;
  	mipi_dsi_set_drvdata(dsi, pinfo);
  
-@@ -481,6 +518,8 @@ static int vtdr6130_probe(struct mipi_dsi_device *dsi)
+@@ -481,6 +546,8 @@
  
  static const struct of_device_id vtdr6130_of_match[] = {
  	{ .compatible = "vtdr6130,rp6", .data = &vtdr6130_rp6_desc },


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** The Visionox panel patch (0105) reuses the RP6's mode table for the RP5 / Flip 2, which lists 120Hz first. The first entry is the preferred mode and the one gamescope runs, so those units come up at 120Hz. Retroid sells and runs them at 60Hz. This gives the sm8250 desc its own table with the 60Hz timing first; the 120Hz timing stays listed. No other change to the driver: the init sequence already sends the matching frame-rate byte (0x6C 0x01) from the mode's vrefresh.

The timings are the ones already in the driver (and in the units' Android DT), reordered into a separate array so the RP6 desc is untouched.

## Testing

* **How was this tested?** Builds against the SM8250 7.2 tree. Needs a Visionox RP5 / Flip 2 to confirm the panel lights at 60Hz; the 60Hz entry has not been run under Linux on this panel yet, on any distro. Two reporters on shuuri-labs/pocknix-os#74 have the hardware and can try a test build.
* **Test results:** pending, hence draft.

## Additional Context

* Follow-up to #3297

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

**Did you use AI tools to help write this code?** Yes
