### PR TITLE
batteryplus: enable on RK3326 and RK3566

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/options
+++ b/projects/ROCKNIX/devices/RK3326/options
@@ -49,6 +49,9 @@
   # Vulkan implementation to use (vulkan-loader / no)
     VULKAN="vulkan-loader"
 
+  # Batteryplus voltage-based battery percentage daemon (yes / no)
+    BATTERYPLUS_SUPPORT="yes"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="wl"
 

--- a/projects/ROCKNIX/devices/RK3566/options
+++ b/projects/ROCKNIX/devices/RK3566/options
@@ -49,6 +49,9 @@
   # Vulkan implementation to use (vulkan-loader / no)
     VULKAN="vulkan-loader"
 
+  # Batteryplus voltage-based battery percentage daemon (yes / no)
+    BATTERYPLUS_SUPPORT="yes"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="wl"
 

--- a/projects/ROCKNIX/packages/tools/batteryplus/patches/0001-discover-voltage_avg-fallback.patch
+++ b/projects/ROCKNIX/packages/tools/batteryplus/patches/0001-discover-voltage_avg-fallback.patch
@@ -1,0 +1,34 @@
+batteryplus: fall back to voltage_avg when voltage_now is absent
+
+Battery discovery only accepts a supply exposing voltage_now, so in
+voltage mode the daemon exits with "No battery voltage path detected"
+on PMICs whose driver reports the averaged reading instead. The
+Rockchip RK817 charger driver (rk817_charger.c, RK3326/RK3566
+handhelds) exposes voltage_avg only. Use voltage_avg when voltage_now
+is missing; the averaged value is, if anything, a better input for the
+daemon's own smoothing, and unit autodetection is unchanged.
+
+Candidate for upstream (Mikhailzrick/knubat.components).
+
+---
+--- a/BatteryPlus/batteryplus.cpp
++++ b/BatteryPlus/batteryplus.cpp
+@@ -807,7 +807,8 @@
+     };
+ 
+     auto has_battery_signal = [](const fs::path& d) {
+-        return fs::exists(d / "voltage_now") || fs::exists(d / "capacity");
++        return fs::exists(d / "voltage_now") || fs::exists(d / "voltage_avg") ||
++               fs::exists(d / "capacity");
+     };
+ 
+     // Prefer likely battery/fuel-gauge supplies and require either voltage_now
+@@ -826,6 +827,8 @@
+ 
+         if (fs::exists(d / "voltage_now"))
+             bp.voltage_now = d / "voltage_now";
++        else if (fs::exists(d / "voltage_avg"))
++            bp.voltage_now = d / "voltage_avg";
+ 
+         if (fs::exists(d / "capacity"))
+             bp.capacity = d / "capacity";


### PR DESCRIPTION
## Summary

Enable the batteryplus daemon on the two RK817-based platforms, matching the S922X wiring already in tree.

* `BATTERYPLUS_SUPPORT="yes"` for RK3326 and RK3566, so the ES toggle *ENABLE BATTERYPLUS* appears and the daemon is pulled into the image.
* One carried patch to batteryplus itself. Its battery discovery only accepts a supply exposing `voltage_now`, and the RK817 charger driver reports `voltage_avg` instead, so in the daemon's default voltage mode it exits with `No battery voltage path detected` on every affected handheld. Two lines make it fall back to `voltage_avg`. It is a candidate for [Mikhailzrick/knubat.components](https://github.com/Mikhailzrick/knubat.components), and the carried patch should be dropped once it lands there.

No changes to `batteryplus-init` or any other script — the daemon runs on its own defaults, including its built-in voltage anchors.

## Testing

Both option lines and the discovery patch have been running in the #3220 test builds since 20260904, on an Anbernic RG353M (RK3566) and a GKD Pixel 2 (RK3326).

* The daemon starts and stays running, and `/tmp/battery.percent` is populated and tracks the battery.
* EmulationStation's header reads that file, since ES prefers it when built with batteryplus support. Its charging indicator still comes from the kernel's own `status` and `current_avg`.
* Without the discovery patch the daemon exits immediately on these platforms, which is why it is part of this change rather than a separate one.

Artifacts containing exactly these two changes (alongside the rest of #3220) are on the test build release: https://github.com/Jacob-Matthew-Cook/distribution/releases/tag/power-charge-sleep-fixes-20260821

Accuracy is the daemon's own: with stock anchors it assumes a 4.2 V pack, which over-reads on cells that are not 4.2 V. Improving that is deliberately out of scope here and is handled separately in #3220.

## Additional Context

* Depends on the `BATTERYPLUS_SUPPORT` plumbing from #3298, already merged.
* H700 was considered and left out. Its AXP717 exposes both `voltage_now` and `capacity`, so the daemon would run there unpatched, but the H700 device trees carry no battery node at all, so voltage mode would run entirely on generic anchors with nothing to calibrate against. Worth doing once those device trees describe their batteries.

---

### AI Usage

**Did you use AI tools to help write this code?** YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNwUueUVhNqodU1izyxqAK
