### PR TITLE
sm4450: map the RG55G1 guide and back keys

### DIFF
--- a/projects/ROCKNIX/devices/SM4450/filesystem/usr/share/inputplumber/capability_maps/anbernic_rg55g1.yaml
+++ b/projects/ROCKNIX/devices/SM4450/filesystem/usr/share/inputplumber/capability_maps/anbernic_rg55g1.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: Anbernic RG 55G1 Mapping
+id: anbernic_rg55g1
+
+# The stock dt has no BTN_MODE: the two keys next to the screen are gpio34
+# KEY_F10 and gpio28 KEY_BACK, which Android's own keylayout leaves as F10 and
+# Back. Route F10 to Guide and the back key to a bindable hotkey. Everything
+# else already uses standard codes and passes through untouched.
+mapping:
+  - name: Guide Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_F10
+          value_type: button
+    target_event:
+      gamepad:
+        button: Guide
+
+  - name: F1 Key
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_BACK
+          value_type: button
+    target_event:
+      keyboard: KeyF1

--- a/projects/ROCKNIX/devices/SM4450/filesystem/usr/share/inputplumber/devices/02-anbernic-rg55g1.yaml
+++ b/projects/ROCKNIX/devices/SM4450/filesystem/usr/share/inputplumber/devices/02-anbernic-rg55g1.yaml
@@ -26,12 +26,14 @@ source_devices:
   # The 16 face/shoulder buttons and the d-pad are plain GPIOs driven by
   # singleadc-joypad; the analog axes come from the MCU on spi3 through the
   # same device. Unlike the Retroid Pocket Classic's MCU, it already emits
-  # standard BTN_SOUTH/EAST/WEST/NORTH and ABS_HAT0X/Y, so no capability map
-  # is needed. The device name comes from joypad-name in the dts.
+  # standard BTN_SOUTH/EAST/WEST/NORTH and ABS_HAT0X/Y, so the map only has
+  # to cover the two keys beside the screen. The device name comes from
+  # joypad-name in the dts.
   - group: gamepad
     evdev:
       name: Anbernic RG 55G1 Gamepad
       handler: event*
+    capability_map_id: anbernic_rg55g1
 
   # Volume up, a separate gpio-keys node in the dts (gpio53).
   - group: gamepad


### PR DESCRIPTION
Adds the missing guide button on the Anbernic RG55G1.

The stock dt has no `BTN_MODE` anywhere: the two keys beside the screen are
gpio34 `KEY_F10` and gpio28 `KEY_BACK`. Verified against the stock EDL
package — all 50 overlays in `dtbo.img`, plus stock Android's own
`/system/usr/keylayout/Vendor_484b_Product_1101.kl` (vendor/product match
`joypad-product = <0x1101>`), which appends `key 158 BACK` / `key 68 F10` to
a copy-pasted Xbox 360 layout. The joypad node has exactly the 16 switches
already in our dts, so no button was missed — nothing was reaching the
target device's guide button.

New capability map routes `KEY_F10` to `Guide` and `KEY_BACK` to `KeyF1`,
following `konkr_gamepad` and `ayaneo_pocketsmini_gpio`. The dts is left as
a faithful copy of the stock gpio map. Everything else on the joypad already
emits standard codes and passes through untouched.

## Test plan

- [ ] `KEY_F10` key opens the ES menu as guide
- [ ] `KEY_BACK` key reports F1
- [ ] Face buttons, d-pad, sticks and triggers unchanged

## Build artifacts

SM4450 `.img.gz` / `.tar` to be attached.

https://claude.ai/code/session_016Up8jJNMrWG9vipJF99uKW
