### PR TITLE
batteryplus: enable on H700

### DIFF
--- a/projects/ROCKNIX/devices/H700/options
+++ b/projects/ROCKNIX/devices/H700/options
@@ -45,6 +45,9 @@
   # For maximum cross compatbility
     PREFER_GLES="yes"
 
+  # Batteryplus voltage-based battery percentage daemon (yes / no)
+    BATTERYPLUS_SUPPORT="yes"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="wl"
 


### PR DESCRIPTION
## Summary

Enable the batteryplus daemon on H700, following #3311 which did the same for RK3326 and RK3566.

* `BATTERYPLUS_SUPPORT="yes"` for H700, so the ES toggle *ENABLE BATTERYPLUS* appears and the daemon is pulled into the image.

That is the whole change. Unlike #3311 no patch is needed here: the AXP717 exposes `voltage_now`, and `0124-battery-name.patch` already renames its supply to `battery`, so the daemon's discovery finds it unaided. No init-script changes either — the two empty-voltage anchors have defaults, and the daemon learns the two full-charge anchors itself after one charge-and-unplug cycle.

**Why voltage mode rather than pmic mode.** The AXP717 has an internal fuel gauge, but its open-circuit-voltage curve is programmed into the PMIC by Allwinner's vendor bootloader. ROCKNIX replaces that with mainline U-Boot, and the mainline AXP driver only ever writes minimum voltage, maximum voltage and charge current from a device-tree battery node — never the curve. So the PMIC's own percentage is running uncalibrated on these devices, while voltage mode depends on nothing the bootloader left behind.

## Testing

**Working on hardware:** RG34XX and RG35XX-H (both DDR4 units), from the images below. The daemon starts on its own defaults, the ES toggle appears, and the ES header shows the batteryplus percentage.

Also verified from source:

* `axp717_battery_props` includes `POWER_SUPPLY_PROP_VOLTAGE_NOW` and `POWER_SUPPLY_PROP_CAPACITY`, so discovery succeeds in either mode.
* The supply is named `battery`, which the daemon's discovery prefers.
* The daemon's config parser accepts `V_EMPTY_DIS` and `V_EMPTY_CHG` and learns `V_FULL_CHG` / `V_FULL_DIS` into its own map file, so no per-device data is required to start.

Not yet covered: the DDR3 image, the other H700 models (RG28XX, RG35XX Plus/SP/Pro, RG40XX, CubeXX), and a side-by-side of the ES header against `cat /sys/class/power_supply/battery/capacity` over a full charge cycle.

Test images built from this branch: https://github.com/Jacob-Matthew-Cook/distribution/releases/tag/h700-batteryplus-20260912 — DDR3 and DDR4 flashable images plus an update tar (the updater picks the right bootloader itself; flashing needs the one matching your device's memory, and the release explains how to tell). Reports from the untested models are welcome.

## Additional Context

* Depends on the `BATTERYPLUS_SUPPORT` plumbing from #3298 and follows #3311, both merged.
* Device-tree battery nodes are deliberately **not** part of this. Only `sun50i-h700-anbernic-rg35xx-2024.dts` has one today, and on AXP717 such a node is programmed into the PMIC as charge parameters, so adding them needs real per-model data rather than plausible values. It is also orthogonal: voltage-mode batteryplus never reads the device tree.
* For reference, Knulli carries this data in its vendor bootloader device trees: 3000 mAh for the RG28XX/RG34XX/RG35XX family, 3200 mAh for RG40XX and RG CubeXX, 170 mΩ and 1500 mA charge current throughout, with a 32-point OCV curve that is byte-identical across all ten devices. That curve is Allwinner's generic lithium curve, not a per-pack characterisation.

---

### AI Usage

**Did you use AI tools to help write this code?** YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNwUueUVhNqodU1izyxqAK
